### PR TITLE
Allows higher saturation for color customizer

### DIFF
--- a/code/_globalvars/customization/organ_customization.dm
+++ b/code/_globalvars/customization/organ_customization.dm
@@ -42,7 +42,7 @@ GLOBAL_LIST_INIT(customizers, build_customizers())
 		.[type] = new type()
 	return .
 
-/proc/color_pick_sanitized(mob/user, description, title, default_value, min_tag = 0.07, max_tag = 0.80)
+/proc/color_pick_sanitized(mob/user, description, title, default_value, min_tag = 0.07, max_tag = 1)
 	var/color = input(user, description, title, default_value) as color|null
 	var/good = TRUE
 	if(!color)
@@ -54,7 +54,7 @@ GLOBAL_LIST_INIT(customizers, build_customizers())
 		hsl[3] = min_tag
 		good = FALSE
 	if(hsl[2] > max_tag)
-		to_chat(user, span_warning("The picked color is too bright! Lowering Saturation to maximum 80%."))
+		to_chat(user, span_warning("The picked color is too bright! Lowering Saturation to maximum 100%."))
 		hsl[2] = max_tag
 		good = FALSE
 	if(!good)


### PR DESCRIPTION
## About The Pull Request

There was a PR that lowered max saturation to 80%. Which is too low. I set it back to 100% and left everything in-tact with the rest of the PR. Though under the previous the color below is essentially considered sparkledog with a saturation of 98.3 yet just looks like actual light blonde hair in game.

![image](https://github.com/user-attachments/assets/deacfc6c-e551-4400-87f0-839cf3d158ab)


![image](https://github.com/user-attachments/assets/c1d07513-7d89-439b-b1bb-553fa9ee7006)


## Testing Evidence

![image](https://github.com/user-attachments/assets/fe15d47d-9214-4f49-ae2c-b3998c012069)

## Why It's Good For The Game

Removes arbitrary limits to patterns of 16,777,216 color combinations.
