### PR TITLE
Lets half-elves have humen ears as an option, lets wild-kin and half-kin have tusks

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -80,6 +80,7 @@
 		/datum/customizer/organ/penis/anthro,
 		/datum/customizer/organ/breasts/animal,
 		/datum/customizer/organ/vagina/anthro,
+		/datum/customizer/organ/horns/tusks,
 		)
 	body_marking_sets = list(
 		/datum/body_marking_set/none,

--- a/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
@@ -69,6 +69,7 @@
 		/datum/customizer/organ/penis/anthro,
 		/datum/customizer/organ/breasts/animal,
 		/datum/customizer/organ/vagina/animal,
+		/datum/customizer/organ/horns/tusks,
 		)
 	body_marking_sets = list(
 		/datum/body_marking_set/none,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -52,7 +52,7 @@
 		ORGAN_SLOT_HEART = /obj/item/organ/heart,
 		ORGAN_SLOT_LUNGS = /obj/item/organ/lungs,
 		ORGAN_SLOT_EYES = /obj/item/organ/eyes/halfelf,
-		ORGAN_SLOT_EARS = /obj/item/organ/ears/elf,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
 		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue,
 		ORGAN_SLOT_LIVER = /obj/item/organ/liver,
 		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach,
@@ -69,6 +69,7 @@
 		/datum/customizer/organ/penis/anthro,
 		/datum/customizer/organ/breasts/human,
 		/datum/customizer/organ/vagina/human_anthro,
+		/datum/customizer/organ/ears/elf,
 		)
 	body_marking_sets = list(
 		/datum/body_marking_set/none,


### PR DESCRIPTION
## About The Pull Request
Simply allows half-elves to better pass as humen if they so wish by giving them the option to unselect ear sprites.
Also does it for tusks on wildkin and halfkin lol whoops almost forgot that part
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![F2yo3lifGZ](https://github.com/user-attachments/assets/9aa7a535-ba0c-4a81-8138-ce51ed7ee16e)
![FzXCzKnZ3c](https://github.com/user-attachments/assets/7fe43e97-f55f-474d-932e-a3d3859957f1)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I was making a half-elf, realized they only get the elf ears and thought the size of them was kind of obnoxious. I thought it'd be a nice way to differentiate them very slightly and allow people to portray different aspects and fractions of elvish blood in their characters while still taking the race, instead of going "ooo, my mother was a half-elf!" '>Corbus is a towering Humen male...'
If preferred I could just sprite a smaller set of elf ears instead so you have to play with SOME kind of visibly point knife-ears instead.
Somebody asked for the other thing and it seemed completely reasonable.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
