### PR TITLE
Raises adventurer slots

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -8,8 +8,8 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 	flag = ADVENTURER
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 25
-	spawn_positions = 25
+	total_positions = 99
+	spawn_positions = 99
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Hero of nothing, a wanderer in foreign lands in search of fame and riches. Whatever led you to this fate is up to the wind to decide, and you've never fancied yourself for much other than the thrill. Some day your pride is going to catch up to you, and you're going to find out why most men don't end up in the annals of history."
 


### PR DESCRIPTION
There’s an unprecedented number of players right now, which is great—but it comes with a real problem: finite role slots. 
Church, Garrison, Adventurers… those fill up fast. And once they’re full, people aren’t going to settle for playing a towner.