### PR TITLE
Confessor Tier1 Miracles (Like Templar)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -61,4 +61,6 @@
 	ADD_TRAIT(H, TRAIT_INQUISITION, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_PERFECT_TRACKER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_OUTLANDER, TRAIT_GENERIC)		//You're a foreigner, a guest of the realm.
+	var/datum/devotion/C = new /datum/devotion(H, H.patron)
+	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)
 	H.grant_language(/datum/language/otavan)


### PR DESCRIPTION
## About The Pull Request
Gives T1 Miracles to Confessors, just like the Inquisitor received. Now all Inquisition roles should have either magic or miracles.
## Testing Evidence
An edgelord in his dumb coat setting himself on fire. 
![eRPPStz](https://github.com/user-attachments/assets/456f4e01-bd58-4832-9b26-4504f7370f10)
## Why It's Good For The Game
They are zealous clergy, and their lack of miracles was justified because of them being psydonites. This makes it clear they are not. It also differentiates them from the guards, and lets them express a little bit of individuality through god choice.