### PR TITLE
!!PRETTY IMPORTANT FIX!! Makes your walkspeed update whenever your SPD changes

### DIFF
--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -231,6 +231,7 @@
 				newamt--
 				BUFSPE++
 			STASPD = newamt
+			update_move_intent_slowdown()
 
 		if("fortune")
 			newamt = STALUC + amt


### PR DESCRIPTION
## About The Pull Request

This makes it so you don't have to toggle RUN on and off to have your SPD stat impact your walkspeed

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/b1785e14-a865-46d3-8dfd-9667434a86cd
(you can see me actually slow down after snorting ozium, this isn't a thing on live)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Without this fix you will move at base speed on spawn, until your run once
when taking moondust you will keep your higher movespeed once it runs out until the point you run once, this is fixed here too
other cases like this as well

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
