### PR TITLE
silly scythe/militiapick nerf (BM PORT)

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -569,7 +569,7 @@
 
 /obj/item/rogueweapon/scythe
 	force = 15
-	force_wielded = 25
+	force_wielded = 20
 	possible_item_intents = list(SPEAR_BASH)
 	gripped_intents = list(/datum/intent/spear/cut/scythe, SPEAR_BASH, MACE_STRIKE)
 	name = "scythe"
@@ -588,7 +588,7 @@
 	max_blade_int = 100
 	anvilrepair = /datum/skill/craft/carpentry
 	smeltresult = /obj/item/rogueore/coal
-	associated_skill = /datum/skill/labor/farming
+	associated_skill = /datum/skill/combat/polearms
 	blade_dulling = DULLING_SHAFT_WOOD
 	walking_stick = TRUE
 	wdefense = 6
@@ -625,7 +625,7 @@
 	max_blade_int = 80
 	max_integrity = 400
 	slot_flags = ITEM_SLOT_HIP
-	associated_skill = /datum/skill/labor/mining
+	associated_skill = /datum/skill/combat/axes
 	anvilrepair = /datum/skill/craft/carpentry
 	smeltresult = /obj/item/ingot/iron
 	wdefense = 1


### PR DESCRIPTION
## About The Pull Request
https://github.com/BlackmoorHold/Blackmoor-hold/pull/157
Scythes/Militiapicks do not use non-combat skills which can be grinded to legendary very easily as their weaponskill.
This is stupid and extremely abusable aswell. Both aren't even bad weapons, infact, they are very good weapons to start with.
## Testing Evidence
Yes, it was already merged aswell.
## Why It's Good For The Game
We shouldn't have hidden powergamer weapons that make no sense.