### PR TITLE
Single letter accent removal

### DIFF
--- a/strings/french_replacement.json
+++ b/strings/french_replacement.json
@@ -7,7 +7,6 @@
 		"not": "nut",
 		"I'm": "j'", 
 		"am": "ahm", 
-		"a": "un",
         "and": "eend", 
 		"the ": "l'",
 		"I": "j'",

--- a/strings/german_replacement.json
+++ b/strings/german_replacement.json
@@ -99,7 +99,6 @@
 		"wonderful": "wunderbar",
 		"many thanks": "vielen dank",
 		"of course": "natürlich",
-		"i": "ich",
 		"and": "und"
     },
     "start": {


### PR DESCRIPTION
## About The Pull Request
"i" to "ich" and "a" to "un" in the german and french autotranslations would lead to people saying "ICH" and "UN" in all capital letters. There are certainly other ways to deal with this, but it's not really worth it, when it's something that people can very easily write themselves if they like those particular accent quirks enough.

## Testing Evidence
trust me

## Why It's Good For The Game
These errors come up a lot, and since I'm the one who did the "ich" thing to begin with, it bothers me a lot.