### PR TITLE
Makes priests SHUNNED races and up, minus constructs

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 1
 	selection_color = JCOLOR_CHURCH
 	f_title = "Priestess"
-	allowed_races = RACES_NO_CONSTRUCT		//Too recent arrivals to ascend to priesthood.
+	allowed_races = list(RACES_RESPECTED, RACES_TOLERATED, RACES_SHUNNED)
 	allowed_patrons = ALL_DIVINE_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	tutorial = "The Divine is all that matters in a world of the immoral. The Weeping God left his children to rule over us mortals--and you will preach their wisdom to any who still heed their will. The faithless are growing in number. It is up to you to shepard them toward a Gods-fearing future; for you are a priest of Astrata."


### PR DESCRIPTION
## About The Pull Request
The other PR was misleadingly named before now, and actually makes Priests *shunned* and up. Goblin, Orc, and Metal Construct Priests are generally coal (though I and some others have voiced that having a limited system to spend triumphs or something to make occasional exceptions would be peak, but I lack the coding skill) so now I've done it myself.
By using a list, this allows Shunned anthropomorphic races, Tolerated races like half-elf and half-kin, and Respected races able to play Priest while barring "Neutral" races (metal construct and aasimar) (why the fuck are these in the same category) and the Despised races The only major sacrifice of this is Aasimar, who really should just be put in another category. Unlike the other priest PR, I have also not changed the rankings of any of the races.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![563735673q](https://github.com/user-attachments/assets/79da473d-8f68-4d0e-90d0-94d1d57523c9)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Metal constructs should really probably not be priests. It's kind of surprising to me they're allowed in the church's ranks at all as anything but servants, they're literally automatons (and I love them for it.)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
