### PR TITLE
Buffs Killer's Ice back to what it was

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -383,7 +383,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	reagent_state = LIQUID
 	color = "#c8c9e9"
 	taste_description = "cold needles"
-	toxpwr = 10
+	toxpwr = 20
 
 //Potion reactions
 /datum/chemical_reaction/alch/stronghealth


### PR DESCRIPTION
## About The Pull Request

Makes **Killer's** Ice more deadly, dropping you into crit in mere seconds.

## Testing Evidence

Before.
![image](https://github.com/user-attachments/assets/b4eb9ba1-dd24-46c0-be28-1749abbef38f)

_Do I really need to screencap the crit screen?_ 

## Why It's Good For The Game

Before Vide ChatGPT code/Azure Peak mass hugboxing, Killer's Ice would instantly crit you in just a few seconds. Currently, it only deals about half your HP. This buffs it back to what it was, an actual **Killer's** poison that crits your victim, it doesn't do worse, no insta kills, but just enough so that you can finish the job quietly.

