### PR TITLE
Psycross changes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -178,8 +178,8 @@
 	if (!H.restrained())
 		to_chat(src, span_warning ("My victim needs to be restrained in order to do this!"))
 		return
-	if(!istype(S, /obj/item/clothing/neck/roguetown/psicross/silver))
-		to_chat(src, span_warning("I need to be holding a silver psycross to extract this divination!"))
+	if(!istype(S, /obj/item/clothing/neck/roguetown/psicross))
+		to_chat(src, span_warning("I need to be holding a psycross to extract this divination!"))
 		return
 	for(var/obj/structure/fluff/psycross/N in oview(5, src))
 		found = N
@@ -195,7 +195,7 @@
 			"TELL ME!",
 		)
 
-		src.visible_message(span_warning("[src] shoves the silver psycross in [H]'s face!"))
+		src.visible_message(span_warning("[src] shoves the psycross in [H]'s face!"))
 		say(pick(torture_lines), spans = list("torture"))
 		H.emote("agony", forced = TRUE)
 		H.add_stress(/datum/stressevent/tortured)
@@ -203,7 +203,7 @@
 		if(!(do_mob(src, H, 10 SECONDS)))
 			return
 
-		src.visible_message(span_warning("[src]'s silver psycross abruptly catches flame, burning away in an instant!"))
+		src.visible_message(span_warning("[src]'s psycross abruptly catches flame, burning away in an instant!"))
 		H.confess_sins("antag")
 		qdel(S)
 		return
@@ -226,8 +226,8 @@
 	if (!H.restrained())
 		to_chat(src, span_warning ("My victim needs to be restrained in order to do this!"))
 		return
-	if(!istype(S, /obj/item/clothing/neck/roguetown/psicross/silver))
-		to_chat(src, span_warning("I need to be holding a silver psycross to extract this divination!"))
+	if(!istype(S, /obj/item/clothing/neck/roguetown/psicross))
+		to_chat(src, span_warning("I need to be holding a psycross to extract this divination!"))
 		return
 	for(var/obj/structure/fluff/psycross/N in oview(5, src))
 		found = N
@@ -243,14 +243,14 @@
 			"WHO IS YOUR SHEPHERD?",
 		)
 
-		src.visible_message(span_warning("[src] shoves the silver psycross in [H]'s face!"))
+		src.visible_message(span_warning("[src] shoves the psycross in [H]'s face!"))
 		say(pick(faith_lines), spans = list("torture"))
 		H.emote("agony", forced = TRUE)
 
 		if(!(do_mob(src, H, 10 SECONDS)))
 			return
 
-		src.visible_message(span_warning("[src]'s silver psycross abruptly catches flame, burning away in an instant!"))
+		src.visible_message(span_warning("[src]'s psycross abruptly catches flame, burning away in an instant!"))
 		H.confess_sins("patron")
 		H.add_stress(/datum/stressevent/tortured)
 		qdel(S)


### PR DESCRIPTION
## About The Pull Request

Makes it so any psycross can be used to interrogate

## Testing Evidence

![Screenshot_20](https://github.com/user-attachments/assets/83d1ebf2-899e-4f33-b46e-477b871e9bea)

## Why It's Good For The Game

Basic feature of inquisitors, locked behind a hard to get item.