### PR TITLE
warscholar Vizier fixes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -159,7 +159,6 @@
 			mask = /obj/item/clothing/mask/rogue/lordmask/tarnished
 			belt = /obj/item/storage/belt/rogue/leather
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
-			beltl = /obj/item/storage/belt/rogue/surgery_bag
 			pants = /obj/item/clothing/under/roguetown/trou/leather
 			shoes = /obj/item/clothing/shoes/roguetown/boots
 			gloves = /obj/item/clothing/gloves/roguetown/angle
@@ -169,7 +168,7 @@
 			H.grant_language(/datum/language/celestial)
 			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
 
-			backpack_contents = list(/obj/item/roguekey/mercenary,/obj/item/rogueweapon/huntingknife, /obj/item/flashlight/flare/torch)
+			backpack_contents = list(/obj/item/roguekey/mercenary,/obj/item/rogueweapon/huntingknife, /obj/item/storage/belt/rogue/surgery_bag)
 			
 			var/datum/devotion/C = new /datum/devotion(H, H.patron)
 			C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)	//Starts off maxed out.

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -159,6 +159,7 @@
 			mask = /obj/item/clothing/mask/rogue/lordmask/tarnished
 			belt = /obj/item/storage/belt/rogue/leather
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
+			beltl = /obj/item/storage/belt/rogue/surgery_bag
 			pants = /obj/item/clothing/under/roguetown/trou/leather
 			shoes = /obj/item/clothing/shoes/roguetown/boots
 			gloves = /obj/item/clothing/gloves/roguetown/angle
@@ -168,7 +169,7 @@
 			H.grant_language(/datum/language/celestial)
 			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
 
-			backpack_contents = list(/obj/item/roguekey/mercenary,/obj/item/rogueweapon/huntingknife, /obj/item/storage/belt/rogue/surgery_bag)
+			backpack_contents = list(/obj/item/roguekey/mercenary,/obj/item/rogueweapon/huntingknife, /obj/item/flashlight/flare/torch)
 			
 			var/datum/devotion/C = new /datum/devotion(H, H.patron)
 			C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)	//Starts off maxed out.

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -325,7 +325,7 @@
 		var/healing = 2.5
 		if(target.has_status_effect(/datum/status_effect/buff/stasis))
 			healing += 2.5
-		
+		target.apply_status_effect(/datum/status_effect/buff/healing, healing)
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = target
 			var/obj/item/bodypart/target_limb = get_most_damaged_limb(H)
@@ -333,10 +333,6 @@
 				// Heal the most damaged/bleeding limb
 				target_limb.heal_damage(healing * 10, healing * 10) // Convert healing to damage values
 				H.update_damage_overlays()
-			else
-				target.apply_status_effect(/datum/status_effect/buff/healing, healing)
-		else
-			target.apply_status_effect(/datum/status_effect/buff/healing, healing)
 		return TRUE
 	revert_cast()
 	return FALSE


### PR DESCRIPTION
## About The Pull Request
Removed bag fixes since im to lazy to learn proper conflict resolving. I'll make the bag fix again if it becomes more of a problem...seems rare anyways.

regression (their healing spell) now always applies the standard healing buff ontop of targeted limb auto healing. This is very similar to the way normal miracles function. I don't believe this was intended originally

## Testing Evidence

Booted up a server and confirmed that even with heavy damage and bleeding on a limb the normal healing buff was applied.

## Why It's Good For The Game

Fixes bug. Bug is bad.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
