### PR TITLE
Werewolf genitals

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -150,6 +150,16 @@
 
 	invisibility = oldinv
 
+	if(getorganslot(ORGAN_SLOT_PENIS))
+		W.internal_organs_slot[ORGAN_SLOT_PENIS] = /obj/item/organ/penis/internal
+	if(getorganslot(ORGAN_SLOT_TESTICLES))
+		W.internal_organs_slot[ORGAN_SLOT_TESTICLES] = /obj/item/organ/testicles
+	if(getorganslot(ORGAN_SLOT_BREASTS))
+		W.internal_organs_slot[ORGAN_SLOT_BREASTS] = /obj/item/organ/breasts/internal
+	if(getorganslot(ORGAN_SLOT_VAGINA))
+		W.internal_organs_slot[ORGAN_SLOT_VAGINA] = /obj/item/organ/vagina/internal
+
+	W.client.prefs.sexable = client.prefs.sexable
 
 /mob/living/carbon/human/proc/werewolf_untransform(dead,gibbed)
 	if(!stored_mob)

--- a/code/modules/surgery/organs/feature_organs/genitals.dm
+++ b/code/modules/surgery/organs/feature_organs/genitals.dm
@@ -81,7 +81,7 @@
 	penis_type = PENIS_TYPE_TENTACLE
 	sheath_type = SHEATH_TYPE_NONE
 
-	
+
 /obj/item/organ/vagina
 	name = "vagina"
 	icon_state = "severedtail" //placeholder
@@ -132,5 +132,24 @@
 
 /obj/item/organ/testicles/internal
 	name = "internal testicles"
+	visible_organ = FALSE
+	accessory_type = /datum/sprite_accessory/none
+/obj/item/organ/testicles/internal
+	name = "internal testicles"
+	visible_organ = FALSE
+	accessory_type = /datum/sprite_accessory/none
+
+/obj/item/organ/penis/internal
+	name = "internal penis"
+	visible_organ = FALSE
+	accessory_type = /datum/sprite_accessory/none
+
+/obj/item/organ/vagina/internal
+	name = "internal vagina"
+	visible_organ = FALSE
+	accessory_type = /datum/sprite_accessory/none
+
+/obj/item/organ/breasts/internal
+	name = "internal breasts"
 	visible_organ = FALSE
 	accessory_type = /datum/sprite_accessory/none


### PR DESCRIPTION
## About The Pull Request

Changed: Werewolves now keep their genitals after the transformation.

Including Penis, Testicles, Vagina and Breasts.

They keep their ERP panel preference after the transformation as well.

## Testing Evidence

I Launched the local server. Tested proc/werewolf_transform() on male, then on female character. Both characters kept their original genitals after transforming.

## Why It's Good For The Game

People wanted it.

#UPD 1:

Collaborated with Kepteyn.

Planning to integrate their sprites and that BlackMoor PR.
