### PR TITLE
Fire balance pass

### DIFF
--- a/code/controllers/subsystem/fire_burning.dm
+++ b/code/controllers/subsystem/fire_burning.dm
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(fire_burning)
 
 		if(O.resistance_flags & ON_FIRE) //in case an object is extinguished while still in currentrun
 			if(!(O.resistance_flags & FIRE_PROOF))
-				O.take_damage(15, BURN, "fire", 0)
+				O.take_damage(3, BURN, "fire", 0)
 			else
 				O.extinguish()
 			if(!O.fire_burn_start)

--- a/code/game/objects/items/rogueitems/bombs.dm
+++ b/code/game/objects/items/rogueitems/bombs.dm
@@ -12,6 +12,7 @@
 	var/fuze = 50
 	var/lit = FALSE
 	var/prob2fail = 23
+	var/blewup = FALSE
 	grid_width = 32
 	grid_height = 64
 
@@ -57,11 +58,14 @@
 		if(lit)
 			if(!skipprob && prob(prob2fail))
 				snuff()
+				new /obj/item/natural/glass/shard (T)
 			else
-				explosion(T, light_impact_range = 1, flame_range = 2, smoke = TRUE, soundin = pick('sound/misc/explode/bottlebomb (1).ogg','sound/misc/explode/bottlebomb (2).ogg'))
+				explosion(T, light_impact_range = 2, flame_range = 2, smoke = TRUE, soundin = pick('sound/misc/explode/bottlebomb (1).ogg','sound/misc/explode/bottlebomb (2).ogg'))
+				blewup = TRUE
 		else
 			if(prob(prob2fail))
 				snuff()
+				new /obj/item/natural/glass/shard (T)
 			else
 				playsound(T, 'sound/items/firesnuff.ogg', 100)
 				new /obj/item/natural/glass/shard (T)
@@ -69,7 +73,12 @@
 
 /obj/item/bomb/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	..()
+	var/mob/living/L = hit_atom
+	if(isliving(hit_atom))
+		L.adjust_fire_stacks(12.5) //6 pats when standing or rolling on the floor 3 times, in case the bomb doesn't explode, you are still covered in accelerant...
 	explode()
+	if(blewup == TRUE) //in case the bomb DOES explode
+		L.IgniteMob()
 
 /obj/item/bomb/process()
 	fuze--

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -355,8 +355,8 @@
 
 /mob/living/carbon/resist_fire()
 	fire_stacks -= 2.5
-	if(fire_stacks > 10 || !(mobility_flags & MOBILITY_STAND))
-		Paralyze(50, TRUE, TRUE)
+	if(!(mobility_flags & MOBILITY_STAND))
+		Paralyze(25, TRUE, TRUE)
 		spin(32,2)
 		fire_stacks -= 5
 		visible_message("<span class='warning'>[src] rolls on the ground, trying to put [p_them()]self out!</span>")

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1864,7 +1864,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		burn_damage = burn_damage * heatmod * H.physiology.heat_mod
 		if (H.stat < UNCONSCIOUS && (prob(burn_damage) * 10) / 4) //40% for level 3 damage on humans
 			H.emote("pain")
-		H.apply_damage(burn_damage, BURN, spread_damage = TRUE)
+		H.apply_damage(CLAMP(burn_damage, 0, 40), BURN, spread_damage = TRUE) // fire damage is capped because people get nuked with no feedback after their core temperature rises
 
 	else if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT && !HAS_TRAIT(H, TRAIT_RESISTCOLD))
 		SEND_SIGNAL(H, COMSIG_CLEAR_MOOD_EVENT, "hot")

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -201,7 +201,7 @@
 			healing += situational_bonus
 
 		// Block excommunicated targets from receiving divine healing
-		if(ispath(user.patron?.type, /datum/patron/divine) && target.real_name in GLOB.excommunicated_players)
+		if(ispath(user.patron?.type, /datum/patron/divine) && (target.real_name in GLOB.excommunicated_players))
 			to_chat(user, span_danger("The gods recoil from [target]! Divine fire scorches your hands as your plea is rejected!"))
 			target.visible_message(span_danger("[target] is seared by divine wrath! The gods hate them!"), span_userdanger("I am seared by divine wrath! The gods hate me!"))
 			revert_cast()
@@ -271,7 +271,7 @@
 			target.fire_act(1,10)
 			return TRUE
 		// Block excommunicated targets from receiving divine healing
-		if(ispath(user.patron?.type, /datum/patron/divine) && target.real_name in GLOB.excommunicated_players)
+		if(ispath(user.patron?.type, /datum/patron/divine) && (target.real_name in GLOB.excommunicated_players))
 			to_chat(user, span_danger("The gods recoil from [target]! Divine fire scorches your hands as your plea is rejected!"))
 			target.visible_message(span_danger("[target] is seared by divine wrath! The gods hate them!"), span_userdanger("I am seared by divine wrath! The gods hate me!"))
 			revert_cast()

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
@@ -27,8 +27,8 @@
 /obj/projectile/magic/aoe/fireball/rogue
 	name = "fireball"
 	exp_heavy = 0
-	exp_light = 0
-	exp_flash = 0
+	exp_light = 1
+	exp_flash = 2
 	exp_fire = 1
 	damage = 10
 	damage_type = BURN
@@ -42,9 +42,12 @@
 /obj/projectile/magic/aoe/fireball/rogue/on_hit(target)
 	. = ..()
 	if(ismob(target))
-		var/mob/M = target
+		var/mob/living/M = target
 		if(M.anti_magic_check())
 			visible_message(span_warning("[src] fizzles on contact with [target]!"))
 			playsound(get_turf(target), 'sound/magic/magic_nulled.ogg', 100)
 			qdel(src)
 			return BULLET_ACT_BLOCK
+		else
+			M.adjust_fire_stacks(10)	//extinguished by patting yourself down 4 times, or dropping on the floor and rolling twice
+			M.IgniteMob()


### PR DESCRIPTION
## About The Pull Request
astrata.dm
-> anastasis now correctly gibs deadites
-> anastasis gives hit liches 15 firestacks instead

-> sacred flames no longer automatically extinguishes after 5 seconds

carbon.dm
-> you are no longer forced to drop and roll if you have more than ten firestacks, you may stay mobile and pat yourself down, to extinguish yourself slower
-> if you do choose to lay down and roll, you will find this more efficient than before. you're no longer stunned for 5 seconds each try, but rather 2 and a half.

species.dm (edited port of blackmoor #185)
-> caps maximum fire damage a tick

fireball.dm (ditto)
-> fireball gains one range of light explosion, two ranges of blind
-> fireball gains hefty firestacks on hit, but loses the ability to nuke with max firestacks since you're thrown out of the fire while you are stunned from getting the firestacks applied to you

bombs.dm
-> gains one range of light explosion, dealing some damage and throwing you away
-> no longer nukes with max firestacks through this either, so has been given an even heftier amount of firestacks on direct hit


<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence


https://github.com/user-attachments/assets/b9be963b-0220-4940-95f8-21bf4d104ea8

(skeletons gib, liches burn)

https://github.com/user-attachments/assets/0a2cadc0-6b76-4382-b5a6-c8b05bfbc983

(kindle doesn't nuke you after 4 ish uses anymore and doesnt auto extinguish)

https://github.com/user-attachments/assets/80bbdcd1-7254-49dd-b311-2946634f4b63

(patting after a fireball puts you in paincrit range. be aware: being hit with 10 or more firestacks stuns you for a moment so this isnt much time lost before resisting. not pictured: stop drop and roll still puts you into paincrit range.)

https://github.com/user-attachments/assets/731b3231-06cc-4b25-8210-68d0a92d82a0

(being hit with a bomb, and opting to pat out on your feet, has you red out a limb more often than not. stop drop and roll will still leave you in paincrit range.)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

fire damage is extremely nasty. it deals a lot of pain and cant be fixed without sleep or miracles. also- after a certain point will nuke you with extreme damage amounts even at low firestacks once your body heated up enough. the intention of this PR is to keep it nasty, but to remove instakill abilities. all of these nerfed abilities will still red out a limb, making it functionless or leave players in paincrit ranges... 

-> anastasis was always meant to blow up deadites, this is a bugfix. liches dont blow up, even if they're not implemented yet i felt it would be kind of a copout death, though they still have to fear the astrata blast

-> cleansing flames. dear god. i've been fragging bandits and wretches up and down with this on a naked acolyte with a wood staff. i cant keep getting away with it. its fire damage nuke was removed by capping total fire damage, in turn i removed the auto extinguish it had, since it was extremely janky. most acolytes will have more than ten INT and as such will cast this faster than the timer, this will have multiple timers running and extinguish the target at random, especially if two people are casting this at once. dissatisfying. it can do with this buff after its fragging capability being removed, it is easy enough to pat out and takes a long time to properly hurt you, letting you deal with the acolyte in question, i believe. you can also now burn people at the stake properly. yay!

-> fireball is easier to hit than the bottlebomb and isn't limited in uses much and can't fail... this is why i made the bottlebomb a little stronger. now none of these get you close to dying first hit but they put you in a pretty spot if you are caught out by one, most likely either in paincrit, or on the ground with your leg redded out. if you drop down and roll to extinguish you can avoid these consequences, but you are kind of lying down on the ground stunned while the mage is charging his next spell, or the psydonite is lighting his next bomb, and a second one can put you with necra easily.

-> stop drop and roll is no longer forced on high firestacks. i felt this gave an interesting avenue of strategy, letting you stay mobile for taking more fire damage in total, or rolling on the spot while, of course being stunned in one spot to minimize the damage you're taking from the fire alone.

all in all im looking for feedback. none of these numbers are dealbreakers and im itching to see how these nerfed and reworked items and spells work in the game...

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
