### PR TITLE
Adjusts Saiga Form, Readds Tame Beast

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -56,6 +56,7 @@
 					/obj/effect/proc_holder/spell/targeted/blesscrop			= CLERIC_T0,
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/targeted/wildshape			= CLERIC_T2,
+					/obj/effect/proc_holder/spell/targeted/beasttame			= CLERIC_T2,
 					/obj/effect/proc_holder/spell/targeted/conjure_glowshroom	= CLERIC_T3,
 					/obj/effect/proc_holder/spell/self/howl/call_of_the_moon	= CLERIC_T4,
 	)

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/saiga.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/saiga.dm
@@ -14,14 +14,14 @@
 	. = ..()
 	if(src.mind)
 		src.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
-		src.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
+		src.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 		src.adjust_skillrank(/datum/skill/misc/swimming, 4, TRUE)
 		src.adjust_skillrank(/datum/skill/misc/athletics, 5, TRUE)
 
 		src.STASTR = 10
 		src.STACON = 13
-		src.STAEND = 18 //Because I don't want to give it TRAIT_INFINITE_STAMINA
-		src.STASPD = 13
+		src.STAEND = 17 //Because I don't want to give it TRAIT_INFINITE_STAMINA
+		src.STASPD = 14
 
 		AddSpell(new /obj/effect/proc_holder/spell/self/saigahoofs)
 		real_name = "Saiga ([stored_mob.real_name])" //So we don't get a random name
@@ -42,7 +42,7 @@
 	)
 	inherent_biotypes = MOB_HUMANOID
 	armor = 5
-	no_equip = list(SLOT_SHIRT, SLOT_HEAD, SLOT_WEAR_MASK, SLOT_ARMOR, SLOT_GLOVES, SLOT_SHOES, SLOT_PANTS, SLOT_CLOAK, SLOT_BELT, SLOT_BACK_R, SLOT_BACK_L, SLOT_S_STORE)
+	no_equip = list(SLOT_SHIRT, SLOT_HEAD, SLOT_WEAR_MASK, SLOT_ARMOR, SLOT_GLOVES, SLOT_SHOES, SLOT_PANTS, SLOT_CLOAK, SLOT_BELT, SLOT_S_STORE)
 	nojumpsuit = 1
 	sexes = 1
 	offset_features = list(OFFSET_HANDS = list(0,2), OFFSET_HANDS_F = list(0,2))

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/saiga.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/saiga.dm
@@ -7,7 +7,7 @@
 	// Someone else balance this, I am here for code, not numbers
 
 //BUCKLING
-/mob/living/carbon/human/species/wildshape/saiga/buckle_mob(mob/living/target, force = TRUE, check_loc = TRUE, lying_buckle = FALSE, hands_needed = 1, target_hands_needed = 0)
+/mob/living/carbon/human/species/wildshape/saiga/buckle_mob(mob/living/target, force = TRUE, check_loc = TRUE, lying_buckle = FALSE, hands_needed = 0, target_hands_needed = 0)
 	. = ..(target, force, check_loc, lying_buckle, hands_needed, target_hands_needed)
 
 /mob/living/carbon/human/species/wildshape/saiga/gain_inherent_skills()
@@ -20,8 +20,8 @@
 
 		src.STASTR = 10
 		src.STACON = 13
-		src.STAEND = 17 //Because I don't want to give it TRAIT_INFINITE_STAMINA
-		src.STASPD = 14
+		src.STAEND = 16 //Because I don't want to give it TRAIT_INFINITE_STAMINA
+		src.STASPD = 15
 
 		AddSpell(new /obj/effect/proc_holder/spell/self/saigahoofs)
 		real_name = "Saiga ([stored_mob.real_name])" //So we don't get a random name

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/saiga.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/saiga.dm
@@ -7,7 +7,7 @@
 	// Someone else balance this, I am here for code, not numbers
 
 //BUCKLING
-/mob/living/carbon/human/species/wildshape/saiga/buckle_mob(mob/living/target, force = TRUE, check_loc = TRUE, lying_buckle = FALSE, hands_needed = 0, target_hands_needed = 0)
+/mob/living/carbon/human/species/wildshape/saiga/buckle_mob(mob/living/target, force = TRUE, check_loc = TRUE, lying_buckle = FALSE, hands_needed = 1, target_hands_needed = 0)
 	. = ..(target, force, check_loc, lying_buckle, hands_needed, target_hands_needed)
 
 /mob/living/carbon/human/species/wildshape/saiga/gain_inherent_skills()


### PR DESCRIPTION
## About The Pull Request
Adds the following:
-2 END for +2 SPD.
Tame Beast Spell.
Saiga form has back slots enabled.

## Testing Evidence
![saigapr](https://github.com/user-attachments/assets/1ecacc55-ab90-48be-a184-a6cc4af6a474)

## Why It's Good For The Game
As someone who has played saiga form consistently, and with the new AP update where druids drop all their things, I've found that it would be a huge QoL to at least give them the ability to carry their shit hands free for SAIGA FORM ONLY.

It's a form dedicated to mobility and moving stuff around. Since we lack the ability to saddle ourselves in saiga form, which would... let you carry stuff realistically like a pack horse, I've done it this way instead.

Although I am not sure how bad the -2 END will be coming down from 18 or how much that +2 SPD is going to affect movement speed. Saigas are supposed to be fast, and 13 SPD didn't feel fast enough. Plus it makes it an inbetween between the cat form's huge speed and the volf form which is a tad slower but built for combat.

Also, tame beast was removed from the recent AP update so I'm adding it back in. There is a Dendor's Chosen quest you sometimes get to tame animals and now you can't even do it... and why they would even remove tame beast from druid's kit is weird itself.
