### PR TITLE
Fixes wizard voices

### DIFF
--- a/code/modules/mob/living/carbon/human/voicepacks/male/wizard.dm
+++ b/code/modules/mob/living/carbon/human/voicepacks/male/wizard.dm
@@ -5,4 +5,4 @@
 			used = 'sound/vo/male/wizard/laugh.ogg'
 	if(!used)
 		used = ..(soundin, modifiers)
-	return
+	return used


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

The wizard voicepack lacked the variable it was supposed to return on the return line, making everyone with a wizard voicepack completely silent, as in, all of the noise emotes made no noise. This fixes it.
## Testing Evidence
Me, entering the game and making all kinds of noises with the fixed voice. It is hearable now.
![image](https://github.com/user-attachments/assets/be3a1ff1-4cab-40eb-913a-e81b0932551c)
![image](https://github.com/user-attachments/assets/c6956b3f-a58b-4fd4-9e13-7d1607551123)


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Bug fix!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
