### PR TITLE
Disables werewolf

### DIFF
--- a/code/modules/events/antagonist/solo/werewolf.dm
+++ b/code/modules/events/antagonist/solo/werewolf.dm
@@ -14,7 +14,7 @@
 	base_antags = 1
 	maximum_antags = 2
 
-	weight = 10
+	weight = 0
 
 	earliest_start = 0 SECONDS
 


### PR DESCRIPTION
## About The Pull Request

Temporarily disables werewolves because they seem to make every round revolve around them

## Testing Evidence

![Screenshot_25](https://github.com/user-attachments/assets/1e9f2f44-4c24-4a5e-b850-2d3cd6d3ffa0)

## Why It's Good For The Game

Should break up the monotony of every round being a werewolf round while antags are adjusted
