### PR TITLE
Intelligence Spellcaps Unlocked

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -4,7 +4,7 @@
 #define SPELL_SCALING_THRESHOLD 10 // The threshold at which the spell scaling starts to kick in
 #define SPELL_POSITIVE_SCALING_THRESHOLD 99 // The threshold at which spell scaling stop
 #define FATIGUE_REDUCTION_PER_INT 0.05 // The amount of fatigue reduction per point of intelligence above / below threshold
-#define COOLDOWN_REDUCTION_PER_INT 0.05 // The amount of cooldown reduction per point of intelligence above / below threshold
+#define COOLDOWN_REDUCTION_PER_INT 0.2 // The amount of cooldown reduction per point of intelligence above / below threshold
 #define CHARGE_REDUCTION_PER_SKILL 0.05 // The amount of charge reduction per skill level.
 #define FATIGUE_REDUCTION_PER_SKILL 0.05 // The amount of fatigue reduction per skill level.
 


### PR DESCRIPTION
Previously, intelligences' benefits when spellcasting were capped out at 15 int and its benefit towards spell cooldowns was marginal at best.

This raises the cap to 99 and increases the spell cooldown reduction to 20%. 

That's all it does, all I did was change a few defines.
