### PR TITLE
Shows the weekdae in the status panel

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -52,7 +52,7 @@ GLOBAL_VAR_INIT(dayspassed, FALSE)
 				if("dawn")
 					if(prob(25))
 						GLOB.forecast = "rain"
-				if("day")
+				if("dae")
 					if(prob(5))
 						GLOB.forecast = "rain"
 				if("dusk")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -804,13 +804,31 @@ GLOBAL_VAR_INIT(mobids, 1)
 			if(check_rights(R_ADMIN,0))
 				stat(null, SSmigrants.get_status_line())
 
+	/var/days = "TWILIGHT"
+	switch(GLOB.dayspassed)
+		if(1)
+			days = "MOON'S DAE"
+		if(2)
+			days = "TIW'S DAE"
+		if(3)
+			days = "WEDDING'S DAE"
+		if(4)
+			days = "THULE'S DAE"
+		if(5)
+			days = "FREYJA'S DAE"
+		if(6)
+			days = "SATURN'S DAE"
+		if(7)
+			days = "SUN'S DAE"
+
 	if(client)
 		if(statpanel("RoundInfo"))
-			stat("Round ID: [GLOB.rogue_round_id]")
-			stat("Round Time: [time2text(STATION_TIME_PASSED(), "hh:mm:ss", 0)] [world.time - SSticker.round_start_time]")
+			stat("ROUND ID: [GLOB.rogue_round_id]")
+			stat("ROUND TIME: [time2text(STATION_TIME_PASSED(), "hh:mm:ss", 0)] [world.time - SSticker.round_start_time]")
 			if(SSgamemode.roundvoteend)
-				stat("Round End: [DisplayTimeText(time_left)]")
-			stat("TimeOfDay: [GLOB.tod]")
+				stat("ROUND END: [DisplayTimeText(time_left)]")
+			stat("[days] ᛉ [uppertext(GLOB.tod)]")
+
 
 	if(client && client.holder && check_rights(R_DEBUG,0))
 		if(statpanel("MC"))


### PR DESCRIPTION
## About The Pull Request
adds the day of the week to the status panel
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![image](https://github.com/user-attachments/assets/e89ec46d-92ff-4be8-8a70-8f8b46f59aa4)
![image](https://github.com/user-attachments/assets/8ddad303-f445-40fe-b78f-90154f4bab37)

(also makes it look a little more charming)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
generally people know what day of the week it is. it's harder in game because many situations dont allow a normal sleeping schedule, as well as the days obviously passing by faster...

its cool and immersive to be able to tell someone to meet on wedding's dae evening somewhere, or to recall what day of the week something happened. this facilitates such
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
