### PR TITLE
Old god patron change

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -262,7 +262,7 @@
 
 #define ALL_DIVINE_PATRONS list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/ravox, /datum/patron/divine/necra, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora)
 
-#define ALL_INHUMEN_PATRONS list(/datum/patron/inhumen/zizo, /datum/patron/inhumen/graggar, /datum/patron/inhumen/matthios, /datum/patron/inhumen/baotha)
+#define ALL_INHUMEN_PATRONS list(/datum/patron/inhumen/zizo, /datum/patron/inhumen/graggar, /datum/patron/inhumen/matthios, /datum/patron/inhumen/baotha, /datum/patron/old_god/psydonite_hidden)
 
 #define NON_PSYDON_PATRONS list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/ravox, /datum/patron/divine/necra, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora, /datum/patron/inhumen/zizo, /datum/patron/inhumen/graggar, /datum/patron/inhumen/matthios, /datum/patron/inhumen/baotha)	//For lord/heir usage
 

--- a/code/datums/gods/patrons/old_god.dm
+++ b/code/datums/gods/patrons/old_god.dm
@@ -1,14 +1,15 @@
 /datum/patron/old_god
-	name = "Psydon"
+	name = "Psydon (Known)"
 	domain = "God of Ontological Reality"
-	desc = "The true God of everything, Psydon is maximally good - He created humen in his image to live in Psydonia, and defended the Black Basin by sending the COMET SYON to defeat the rampaging archdemon."
+	desc = "Those who openly worship Psydon in defiance of the Holy See are seen as heretics, but most are regarded as harmless relics of a bygone age. Tolerated but scorned, they endure quietly, holding to the hope that PSYDON YET LIVES. PSYDON YET ENDURES."
 	worshippers = "Fanatics and Nostalgists"
 	associated_faith = /datum/faith/old_god
 	mob_traits = list(TRAIT_PSYDONITE)
-	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
-					/obj/effect/proc_holder/spell/self/check_boot				= CLERIC_T0,
-					/obj/effect/proc_holder/spell/invoked/psydonendure			= CLERIC_T1,
-					/obj/effect/proc_holder/spell/self/psydonrespite			= CLERIC_T2,
+	miracles = list(
+		/obj/effect/proc_holder/spell/targeted/touch/orison = CLERIC_ORI,
+		/obj/effect/proc_holder/spell/self/check_boot = CLERIC_T0,
+		/obj/effect/proc_holder/spell/invoked/psydonendure = CLERIC_T1,
+		/obj/effect/proc_holder/spell/self/psydonrespite = CLERIC_T2,
 	)
 	confess_lines = list(
 		"THERE IS ONLY ONE TRUE GOD!",
@@ -224,3 +225,22 @@
 
 	revert_cast()
 	return FALSE
+
+/datum/patron/old_god/psydonite_hidden
+	name = "Psydonite (Hidden)"
+	domain = "God of Ontological Reality"
+	desc = "These followers hide their worship of Psydon, blending into society and sometimes gaining privilege or status. But discovery risks being hunted, for only worshippers of the Ten can be nobility."
+	worshippers = "Secret cults, double agents, those who must hide their faith to survive."
+	associated_faith = /datum/faith/old_god
+	mob_traits = list(TRAIT_PSYDONITE)
+	miracles = list(
+		/obj/effect/proc_holder/spell/targeted/touch/orison = CLERIC_ORI,
+		/obj/effect/proc_holder/spell/self/check_boot = CLERIC_T0,
+		/obj/effect/proc_holder/spell/invoked/psydonendure = CLERIC_T1,
+		/obj/effect/proc_holder/spell/self/psydonrespite = CLERIC_T2,
+	)
+	confess_lines = list(
+		"THERE IS ONLY ONE TRUE GOD!",
+		"PSYDON YET LYVES! PSYDON YET ENDURES!",
+		"REBUKE THE HERETICAL- PSYDON ENDURES!",
+	)


### PR DESCRIPTION
Gives psydonites the hidden patron option, which for coded purposes, gives them the same role list as inhumen worshippers, as they are making an effort to hide their faith. Only ten worshippers are "allowed" to be nobility by the holy see. 
Open psydonites will have a smaller role list but are tolerated.

![image](https://github.com/user-attachments/assets/d995424c-7678-4bb6-8996-96311a731827)
