### PR TITLE
Inquisitors get T1 Miracles

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -34,6 +34,9 @@
 		H.advsetup = 1
 		H.invisibility = INVISIBILITY_MAXIMUM
 		H.become_blind("advsetup")
+		var/datum/devotion/C = new /datum/devotion(H, H.patron)
+		C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
+
 
 
 ////Classic Inquisitor with a much more underground twist. Use listening devices, sneak into places to gather evidence, track down suspicious individuals. Has relatively the same utility stats as Confessor, but fulfills a different niche in terms of their combative job as the head honcho. 


### PR DESCRIPTION
## About The Pull Request
Gives Inquisitors Templar tier miracles (T1, no regen)
## Testing Evidence
![F2nIhpx](https://github.com/user-attachments/assets/8c67f2a0-4f73-45d4-9e57-0dcb119a0c67)
## Why It's Good For The Game
Because our Inquisitors are Tennites, and zealous ones at that.
Infact, I'd like all Inquisitors to have T0 or perhaps even T1 miracles, but that would be a different PR.