### PR TITLE
Update arcyne_bolt.dm

### DIFF
--- a/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_bolt.dm
@@ -28,7 +28,7 @@
 /obj/projectile/energy/rogue3
 	name = "Arcyne Bolt"
 	icon_state = "arcane_barrage"
-	damage = 40
+	damage = 39
 	woundclass = BCLASS_BLUNT
 	nodamage = FALSE
 	npc_damage_mult = 1.5 // Makes it more effective against NPCs.


### PR DESCRIPTION
## About The Pull Request

Fixes some leftover slop from AP bad coding.

## Testing Evidence

Launched on local no issue.

## Why It's Good For The Game

So I want people to bear in mind that attacks that do 40 damage or more (or so I'm told) do what I'll refer to as 'micro stuns' which will slow and completely stop someone's action when they occur, the issue that arises is that you can legitimately juggle arcyne bolt fast enough to the point where someone nearly can't move to dodge the next hit at all because of the aforementioned 'micro stun'. Now this is all made worse because some 'genius' on AP decided it'd be funny to make staffs that can reduce the cooldown time on spells.

