### PR TITLE
Fixes Smashing/Biting missing defines

### DIFF
--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -493,6 +493,7 @@
 /obj/item/grabbing/bite
 	name = "bite"
 	icon_state = "bite"
+	d_type = "stab"
 	slot_flags = ITEM_SLOT_MOUTH
 	bleed_suppressing = 1
 	var/last_drink
@@ -529,7 +530,7 @@
 
 	user.changeNext_move(CLICK_CD_MELEE)
 	var/mob/living/carbon/C = grabbed
-	var/armor_block = C.run_armor_check(sublimb_grabbed, d_type)
+	var/armor_block = C.run_armor_check(sublimb_grabbed, d_type, armor_penetration = BLUNT_DEFAULT_PENFACTOR)
 	var/damage = user.get_punch_dmg()
 	if(HAS_TRAIT(user, TRAIT_STRONGBITE))
 		damage = damage*2


### PR DESCRIPTION
## About The Pull Request
Port of https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/2779
Fixes missing damagetype defines on smashing and bites. This was resulting in those being way way stronger than intended.
## Testing Evidence
What's important is the crit message of my bite, the sort you'd get from a stab.
![wjmQZRq](https://github.com/user-attachments/assets/45ec7d79-326d-4074-a8b3-91afda7962ba)
## Why It's Good For The Game
Otherwise bites will penetrate through basically all heavy armor in the game because of how blunt works, also bites just... shouldn't deal blunt damage?
The same with smash, all blunt has -100ap and it had 0, making it ignore heavy armors in particular.