### PR TITLE
Cure Rot miracle spell should revive dead player back regardless of who casts it.

### DIFF
--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -170,7 +170,7 @@
 	antimagic_allowed = TRUE
 	recharge_time = 3 MINUTES /// Scarlet edit. Original: 2 MINUTES
 	miracle = TRUE
-	devotion_cost = 100 /// Scarlet edit. Original 30
+	devotion_cost = 200 /// Scarlet edit. Original 30
 	/// Amount of PQ gained for curing zombos
 	var/unzombification_pq = PQ_GAIN_UNZOMBIFY
 	var/is_lethal = FALSE /// Scarlet edit. Original: TRUE

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -168,15 +168,17 @@
 	sound = 'sound/magic/revive.ogg'
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
-	recharge_time = 2 MINUTES
+	recharge_time = 3 MINUTES /// Scarlet edit. Original: 2 MINUTES
 	miracle = TRUE
-	devotion_cost = 30
+	devotion_cost = 100 /// Scarlet edit. Original 30
 	/// Amount of PQ gained for curing zombos
 	var/unzombification_pq = PQ_GAIN_UNZOMBIFY
-	var/is_lethal = TRUE
+	var/is_lethal = FALSE /// Scarlet edit. Original: TRUE
 
 /obj/effect/proc_holder/spell/invoked/cure_rot/priest
 	is_lethal = FALSE
+	recharge_time = 2 MINUTES
+	devotion_cost = 30
 
 /obj/effect/proc_holder/spell/invoked/cure_rot/cast(list/targets, mob/living/user)
 	var/stinky = FALSE


### PR DESCRIPTION
## About The Pull Request

What the title says, basically Pestran's Cure Rot receives a buff but to keep things balanced, I increased the devotion cost and longer cooldown so it can show the efforth a pestra acolyte does to unrot and revive someone if there is lux out of reach or no body knows surgery to extract one.

Priest's Cure Rot is unchaged.

## Testing Evidence

Trust me, it should work.

## Why It's Good For The Game

Because curing rot and not automatically reviving people sucks a lot, specially on lowpop.