### PR TITLE
Dodge Experts can now be hit by other Speedsters

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -495,13 +495,11 @@
 	var/prob2defend = U.defprob
 	if(L.rogfat >= L.maxrogfat)
 		return FALSE
-	if(L)
-		if(H?.check_dodge_skill())
-			prob2defend = prob2defend + (L.STASPD * 15)
-		else
-			prob2defend = prob2defend + (L.STASPD * 10)
-	if(U)
-		prob2defend = prob2defend - (U.STASPD * 10)
+	if(L && U)
+		var/dodgechance = ((L.STASPD-U.STASPD)*10)
+		if(dodgechance>0 && H?.check_dodge_skill()) //This does not penalize you if you are losing
+			dodgechance = dodgechance*1.5 //dodgeexpert multiplier = 1.5
+		prob2defend += dodgechance
 	if(I)
 		if(I.wbalance > 0 && U.STASPD > L.STASPD) //nme weapon is quick, so they get a bonus based on spddiff
 			prob2defend = prob2defend - ( I.wbalance * ((U.STASPD - L.STASPD) * 10) )


### PR DESCRIPTION
## About The Pull Request

Currently, because of how the dodge calculation is coded, two 15spd dodge experts will always have 90% dodge against each other.
Also, as soon as somebody has dodgeexpert, even if they have a very modest spd, they will always reach 90% dodge against you..
This changes the calculation to make the enemies spd matter more for your own dodging - atleast now other spdbuilds can hit you.
## Testing Evidence
Two identical rogues can hit each other 50% of the time. Previously, this was 10%.
![iltbpRt](https://github.com/user-attachments/assets/e1adace5-4e96-4c3d-bbe2-c9c675bf2b55)

## Why It's Good For The Game
Spd is incredibly dominant right now.
Dodge expert comes from a time when light armor was actually bad.
This atleast makes it less comical.
