### PR TITLE
Changes the cup size descriptions back to adjectives

### DIFF
--- a/code/_globalvars/customization/organ_customization.dm
+++ b/code/_globalvars/customization/organ_customization.dm
@@ -12,15 +12,15 @@ GLOBAL_LIST_INIT(named_ball_sizes, list(
 
 GLOBAL_LIST_INIT(named_breast_sizes, list(
 	"Flat" = 0,
-	"A-cup" = 1,
-	"B-cup" = 2,
-	"C-cup" = 3,
-	"D-cup" = 4,
-	"E-cup" = 5,
-	"F-cup" = 6,
-	"G-cup" = 7,
-	"H-cup" = 8,
-	"I-cup" = 9
+	"Slight" = 1,
+	"Small" = 2,
+	"Moderate" = 3,
+	"Large" = 4,
+	"Generous" = 5,
+	"Heavy" = 6,
+	"Massive" = 7,
+	"Heaping" = 8,
+	"Obscene" = 9
 ))
 
 GLOBAL_LIST_INIT(customizer_choices, build_customizer_choices())

--- a/code/datums/mob_descriptors/descriptors/other.dm
+++ b/code/datums/mob_descriptors/descriptors/other.dm
@@ -179,27 +179,27 @@
 		if(0)
 			adjective = "a flat"
 		if(1)
-			adjective = "an A-cup"
+			adjective = "a slight"
 		if(2)
-			adjective = "a B-cup"
+			adjective = "a small"
 		if(3)
-			adjective = "a C-cup"
+			adjective = "a moderate"
 		if(4)
-			adjective = "a D-cup"
+			adjective = "a large"
 		if(5)
-			adjective = "an E-cup"
+			adjective = "a generous"
 		if(6)
-			adjective = "an F-cup"
+			adjective = "a heavy"
 		if(7)
-			adjective = "a G-cup"
+			adjective = "a massive"
 		if(8)
-			adjective = "an H-cup"
+			adjective = "a heaping"
 		if(9)
-			adjective = "an I-cup"
+			adjective = "an obscene"
 		if(10)
-			adjective = "a J-cup"
+			adjective = "a backbreaking"
 		if(11)
-			adjective = "a K-cup"
+			adjective = "a stomach-hiding"
 		if(12)
-			adjective = "an L-cup"
+			adjective = "a torso-sized"
 	return "[adjective] pair of breasts"

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -469,32 +469,32 @@
 					should_update = TRUE
 
 		if("breast size")
-			var/list/breast_sizes = list("flat", "very small", "small", "average", "large", "enormous")
+			var/list/breast_sizes = list("Flat", "Slight", "Small", "Moderate", "Large", "Generous", "Heavy", "Massive", "Heaping", "Obscene")
 			var/new_size = input(user, "Choose your breast size", "Breast Size") as null|anything in breast_sizes
 			if(new_size)
 				var/obj/item/organ/breasts/breasts = H.getorganslot(ORGAN_SLOT_BREASTS)
 				if(breasts)
 					var/size_num
 					switch(new_size)
-						if("flat")
+						if("Flat")
 							size_num = 0
-						if("A-cup")
+						if("Slight")
 							size_num = 1
-						if("B-cup")
+						if("Small")
 							size_num = 2
-						if("C-cup")
+						if("Moderate")
 							size_num = 3
-						if("D-cup")
+						if("Large")
 							size_num = 4
-						if("E-cup")
+						if("Generous")
 							size_num = 5
-						if("F-cup")
+						if("Heavy")
 							size_num = 6
-						if("G-cup")
+						if("Massive")
 							size_num = 7
-						if("H-cup")
+						if("Heaping")
 							size_num = 8
-						if("I-cup")
+						if("Obscene")
 							size_num = 9
 
 					breasts.breast_size = size_num


### PR DESCRIPTION
## About The Pull Request
After discussion in chat, it seems people preferred the adjectives, so I tried to come up with suitable ones to replace them. If people prefer the original "Flat/small/average/large/enormous", we could bring the original descriptors back and continue from "enormous" to shit like "titanic", but I think this is moderately more tasteful. I'm not bringing back "average" though, as the implication bothered at least one person I know.
If you don't like any of the descriptors, that's fine, this is a super trivial change, just suggest an alternative please.
Sizes above "obscene" are not available in the game and only exist because I worked on the sprites for them already and maybe somebody wants to do something with them later.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_M8DVLgU40Q](https://github.com/user-attachments/assets/d2f635a8-05fd-4d52-869c-f079fe1efdaa)
![465784674Vja](https://github.com/user-attachments/assets/717a893f-46ed-44cc-b080-4b772d103857)


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I honestly don't think this mattered but I truly do not care and other people seem to!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
