### PR TITLE
HERE LIES... Let's you rename grave markers

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -696,14 +696,14 @@
 	. = ..()
 	if(wrotesign)
 		if(!user.is_literate())
-			. += "I have no idea what it says."
+			. += "I do not know how to read. Let us hope it says nothing of importance."
 		else
-			. += "It says \"[wrotesign]\"."
+			. += "It says here... \"[wrotesign]\"."
 
 /obj/structure/fluff/customsign/attackby(obj/item/W, mob/user, params)
 	if(!user.cmode)
 		if(!user.is_literate())
-			to_chat(user, span_warning("I don't know any verba."))
+			to_chat(user, span_warning("I do not know how to write."))
 			return
 		if((user.used_intent.blade_class == BCLASS_STAB) && (W.wlength == WLENGTH_SHORT))
 			if(wrotesign)
@@ -714,6 +714,9 @@
 				if(inputty && !wrotesign)
 					wrotesign = inputty
 					icon_state = "signwrote"
+		else
+			to_chat(user, span_warning("Alas, this will not work. I could carve words, if I stabbed at this with something posessing a short, sharp point. A knife comes to mind."))
+			return
 	..()
 
 /obj/structure/fluff/alch

--- a/code/modules/roguetown/roguejobs/gravedigger/gravemarker.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/gravemarker.dm
@@ -33,6 +33,35 @@
 	anchored = TRUE
 	layer = 2.91
 	obj_flags = UNIQUE_RENAME
+	var/wrotesign
+
+/obj/structure/gravemarker/examine(mob/user)
+	. = ..()
+	if(wrotesign)
+		if(!user.is_literate())
+			. += "I do not know how to read. Not like this one's name matters much anymore."
+		else
+			. += "A grave marker. It says... \"[wrotesign]\"."
+
+
+/obj/structure/gravemarker/attackby(obj/item/W, mob/user, params)
+	if(!user.cmode)
+		if(!user.is_literate())
+			to_chat(user, span_warning("I do not know how to write. It shall remain unmarked."))
+			return
+		if((user.used_intent.blade_class == BCLASS_STAB) && (W.wlength == WLENGTH_SHORT))
+			if(wrotesign)
+				to_chat(user, span_warning("Something is already carved here."))
+				return
+			else
+				var/inputty = stripped_input(user, "Someone rests here. Perhaps I should carve a name?", "", null, 200)
+				if(inputty && !wrotesign)
+					wrotesign = inputty
+					name = "[inputty]"
+		else
+			to_chat(user, span_warning("Alas, this will not work. I could carve words, if I stabbed at this with something posessing a short, sharp point. A knife comes to mind."))
+			return
+	..()
 
 /obj/structure/gravemarker/Destroy()
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
## About The Pull Request

grave markers can now be STABbed with a short blade to let you rename them, like custom signs

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![image](https://github.com/user-attachments/assets/55ec76be-ef22-4d51-b9e7-83aa251afc96)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Let's you keep track of who died, in case someone is missing someone! I always disliked how anonymous graves are...
also fluff and vibe of going "here lies: unnamed wanderer".
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
