### PR TITLE
Werewolf dynamic stats (werewolf nerf)

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -118,10 +118,10 @@
 	W.emote("rage")
 
 
-	W.mind.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
-	W.mind.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)
-	W.mind.adjust_skillrank(/datum/skill/misc/climbing, 6, TRUE)
- 	W.mind.adjust_skillrank(/datum/skill/misc/swimming, 5, TRUE)
+	W.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
+	W.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)
+	W.adjust_skillrank(/datum/skill/misc/climbing, 6, TRUE)
+	W.adjust_skillrank(/datum/skill/misc/swimming, 5, TRUE)
 	
 	W.STASTR = src.STASTR +5
 	W.STACON = src.STACON +5


### PR DESCRIPTION
## About The Pull Request

WW stats were hardcoded to be 10 for everything, except str,end and con, which were hardcoded to be 20.
Now WW stats are ontop of your previous stats: +5 to str,end,con -3 to int, and the same you had as nonww for the other ones.
This generally results in weaker WWs, especially in the most important fragger stats, aswell as some variation between them.

## Testing Evidence

pre transformation, intentionally super weak build
![oifGEQD](https://github.com/user-attachments/assets/1d56b78a-6490-44df-9603-322dc85c9538)
after transformation, weak asf werewolf
![sxbUYPV](https://github.com/user-attachments/assets/1e688c48-07ce-4c5d-a829-58666b6bded6)

## Why It's Good For The Game
So we can have ww ingame without them fragging everybody and "making the round revolve around them".