### PR TITLE
Honey, I Shrunk the Keep

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -168,15 +168,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
-"adV" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "adW" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -261,9 +252,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "aft" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/machinery/light/rogue/wallfire/candle/blue{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/water/bath,
+/area/rogue/under/town/basement/keep)
 "afv" = (
 /obj/structure/chair/wood/rogue/fancy,
 /obj/effect/landmark/start/guildmaster,
@@ -304,13 +298,11 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/woods)
 "agd" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
+/obj/structure/bars/passage/shutter/open{
+	redstone_id = "stewardshutter"
 	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "agh" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -526,14 +518,10 @@
 	},
 /area/rogue/indoors/town)
 "ajc" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/obj/structure/fluff/littlebanners{
-	pixel_y = -6
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/roguewindow,
+/obj/structure/fluff/statue/knightalt,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/dwarfin)
 "ajm" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -593,6 +581,7 @@
 	dir = 2;
 	icon_state = "longtable"
 	},
+/obj/item/paper/scroll,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "akG" = (
@@ -907,14 +896,31 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "aoJ" = (
-/obj/structure/chair/bench/ultimacouch/r,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/obj/structure/closet/crate/chest/neu,
+/obj/item/clothing/shoes/roguetown/boots/armor/iron,
+/obj/item/clothing/shoes/roguetown/boots/armor/iron,
+/obj/item/clothing/gloves/roguetown/angle,
+/obj/item/clothing/gloves/roguetown/angle,
+/obj/item/clothing/shoes/roguetown/boots/leather/atgervi,
+/obj/item/clothing/shoes/roguetown/boots/leather/atgervi,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "aoM" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
-	dir = 1
+/obj/effect/decal/cobbleedge{
+	dir = 5
 	},
-/area/rogue/indoors/town/manor)
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve{
+	pixel_x = -14;
+	pixel_y = -13
+	},
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve{
+	pixel_x = -21;
+	pixel_y = -18
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "aoO" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -1000,18 +1006,15 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/indoors)
 "aqz" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
-"aqA" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/structure/fermentation_keg/water,
+/obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"aqA" = (
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "aqC" = (
 /obj/structure/winch{
 	gid = "tertiarygate";
@@ -1175,14 +1178,14 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/beach)
 "atr" = (
-/obj/structure/closet/crate/drawer,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/natural/feather,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "atx" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mossback,
 /turf/open/water/ocean,
@@ -1695,10 +1698,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "aCu" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 1
-	},
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/wooddark/vertical,
+/area/rogue/outdoors/town/roofs)
 "aCJ" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/rogue/AzureSand,
@@ -1791,11 +1792,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
 "aEj" = (
-/obj/structure/fluff/statue/astrata/gold{
-	pixel_x = -18;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/church,
+/obj/structure/chair/bench/church/r,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/church/basement)
 "aEn" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -1816,12 +1814,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "aEu" = (
-/obj/effect/decal/cobbleedge{
-	dir = 7;
-	pixel_x = 13
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/vault)
 "aEz" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
@@ -2021,16 +2015,37 @@
 /turf/open/floor/rogue/concrete/bronze,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "aIi" = (
-/obj/structure/bed/rogue/inn/double{
-	dir = 4
+/obj/structure/closet/crate/chest,
+/obj/item/roguekey/manor,
+/obj/item/roguekey/walls,
+/obj/item/roguekey/crafterguild,
+/obj/item/roguekey/steward,
+/obj/item/roguekey/church,
+/obj/item/roguekey/dungeon,
+/obj/item/roguekey/graveyard,
+/obj/item/roguekey/garrison{
+	name = "garrison key"
 	},
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/effect/landmark/start/apothecary,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/item/roguekey/mercenary,
+/obj/item/roguekey/nightmaiden,
+/obj/item/roguekey/tavern,
+/obj/item/roguekey/physician,
+/obj/item/roguekey/knight,
+/obj/item/roguekey/armory,
+/obj/item/roguekey/tower,
+/obj/item/roguekey/sergeant,
+/obj/item/roguekey/sheriff,
+/obj/item/roguekey/royal,
+/obj/item/roguekey/lord,
+/obj/item/roguekey/merchant,
+/obj/item/roguekey/warden,
+/obj/item/roguekey/hand,
+/obj/item/storage/keyring,
+/obj/item/storage/keyring,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 1
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/town/roofs)
+/area/rogue/indoors/town/vault)
 "aIn" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grassyel,
@@ -2350,12 +2365,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "aOc" = (
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "aOg" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor5-old"
@@ -2376,13 +2388,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach)
 "aOM" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/item/roguestatue/gold/loot,
+/turf/open/floor/rogue/tile/masonic,
+/area/rogue/indoors/town/vault)
 "aOO" = (
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/alt/pink,
 /turf/open/floor/rogue/churchbrick,
@@ -2587,13 +2595,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
 "aRC" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "aRF" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -2619,13 +2627,17 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "aSm" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "aSu" = (
 /obj/structure/closet/crate/chest/wicker{
 	opened = 1
@@ -2685,9 +2697,9 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cave/skeletoncrypt)
 "aUk" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "aUl" = (
 /obj/effect/landmark/start/physician,
 /turf/open/floor/carpet/red,
@@ -2748,9 +2760,10 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/mazedungeon)
 "aVE" = (
-/obj/structure/rogue/trophy/deer,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/chair/bench/ultimacouch,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "aVL" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -3277,11 +3290,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "bdw" = (
-/obj/structure/chair/wood/rogue{
-	pixel_x = 1;
-	pixel_y = -6
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shield/tower/metal,
+/obj/item/rogueweapon/shield/buckler,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "bdx" = (
 /obj/item/natural/stone,
@@ -3306,9 +3318,19 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/magician)
 "bdV" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/town/roofs)
+/obj/item/candle/yellow/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/candle/yellow/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = 8;
+	pixel_y = 13
+	},
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "bdZ" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/mazedungeon)
@@ -3410,18 +3432,13 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/cave)
 "bgr" = (
-/obj/item/candle/skull/lit,
-/obj/item/candle/yellow/lit{
-	pixel_x = 11;
-	pixel_y = 1
-	},
-/obj/item/candle/yellow/lit{
-	pixel_x = -13;
-	pixel_y = 3
-	},
-/obj/machinery/light/rogue/wallfire/candle/floorcandle,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/obj/structure/closet/crate/roguecloset/crafted,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
+/obj/item/clothing/suit/roguetown/armor/silkcoat,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "bgG" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -3492,15 +3509,9 @@
 /turf/closed/wall/mineral/rogue/roofwall/middle,
 /area/rogue/indoors)
 "bhE" = (
-/obj/structure/lever/wall{
-	dir = 5;
-	redstone_id = "stewardshutter";
-	pixel_x = 16;
-	pixel_y = 1
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "bhJ" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cave)
@@ -3549,14 +3560,6 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/skeletoncrypt)
-"biX" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
-/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
-/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
-/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
 "bjm" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /obj/structure/bars/passage/steel{
@@ -3624,9 +3627,12 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/physician)
 "bko" = (
-/obj/structure/fluff/walldeco/steward,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 10
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "bkv" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -3650,12 +3656,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "blj" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "garrison"
+/turf/closed/wall/mineral/rogue/roofwall/middle{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/manor)
 "blp" = (
 /mob/living/carbon/human/species/dwarfskeleton/ambush,
 /turf/open/floor/rogue/concrete,
@@ -3887,18 +3891,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
 "bpF" = (
-/obj/structure/table/wood,
-/obj/item/clothing/mask/cigarette/rollie/nicotine{
-	pixel_x = 7;
-	pixel_y = 0
-	},
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/item/clothing/mask/cigarette/rollie/nicotine/cheroot{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/under/town/basement/keep)
+/obj/structure/table/church,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "bpK" = (
 /obj/structure/table/wood{
 	icon_state = "longtable";
@@ -3930,10 +3925,13 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "bqk" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
+/obj/structure/chair/wood/rogue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11
 	},
-/area/rogue/indoors/town/manor)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "bqp" = (
 /obj/structure/fluff/walldeco/chains{
 	icon_state = "chains3"
@@ -4073,16 +4071,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "bsx" = (
-/obj/structure/floordoor/gatehatch/inner{
-	redstone_id = "wallbridge"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/obj/structure/kybraxor{
-	pixel_x = -32;
-	pixel_y = -32;
-	redstone_id = "wallbridge"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/turf/open/water/bath,
+/area/rogue/under/town/basement/keep)
 "bsz" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -4092,15 +4085,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
-"bsC" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/obj/structure/fluff/littlebanners{
-	pixel_y = -6
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
 "bsE" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/wood,
@@ -4514,10 +4498,6 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
-"byI" = (
-/obj/effect/landmark/start/steward,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
 "byP" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/cobble,
@@ -5013,9 +4993,14 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
 "bHv" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "bHE" = (
 /mob/living/simple_animal/hostile/rogue/mirespider_lurker,
 /turf/open/floor/rogue/dirt,
@@ -5171,8 +5156,13 @@
 /turf/open/water/swamp,
 /area/rogue/indoors/cave)
 "bJB" = (
-/obj/structure/roguewindow/openclose/reinforced,
-/turf/open/floor/rogue/concrete,
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "longtable"
+	},
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "bJH" = (
 /obj/structure/table/wood,
@@ -5208,8 +5198,10 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "bKp" = (
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/town/roofs)
+/turf/closed/wall/mineral/rogue/stonebrick{
+	density = 0
+	},
+/area/rogue/under/town/basement/keep)
 "bKv" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -6032,17 +6024,12 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
 "bYk" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
 	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/garrison)
 "bYr" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt/road,
@@ -6614,13 +6601,14 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield/eora)
 "cke" = (
-/obj/item/tablecloth/silk{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/under/town/basement/keep)
+/obj/structure/closet/crate/roguecloset/crafted,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
+/obj/item/clothing/under/roguetown/skirt,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/manor)
 "ckm" = (
 /turf/open/water/ocean,
 /area/rogue/under/cavewet/bogcaves)
@@ -6937,10 +6925,10 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/cell)
 "cqj" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/turf/open/floor/carpet/inn,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "cqn" = (
 /turf/closed/wall/mineral/rogue/tent{
@@ -6995,19 +6983,14 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "crj" = (
-/obj/structure/flora/roguegrass/bush{
-	pixel_x = 5;
-	pixel_y = 0
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+	dir = 5
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "crl" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/beach)
@@ -7299,12 +7282,11 @@
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
 "cvU" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/water/bath,
-/area/rogue/under/town/basement/keep)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "cvV" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
@@ -7686,6 +7668,12 @@
 /obj/item/bedsheet/rogue/pelt,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"cCJ" = (
+/obj/structure/fluff/walldeco/steward{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "cCT" = (
 /obj/machinery/light/roguestreet,
 /turf/open/floor/rogue/dirt/road,
@@ -7714,19 +7702,8 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "cDw" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/obj/effect/decal/cobbleedge,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/pillory/reinforced{
-	lockid = list("garrison")
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/closed/wall/mineral/rogue/pipe,
+/area/rogue/indoors/town/manor)
 "cDB" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/under/cave/dukecourt)
@@ -7774,17 +7751,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "cEN" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/structure/chair/wood/rogue/chair3,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "cEP" = (
 /obj/structure/rack/rogue/shelf/big{
 	icon_state = "shelf_biggest";
@@ -8208,10 +8177,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "cLX" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/turf/open/floor/rogue/concrete,
+/obj/effect/landmark/start/apothecary,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/outdoors/town/roofs)
 "cMc" = (
 /obj/structure/stairs{
@@ -8335,13 +8302,9 @@
 	},
 /area/rogue/indoors/town)
 "cNi" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "cNn" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -8612,6 +8575,15 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
+"cRi" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "cRk" = (
 /obj/item/clothing/neck/roguetown/psicross/necra,
 /obj/structure/table/wood/fancy/black,
@@ -8736,14 +8708,16 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach)
 "cUj" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/effect/decal/cobbleedge{
+	dir = 6
 	},
-/turf/open/water/bath,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "cUk" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/blocks,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement/keep)
 "cUm" = (
 /obj/structure/fluff/walldeco/chains{
@@ -8814,14 +8788,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "cVo" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cobbleedge,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/vault)
 "cVp" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -8840,11 +8810,13 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "cVX" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -10
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "cWe" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/cobble,
@@ -8889,16 +8861,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach/forest)
-"cWR" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/structure/mirror,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
 "cWT" = (
 /obj/structure/fluff/walldeco/chains{
 	icon_state = "chains7"
@@ -9107,13 +9069,15 @@
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/manor)
 "dau" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "daw" = (
 /obj/structure/fluff/railing/border{
 	dir = 5;
@@ -9316,17 +9280,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "deO" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/obj/structure/flora/roguegrass,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "deQ" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/carpet,
@@ -9409,9 +9365,41 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "dgz" = (
-/obj/structure/stairs/stone/d,
-/turf/closed,
-/area/rogue/indoors/town/manor)
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/cloth{
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/obj/item/natural/cloth{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/natural/cloth{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/natural/cloth{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/natural/cloth{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/natural/cloth{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/soap/bath{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/soap/bath{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "dgC" = (
 /obj/structure/plasticflaps,
 /turf/open/floor/rogue/dirt,
@@ -9439,12 +9427,9 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/mountains/decap)
 "dha" = (
-/obj/machinery/light/rogue/firebowl/standing{
-	pixel_x = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/basement)
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "dhf" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/greenstone,
@@ -9540,13 +9525,16 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "djh" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/gold/lit{
+	pixel_y = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/under/town/basement/keep)
 "djl" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder,
 /turf/open/floor/rogue/dirt,
@@ -9597,8 +9585,12 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/shelter/mountains/decap)
 "dkt" = (
-/turf/open/floor/rogue/blocks/bluestone,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 7;
+	pixel_x = 13
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "dky" = (
 /obj/item/natural/rock/salt,
 /turf/open/floor/rogue/hexstone,
@@ -9996,12 +9988,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "drE" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/effect/decal/cobbleedge,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "drN" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/magician)
@@ -10321,14 +10315,9 @@
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "dyx" = (
-/obj/effect/decal/cobbleedge{
-	pixel_y = 1
-	},
-/obj/machinery/light/rogue/lanternpost{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town/roofs/keep)
 "dyA" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
@@ -10525,6 +10514,17 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"dBS" = (
+/obj/structure/closet/crate/chest,
+/obj/item/quiver,
+/obj/item/quiver,
+/obj/item/quiver,
+/obj/item/quiver/sling/iron,
+/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dBW" = (
 /obj/structure/chair/wood/rogue,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10643,16 +10643,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "dEP" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 32
 	},
-/obj/item/candle/silver/lit,
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 10;
-	pixel_y = -70
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/town/basement/keep)
+/obj/effect/particle_effect/smoke,
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "dEQ" = (
 /obj/structure/flora/roguegrass/bush,
 /obj/structure/fluff/railing/fence{
@@ -10691,13 +10688,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "dFk" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread"
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "dFp" = (
 /obj/structure/bars/pipe,
 /obj/structure/bars/pipe{
@@ -10920,11 +10916,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "dJv" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
+/area/rogue/outdoors/exposed/town/keep)
 "dJx" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -10956,8 +10949,17 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/underdark)
 "dKe" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/mannequin,
+/obj/item/clothing/suit/roguetown/armor/plate/half{
+	pixel_x = 0;
+	pixel_y = -4
+	},
+/obj/item/clothing/head/roguetown/helmet/sallet{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "dKf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -11108,13 +11110,6 @@
 	},
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/mountains/decap)
-"dMM" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/garrison)
 "dMS" = (
 /obj/structure/table/church,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -11182,9 +11177,12 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "dNO" = (
-/obj/structure/chair/bench/church/mid,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/basement)
+/obj/structure/chair/wood/rogue{
+	pixel_x = 1;
+	pixel_y = -6
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "dOd" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia,
 /turf/open/floor/rogue/naturalstone,
@@ -11500,13 +11498,19 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cavewet/bogcaves)
 "dTu" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = 32
+/obj/item/candle/yellow/lit{
+	pixel_x = -70;
+	pixel_y = 47
 	},
-/obj/effect/particle_effect/smoke/transparent,
-/obj/machinery/light/rogue/hearth,
+/obj/item/candle/yellow/lit{
+	pixel_x = -14;
+	pixel_y = 41
+	},
+/obj/structure/table/church{
+	icon_state = "churchtable_end"
+	},
 /turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/area/rogue/indoors/town/church/basement)
 "dTv" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
@@ -11540,11 +11544,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "dTQ" = (
-/obj/structure/fluff/littlebanners{
-	pixel_y = -6
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "dTS" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -11865,7 +11867,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/church/basement)
 "dZz" = (
-/turf/open/floor/rogue/concrete,
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_line"
+	},
 /area/rogue/indoors/town/manor)
 "dZC" = (
 /obj/structure/table/church,
@@ -11985,16 +11989,11 @@
 	},
 /area/rogue/indoors)
 "ebP" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/roguewindow/openclose{
+	dir = 8
 	},
-/obj/item/candle/gold/lit{
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/town/roofs)
 "ebQ" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -12152,12 +12151,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
 "eeK" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "steward";
-	name = "Clerk's Bedroom"
-	},
-/turf/open/floor/rogue/wood,
+/obj/structure/bed/rogue/inn/double,
+/obj/structure/fluff/wallclock/r,
+/obj/item/bedsheet/rogue/fabric_double,
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "eeL" = (
 /turf/open/floor/rogue/dirt,
@@ -12456,9 +12453,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "eja" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "ejb" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
@@ -12572,11 +12571,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "ekz" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/structure/chair/bench/church,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/basement)
 "ekF" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -12612,8 +12609,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/goblinfort)
 "els" = (
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/vault)
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/food/snacks/smallrat,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "elw" = (
 /obj/structure/table/wood{
 	icon_state = "longtable_mid"
@@ -12627,10 +12626,6 @@
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/forest)
-"elC" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/town/roofs)
 "elD" = (
 /obj/item/roguecoin/copper,
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
@@ -12647,9 +12642,18 @@
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/woods)
 "elZ" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+/obj/structure/closet/crate/roguecloset{
+	name = "Ropes and Chains"
+	},
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rogueweapon/whip,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "emg" = (
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/cobble,
@@ -12884,11 +12888,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "ept" = (
-/obj/structure/chair/wood/rogue{
-	pixel_x = 2;
-	pixel_y = -5
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4;
+	icon_state = "wooddir"
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "epy" = (
 /obj/structure/flora/roguetree,
@@ -13001,10 +13005,16 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
 "erO" = (
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
+/obj/structure/bed/rogue/inn/double{
+	dir = 4
 	},
-/area/rogue/indoors/town/vault)
+/obj/item/bedsheet/rogue/fabric_double,
+/obj/effect/landmark/start/apothecary,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/outdoors/town/roofs)
 "erP" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/mountains/decap)
@@ -13034,12 +13044,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "esm" = (
-/obj/structure/bars{
-	color = "#755f48";
-	name = "rusted bars"
+/obj/structure/mineral_door/wood/donjon{
+	locked = 1;
+	lockid = "garrison"
 	},
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "esn" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -13113,9 +13123,8 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "etH" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/closed,
+/area/rogue/under/cave)
 "etM" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/spider/stickyweb,
@@ -13436,14 +13445,9 @@
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/outdoors/exposed/bath/vault)
 "exS" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
-	},
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "exT" = (
 /obj/structure/rack/rogue/shelf,
@@ -13475,14 +13479,8 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/underdark)
 "eyl" = (
-/obj/structure/mineral_door/wood{
-	name = "Bath";
-	icon_state = "wcv";
-	locked = 1;
-	lockid = "manor"
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/blocks/bluestone,
+/area/rogue/outdoors/exposed/town/keep)
 "eyn" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -13555,11 +13553,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
 "ezM" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
+	dir = 1
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/indoors/town/manor)
 "ezQ" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -13943,11 +13940,15 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/forest)
 "eGS" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/town/roofs)
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "eHa" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
@@ -13972,19 +13973,14 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/shelter/woods)
 "eHY" = (
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = 9;
-	pixel_y = 10
-	},
-/obj/item/tablecloth/silk{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/under/town/basement/keep)
+/obj/structure/closet/crate/drawer,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/natural/feather,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/outdoors/town/roofs)
 "eIa" = (
 /obj/machinery/light/rogue/oven{
 	desc = "...?";
@@ -14106,10 +14102,6 @@
 /obj/structure/stairs/fancy/c,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"eKr" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/under/town/basement/keep)
 "eKx" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/wood,
@@ -14204,18 +14196,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/physician)
 "eMi" = (
-/obj/structure/closet/crate/roguecloset{
-	name = "Ropes and Chains"
-	},
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope,
-/obj/item/rope,
-/obj/item/rogueweapon/whip,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/carpet,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "eMl" = (
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/tile,
@@ -14478,19 +14461,14 @@
 /obj/machinery/light/rogue/oven/east,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
-"eRr" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+"eRG" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
-"eRG" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
 "eRS" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -14513,9 +14491,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "eSn" = (
-/obj/structure/fluff/statue/knight/r,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/exposed/town/keep)
 "eSo" = (
 /obj/structure/table/wood,
 /obj/structure/lever{
@@ -14595,6 +14573,11 @@
 "eTj" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/underdark)
+"eTw" = (
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 8
+	},
+/area/rogue/indoors/town/manor)
 "eTA" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -14799,10 +14782,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/goblindungeon)
 "eXA" = (
-/turf/closed/wall/mineral/rogue/stonebrick{
-	density = 0
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "eXE" = (
 /obj/structure/table/cooling,
 /obj/structure/bars{
@@ -14876,6 +14862,13 @@
 	dir = 4
 	},
 /area/rogue/indoors/shelter/woods)
+"eYZ" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "eZb" = (
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town)
@@ -15047,14 +15040,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
 "fbW" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/flail,
-/obj/item/rogueweapon/flail{
-	pixel_x = 0;
-	pixel_y = -5
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 32
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "fbZ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -15371,20 +15362,18 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/woods)
+"ffz" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/bfloorz,
+/area/rogue/under/town/basement/keep)
 "ffL" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/item/reagent_containers/glass/cup/golden{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/beer/stonebeardreserve{
-	pixel_x = 13;
-	pixel_y = 11
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/decostone/cand,
+/area/rogue/under/town/basement/keep)
 "ffN" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -15463,6 +15452,11 @@
 /obj/structure/roguewindow/stained/zizo,
 /turf/closed/wall/mineral/rogue/stone/red_moss,
 /area/rogue/indoors/shelter/mountains/decap)
+"fht" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "fhv" = (
 /obj/structure/fluff/wallclock,
 /obj/structure/closet/crate/drawer,
@@ -15532,13 +15526,8 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "fiP" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "steward";
-	name = "Stewardry Office"
-	},
-/turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/indoors/town/manor)
+/turf/closed,
+/area/rogue/indoors/town/physician)
 "fiU" = (
 /obj/structure/chair/bench/coucha{
 	can_buckle = 0
@@ -15622,10 +15611,12 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "fjY" = (
 /obj/effect/decal/cobbleedge{
-	dir = 7;
-	pixel_x = 13
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
-/turf/open/floor/rogue/cobblerock,
+/obj/machinery/light/rogue/firebowl/standing,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "fkc" = (
 /obj/structure/bars,
@@ -15893,11 +15884,19 @@
 	},
 /area/rogue/indoors)
 "foK" = (
-/obj/structure/stairs/stone/d{
+/obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/effect/decal/cobbleedge{
+	icon_state = "borderfall";
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "foN" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -16121,10 +16120,13 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
 "frA" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/effect/decal/carpet/square,
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/torchholder/c{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "frN" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16325,17 +16327,18 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "fvA" = (
-/obj/machinery/light/rogue/torchholder/c{
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
+"fvC" = (
+/obj/structure/fluff/statue/tdummy,
+/obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
-"fvC" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/vault)
+/area/rogue/indoors/town/manor)
 "fvE" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /obj/item/clothing/head/roguetown/articap,
@@ -16519,11 +16522,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblindungeon)
 "fyA" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/structure/fluff/wallclock/r,
-/obj/item/bedsheet/rogue/fabric_double,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/tile/tilerg,
+/area/rogue/outdoors/exposed/town/keep)
 "fyQ" = (
 /obj/item/bedsheet/rogue/double_pelt,
 /obj/structure/bed/rogue/inn/wooldouble,
@@ -16672,19 +16673,22 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/cave)
 "fBd" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
+	},
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "fBm" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/mazedungeon)
 "fBn" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = 32
-	},
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/rogue/church,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "fBq" = (
 /obj/structure/rack/rogue,
@@ -16700,6 +16704,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -16725,8 +16730,8 @@
 /area/rogue/indoors/town/magician)
 "fCk" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/garrison)
 "fCr" = (
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/blocks,
@@ -16906,12 +16911,14 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "fFz" = (
-/obj/structure/mannequin/male/female,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/concrete,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "fFF" = (
 /obj/structure/table/wood{
@@ -16987,12 +16994,19 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/underdark)
 "fHg" = (
-/obj/machinery/light/rogue/firebowl/standing{
-	pixel_x = -5;
-	pixel_y = 2
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/basement)
+/obj/effect/decal/cobbleedge,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/pillory/reinforced{
+	lockid = list("garrison")
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "fHh" = (
 /obj/structure/stairs{
 	dir = 8
@@ -17268,16 +17282,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "fLP" = (
-/obj/structure/closet/crate/chest,
-/obj/item/quiver,
-/obj/item/quiver,
-/obj/item/quiver,
-/obj/item/quiver/sling/iron,
-/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
+/obj/machinery/light/rogue/torchholder/c{
+	pixel_y = -32
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/under/town/basement/keep)
 "fLQ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17417,9 +17428,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "fNC" = (
-/obj/item/roguemachine/mastermail,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/obj/item/tablecloth/silk{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "fNH" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/dirt/road,
@@ -17532,20 +17547,15 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "fPZ" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	icon_state = "tablewood1"
 	},
-/obj/item/cooking/platter/silver,
-/obj/item/kitchen/fork/silver{
-	pixel_x = 12;
-	pixel_y = 6
+/obj/item/candle/silver/lit,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 10;
+	pixel_y = -70
 	},
-/obj/item/reagent_containers/glass/cup/silver{
-	pixel_x = -13;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/carpet,
+/area/rogue/under/town/basement/keep)
 "fQb" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -17656,9 +17666,9 @@
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
 "fRL" = (
-/obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/chair/bench/church/mid,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/basement)
 "fRM" = (
 /mob/living/simple_animal/pet/cat/rogue/black,
 /turf/open/floor/rogue/blocks,
@@ -17711,13 +17721,19 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "fSB" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 12
+/obj/structure/table/wood{
+	icon_state = "longtable"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/item/reagent_containers/glass/cup/golden{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/beer/stonebeardreserve{
+	pixel_x = 13;
+	pixel_y = 11
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "fSD" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17906,13 +17922,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "fVF" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/storage/belt/rogue/pouch,
-/obj/item/storage/belt/rogue/pouch,
-/turf/open/floor/rogue/blocks,
+/obj/machinery/light/rogue/wallfire/candle/blue{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile/bath,
 /area/rogue/under/town/basement/keep)
 "fVR" = (
 /obj/structure/closet/crate/drawer,
@@ -18401,17 +18414,14 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
 "gei" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/obj/structure/flora/roguegrass,
-/obj/effect/decal/cobbleedge{
+/obj/structure/mineral_door/wood/donjon{
 	dir = 1;
-	icon_state = "borderfall"
+	locked = 1;
+	lockid = "manor";
+	name = "Service Halls"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/manor)
 "gem" = (
 /obj/structure/mineral_door/bars{
 	lockid = "manor"
@@ -18591,11 +18601,22 @@
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
 "gij" = (
-/obj/structure/table/wood,
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/obj/structure/rack/rogue/shelf,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = -5;
+	pixel_y = 39
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 7;
+	pixel_y = 39
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "gik" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 1
@@ -18821,9 +18842,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
 "gmR" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks/bluestone,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
+/area/rogue/indoors/town/manor)
 "gmZ" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
@@ -19224,13 +19244,15 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "gtR" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "gtY" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/effect/decal/cleanable/blood,
@@ -19731,12 +19753,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "gAH" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-sread"
-	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
+/area/rogue/indoors/town/manor)
 "gAL" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/dirt,
@@ -19749,17 +19767,20 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/magician)
 "gAQ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
+/obj/structure/closet/crate/roguecloset{
+	name = "Chainmail"
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
-	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/item/clothing/gloves/roguetown/chain/iron,
+/obj/item/clothing/gloves/roguetown/chain/iron,
+/obj/item/clothing/neck/roguetown/chaincoif/iron,
+/obj/item/clothing/neck/roguetown/chaincoif/iron,
+/obj/item/clothing/under/roguetown/chainlegs/iron,
+/obj/item/clothing/under/roguetown/chainlegs/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "gAZ" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 1
@@ -19850,11 +19871,9 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "gDG" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = 32
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/town/roofs)
 "gDJ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -19961,11 +19980,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/sewer)
 "gFm" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/border{
+	dir = 9
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "gFt" = (
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/rogue/herringbone,
@@ -20450,11 +20469,21 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "gMS" = (
-/obj/effect/decal/cobbleedge{
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows{
+	pixel_x = -2;
 	pixel_y = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/item/quiver/arrows{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/quiver/arrows{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "gMT" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/roguemachine/mail{
@@ -21506,15 +21535,9 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement)
 "hfn" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "hft" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/beach)
@@ -21611,11 +21634,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
 "hhv" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/town/basement/keep)
+/obj/structure/flora/ausbushes,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "hhG" = (
 /obj/item/roguestatue/iron,
 /obj/structure/table/wood,
@@ -21819,11 +21840,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "hkj" = (
-/obj/structure/mineral_door/wood{
-	name = "Throne Room";
-	icon_state = "wcv";
-	locked = 1;
-	lockid = "manor"
+/obj/structure/bars/passage/shutter{
+	redstone_id = "warehouse_shutter"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
@@ -21948,17 +21966,16 @@
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "hmp" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
+/obj/machinery/light/rogue/torchholder/c{
+	pixel_y = -32
 	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hmt" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/concrete,
@@ -21970,13 +21987,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "hmx" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "manor";
-	name = "Chapel"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/town/basement/keep)
+/obj/structure/foxpelt,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "hmE" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -22057,13 +22070,14 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/dwarfin)
 "hof" = (
-/obj/structure/table/church,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/turf/closed/wall/mineral/rogue/roofwall/innercorner,
+/area/rogue/outdoors/town/roofs)
 "hog" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/exposed/town/keep)
 "hoo" = (
 /obj/structure/flora/rogueshroom{
 	pixel_y = -5
@@ -22122,8 +22136,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "hqc" = (
-/turf/open/floor/rogue/tile/tilerg,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "hqd" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -22364,8 +22381,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
 "hsS" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/fluff/canopy/booth/booth02,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "hsX" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -22430,21 +22448,18 @@
 "htK" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "htN" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "htV" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/clothing/shoes/roguetown/boots/armor/iron,
-/obj/item/clothing/shoes/roguetown/boots/armor/iron,
-/obj/item/clothing/gloves/roguetown/angle,
-/obj/item/clothing/gloves/roguetown/angle,
-/obj/item/clothing/shoes/roguetown/boots/leather/atgervi,
-/obj/item/clothing/shoes/roguetown/boots/leather/atgervi,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "htY" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -22613,11 +22628,13 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/fishmandungeon)
 "hvV" = (
-/obj/structure/stairs{
-	dir = 8
+/obj/structure/mineral_door/wood/donjon{
+	dir = 8;
+	locked = 1;
+	lockid = "steward"
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "hvW" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -23091,14 +23108,14 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
 "hDh" = (
-/obj/structure/stairs{
-	dir = 8
-	},
 /obj/structure/fluff/railing/border{
-	dir = 1
+	dir = 10
 	},
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "hDr" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -23247,6 +23264,7 @@
 	},
 /obj/item/armor_brush,
 /obj/item/polishing_cream,
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -23598,9 +23616,22 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"hMA" = (
+/turf/closed/wall/mineral/rogue/roofwall/middle{
+	dir = 8
+	},
+/area/rogue/outdoors/town/roofs)
 "hMB" = (
-/turf/open/lava/acid,
-/area/rogue/under/town/basement/keep)
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/walldeco/wantedposter,
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town)
 "hMD" = (
 /obj/item/natural/bone,
 /turf/open/floor/rogue/hexstone,
@@ -23715,10 +23746,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "hOT" = (
-/obj/structure/closet/crate/chest/neu_fancy,
-/obj/item/roguecoin/silver/pile,
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/vault)
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/town/roofs)
 "hOX" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -23752,11 +23784,8 @@
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "hPG" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/outdoors/town/roofs)
 "hPK" = (
 /obj/structure/chair/stool/rogue,
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -23775,12 +23804,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "hQj" = (
-/obj/structure/lever/wall{
-	pixel_x = 32;
-	redstone_id = "warehouse_shutter"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "hQq" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -23918,16 +23944,6 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet/bogcaves)
-"hSA" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "hSE" = (
 /obj/item/natural/bowstring,
 /turf/open/floor/rogue/concrete,
@@ -24006,13 +24022,12 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
 "hUf" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	pixel_x = 7;
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = 8;
 	pixel_y = 2
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/basement)
 "hUM" = (
 /mob/living/simple_animal/pet/cat/inn{
 	name = "Bintu"
@@ -24357,9 +24372,19 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "iaB" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/metal/barograte,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/undies/bikini,
+/obj/item/undies/bikini,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "iaL" = (
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
@@ -24424,11 +24449,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "ibZ" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ica" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
@@ -24510,9 +24537,15 @@
 	},
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ida" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
-	dir = 7
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
 	},
+/obj/item/candle/candlestick/silver/lit{
+	pixel_y = 14;
+	pixel_x = 0
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "idh" = (
 /obj/effect/decal/cobbleedge{
@@ -24747,17 +24780,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "igz" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/turf/closed/wall/mineral/rogue/roofwall/middle{
+	dir = 4
 	},
-/obj/structure/flora/roguegrass/bush/wall/tall,
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
-	},
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/indoors/town/manor)
 "igJ" = (
 /obj/structure/mineral_door/wood/window{
 	locked = 1;
@@ -24889,11 +24915,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "ijk" = (
-/obj/structure/table/wood{
-	icon_state = "map6"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/roofwall/outercorner,
+/area/rogue/indoors/town/manor)
 "ijo" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -25149,16 +25172,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"ine" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "ini" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/scarymaze)
@@ -25367,7 +25380,6 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains/decap)
 "iqA" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
 /obj/item/natural/feather{
 	pixel_x = 33;
 	pixel_y = -122
@@ -25659,8 +25671,13 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "ivq" = (
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/vault)
+/obj/structure/chair/wood/rogue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "ivC" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/herringbone,
@@ -25781,7 +25798,7 @@
 /obj/item/clothing/cloak/tabard/knight/guard,
 /obj/item/clothing/cloak/tabard/knight/guard,
 /obj/item/clothing/cloak/tabard/knight/guard,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -25932,6 +25949,7 @@
 	pixel_x = 4;
 	pixel_y = 2
 	},
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -26048,13 +26066,14 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "iCz" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/halberd,
+/obj/item/rogueweapon/halberd{
+	pixel_x = -13;
+	pixel_y = -19
 	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "iCA" = (
 /obj/machinery/light/small{
 	color = "#b51d12";
@@ -26080,13 +26099,13 @@
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/outdoors/rtfield)
 "iCY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/machinery/light/rogue/firebowl/standing,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "iCZ" = (
 /obj/structure/closet/crate/chest,
@@ -26224,8 +26243,14 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "iFA" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/hexstone,
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 16;
+	pixel_y = 32
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "iFF" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -26287,13 +26312,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "iGT" = (
-/obj/structure/table/wood{
-	icon_state = "map5"
-	},
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "iHa" = (
 /obj/machinery/light/rogue/smelter/great{
 	color = "#485775";
@@ -26354,6 +26375,10 @@
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
+"iHI" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/under/town/basement/keep)
 "iHM" = (
 /obj/structure/mineral_door/wood/violet{
 	locked = 1
@@ -26428,30 +26453,24 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/town)
 "iJi" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/gwstrap{
-	pixel_x = -12;
-	pixel_y = 13
-	},
-/obj/item/gwstrap{
-	pixel_x = -19;
-	pixel_y = 16
-	},
-/obj/item/gwstrap{
-	pixel_x = -15;
-	pixel_y = 16
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/bookcase/random/archive,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/town/roofs)
 "iJp" = (
-/obj/item/roguekey/vault,
-/obj/structure/closet/crate/roguecloset/lord{
-	lockid = "steward"
+/obj/item/candle/yellow/lit{
+	pixel_x = 4;
+	pixel_y = 5
 	},
-/obj/item/roguekey/armory,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/manor)
+/obj/item/candle/yellow/lit{
+	pixel_x = -4;
+	pixel_y = -8
+	},
+/obj/item/candle/yellow/lit{
+	pixel_x = -11;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "iJx" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
 /turf/open/floor/rogue/churchmarble,
@@ -26628,11 +26647,13 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "iLV" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "warehouse_shutter"
+/obj/structure/closet/crate/chest/neu_fancy,
+/obj/item/roguecoin/gold/pile,
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/area/rogue/indoors/town/vault)
 "iLW" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -26709,10 +26730,12 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/woods)
 "iMQ" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/closed/wall/mineral/rogue/decowood,
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "iMR" = (
 /obj/structure/table/wood{
@@ -27077,12 +27100,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
 "iSQ" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
+/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
+/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
+/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "iSR" = (
 /obj/structure/stairs{
@@ -27195,12 +27218,9 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/item/natural/feather{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/town/basement/keep)
+/obj/item/kitchen/spoon/tin,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "iVn" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -27795,14 +27815,23 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "jdv" = (
-/turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/flora/roguegrass/bush,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "jdx" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/beach)
 "jdB" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner,
-/area/rogue/outdoors/town/roofs)
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "jdF" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -27901,12 +27930,8 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/cave/dukecourt)
 "jfm" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 11
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/fluff/statue/knight/r,
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "jfu" = (
 /obj/structure/fluff/railing/border{
@@ -27929,16 +27954,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/orcdungeon)
-"jfF" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "jfI" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -28148,11 +28163,13 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "jiZ" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt{
+	pixel_x = 0;
+	pixel_y = 8
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/church/m,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "jja" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /obj/item/clothing/ring/silver,
@@ -28216,8 +28233,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "jkr" = (
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "jkC" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -28267,10 +28286,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
 "jlB" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "jlI" = (
 /obj/effect/spawner/roguemap/stump,
 /obj/structure/fluff/railing/fence{
@@ -28304,6 +28324,11 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"jmj" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "jmp" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/naturalstone,
@@ -28429,10 +28454,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
 "jph" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/handcart,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/roguemachine/vaultbank,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/vault)
 "jpn" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/carpet/lord/center/no_teleport,
@@ -28558,14 +28582,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
 "jrn" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/table/wood{
+	icon_state = "map6"
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "jrv" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -28639,9 +28660,10 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "jsG" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+/obj/structure/stairs/stone/d{
 	dir = 8
 	},
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "jsI" = (
 /obj/structure/table/wood{
@@ -28762,6 +28784,12 @@
 "juE" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/cave)
+"juI" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town/vault)
 "jvc" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/greenstone,
@@ -28896,12 +28924,9 @@
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "jxC" = (
-/obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/outdoors/town/roofs/keep)
 "jxK" = (
 /obj/structure/chair/wood/rogue/chair4,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -28918,7 +28943,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "jyb" = (
-/obj/structure/bars/steel,
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = "garrison"
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "jyo" = (
@@ -29034,17 +29063,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "jAe" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/obj/structure/closet/crate/chest/wicker,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/rooftop/green,
+/area/rogue/outdoors/town/roofs/keep)
 "jAo" = (
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/naturalstone,
@@ -29105,6 +29128,10 @@
 /mob/living/carbon/human/species/elf/dark/drowraider,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"jBH" = (
+/obj/structure/fluff/walldeco/steward,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "jCd" = (
 /obj/structure/vine,
 /turf/open/water/swamp/deep,
@@ -29140,6 +29167,10 @@
 /obj/item/natural/rock/salt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"jCA" = (
+/obj/item/roguemachine/mastermail,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "jCB" = (
 /obj/structure/hotspring/border/eight,
 /turf/open/floor/rogue/grass,
@@ -29319,10 +29350,27 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/under/cave/dukecourt)
+"jGc" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = 1
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "jGd" = (
 /obj/structure/fluff/pillow/magenta,
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
+"jGg" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
+	dir = 7
+	},
+/area/rogue/indoors/town/manor)
 "jGj" = (
 /obj/structure/fermentation_keg/hagwoodbitter,
 /turf/open/floor/rogue/blocks,
@@ -29542,9 +29590,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "jKf" = (
-/obj/structure/chair/bench/church,
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = -6;
+	pixel_y = 5
+	},
 /turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/basement)
+/area/rogue/indoors/town/manor)
 "jKh" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 4
@@ -29777,9 +29831,12 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "jOP" = (
-/obj/structure/fluff/statue/knight,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/basement)
 "jPe" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -29796,17 +29853,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "jPl" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
-/obj/item/quiver/sling/iron,
-/obj/item/quiver/sling/iron,
-/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
-/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "jPs" = (
 /obj/machinery/light/roguestreet{
 	dir = 1
@@ -29880,9 +29931,15 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "jQJ" = (
-/obj/effect/decal/carpet,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/obj/structure/mineral_door/wood/donjon{
+	dir = 8;
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "jQO" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/hexstone,
@@ -30305,14 +30362,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"jZa" = (
-/obj/structure/closet/crate/chest,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/flint,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/basement)
 "jZe" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
@@ -30396,11 +30445,17 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains/decap)
 "kac" = (
-/turf/closed/wall/mineral/rogue/pipe{
-	dir = 8;
-	icon_state = "iron_joint"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "kan" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -30501,14 +30556,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kbS" = (
-/obj/item/roguecoin/gold/pile,
-/obj/structure/fluff/walldeco/painting{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
-/area/rogue/indoors/town/vault)
+/turf/open/floor/rogue/church,
+/area/rogue/outdoors/exposed/town/keep)
 "kbV" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/herb/salvia,
@@ -30558,20 +30607,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors)
-"kcz" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
 "kcD" = (
 /obj/structure/fluff/walldeco/bigpainting/lake{
 	pixel_x = 0
@@ -30915,7 +30950,7 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kiz" = (
-/turf/closed/wall/mineral/rogue/decostone/cand,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement/keep)
 "kiD" = (
 /obj/structure/mineral_door/bars,
@@ -31324,16 +31359,16 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
 "kqG" = (
-/obj/item/roguegem/blue,
-/obj/item/roguegem/green,
-/obj/item/roguegem/yellow,
-/obj/item/roguegem/violet,
-/obj/item/roguegem/ruby,
-/obj/item/roguegem/ruby,
-/obj/structure/closet/crate/chest/neu_fancy,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/vault)
+/obj/item/candle/yellow/lit{
+	pixel_x = 19;
+	pixel_y = -1
+	},
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/basement)
 "kqL" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -31462,11 +31497,14 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/cell)
 "ktO" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 4
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "ktV" = (
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/outdoors/beach/forest)
@@ -31895,11 +31933,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
 "kAv" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/structure/mirror,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement/keep)
 "kAx" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
@@ -31914,8 +31956,9 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/shelter/mountains/decap)
 "kAF" = (
-/turf/closed,
-/area/rogue/indoors/town/physician)
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/town/roofs)
 "kAI" = (
 /obj/structure/rack/rogue/shelf,
 /obj/item/reagent_containers/glass/cup/wooden{
@@ -32593,16 +32636,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "kMx" = (
-/obj/structure/mannequin,
-/obj/item/clothing/suit/roguetown/armor/leather/studded{
-	pixel_x = 0;
-	pixel_y = -3
+/obj/machinery/light/rogue/torchholder/c{
+	pixel_y = -32
 	},
-/obj/item/clothing/head/roguetown/helmet/kettle{
-	pixel_x = 0;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "kMF" = (
 /obj/structure/ladder,
@@ -32898,13 +32935,9 @@
 	},
 /area/rogue/indoors/town/dwarfin)
 "kRO" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 8;
-	locked = 1;
-	lockid = "steward"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "kRY" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -33066,9 +33099,12 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
 "kUH" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/wallfire/candle/blue{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/manor)
 "kUI" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -33352,8 +33388,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains/decap)
 "laf" = (
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/carpet/inn,
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 4
+	},
 /area/rogue/indoors/town/manor)
 "lal" = (
 /obj/structure/flora/roguegrass/water/reeds,
@@ -33397,14 +33434,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
 "laF" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-n";
-	pixel_x = 2;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/outdoors/town/roofs)
 "laK" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/remains/human,
@@ -33512,9 +33543,9 @@
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
 "lcZ" = (
-/obj/structure/toilet,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "ldf" = (
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/dirt/road,
@@ -33916,8 +33947,15 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "lkJ" = (
-/turf/open/floor/rogue/church,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/table/wood{
+	icon_state = "map4"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/beer/voddena{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "lkT" = (
 /obj/structure/closet/crate/drawer,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -33949,36 +33987,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
-"lll" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
 "llp" = (
 /obj/structure/stairs{
 	dir = 8
@@ -34024,11 +34032,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "llF" = (
-/obj/item/roguecoin/gold/pile,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
+/obj/structure/closet/crate/chest/neu_fancy,
+/obj/item/roguecoin/silver/pile,
+/turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/vault)
 "llI" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -34095,36 +34101,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "lmP" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "steward"
+/obj/structure/stairs/stone{
+	dir = 4
 	},
-/obj/item/roguekey/manor,
-/obj/item/roguekey/walls,
-/obj/item/roguekey/crafterguild,
-/obj/item/roguekey/steward,
-/obj/item/roguekey/church,
-/obj/item/roguekey/dungeon,
-/obj/item/roguekey/graveyard,
-/obj/item/roguekey/garrison{
-	name = "garrison key"
-	},
-/obj/item/roguekey/mercenary,
-/obj/item/roguekey/nightmaiden,
-/obj/item/roguekey/tavern,
-/obj/item/roguekey/physician,
-/obj/item/roguekey/knight,
-/obj/item/roguekey/armory,
-/obj/item/roguekey/tower,
-/obj/item/roguekey/apartments/stable1,
-/obj/item/roguekey/apartments/stable2,
-/obj/item/roguekey/tailor,
-/obj/item/roguekey/shop,
-/obj/item/roguekey/archive,
-/obj/item/paper{
-	info = "Hand Key, Lord's Key, Knight Captain's Key, Marshall Key, Sergeant Key, Royal Key kept in Vault."
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "lmV" = (
 /obj/effect/decal/cobbleedge{
@@ -34152,15 +34132,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "lnu" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/manor)
+/area/rogue/indoors/town/garrison)
 "lnx" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -34257,8 +34233,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/skeletoncrypt)
 "loz" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/water/bath,
+/area/rogue/under/town/basement/keep)
 "loC" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -34423,6 +34402,18 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/underdark)
+"lqY" = (
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = "steward"
+	},
+/obj/structure/fluff/walldeco/alarm{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "lrc" = (
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/indoors/shelter)
@@ -35003,12 +34994,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/shop)
 "lAt" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5
+/obj/structure/fluff/railing/border{
+	dir = 9
 	},
-/obj/structure/fluff/canopy/booth/booth02,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/structure/fermentation_keg/water,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lAw" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/ocean/deep,
@@ -35020,10 +35013,15 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
 "lAF" = (
-/obj/structure/chair/bench/couchablack,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/under/town/basement/keep)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "lAO" = (
 /obj/structure/roguemachine/bounty,
 /turf/open/floor/rogue/concrete,
@@ -35182,8 +35180,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
 "lDn" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/under/town/basement/keep)
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "lDp" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/head/roguetown/helmet,
@@ -35332,10 +35333,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "lGl" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 8
+	},
+/area/rogue/outdoors/town/roofs)
 "lGp" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -35656,11 +35657,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "lLV" = (
-/obj/structure/bars/passage/shutter/open{
-	redstone_id = "stewardshutter"
+/obj/structure/fluff/railing/border{
+	dir = 9
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town/roofs)
 "lLY" = (
 /obj/structure/table/vtable/v2,
 /obj/item/candle/skull,
@@ -35854,9 +35855,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter)
 "lPk" = (
-/obj/structure/flora/ausbushes,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "lPm" = (
 /obj/structure/stairs{
 	dir = 1
@@ -35999,20 +36000,14 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
 "lSh" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/stoneaxe/woodcut/steel,
-/obj/item/rogueweapon/stoneaxe/woodcut/steel{
-	pixel_x = -1;
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "lSo" = (
-/obj/structure/floordoor/gatehatch/inner{
-	redstone_id = "wallbridge"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/chair/bench/couchablack,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/under/town/basement/keep)
 "lSt" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -36020,21 +36015,6 @@
 /obj/machinery/light/rogue/wallfire/candle/off/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"lSR" = (
-/obj/structure/flora/roguegrass/bush/wall/tall{
-	pixel_x = -11;
-	pixel_y = 0
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
 "lTn" = (
 /obj/structure/bars/pipe{
 	dir = 4
@@ -36125,20 +36105,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "lVB" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5
+/obj/structure/stairs/stone/d{
+	dir = 8
 	},
-/obj/structure/rack/rogue,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve{
-	pixel_x = -14;
-	pixel_y = -13
-	},
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve{
-	pixel_x = -21;
-	pixel_y = -18
-	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/under/town/basement/keep)
 "lVE" = (
 /obj/structure/bars/cemetery,
@@ -36321,11 +36291,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/magician)
 "lZz" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/indoors/town/vault)
+/obj/structure/fluff/walldeco/stone,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/manor)
 "lZA" = (
 /obj/structure/meathook,
 /obj/effect/decal/cleanable/blood,
@@ -36445,10 +36413,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "mbG" = (
-/obj/structure/fluff/walldeco/steward{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/metal/barograte,
 /area/rogue/outdoors/exposed/town/keep)
 "mbI" = (
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
@@ -36476,14 +36442,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "mca" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/natural/bundle/stick,
-/obj/item/natural/bundle/stick,
-/turf/open/floor/rogue/church,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "mcl" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -36527,14 +36489,17 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet/bogcaves)
 "mcU" = (
-/obj/structure/mineral_door/wood/donjon{
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/cobbleedge{
 	dir = 1;
-	locked = 1;
-	lockid = "manor";
-	name = "Service Halls"
+	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "mcY" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -36841,15 +36806,9 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "mhx" = (
-/obj/structure/table/wood{
-	icon_state = "map3"
-	},
-/obj/item/candle/silver/lit{
-	pixel_x = -2;
-	pixel_y = 15
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/bluestone,
+/area/rogue/outdoors/exposed/town/keep)
 "mhy" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road,
@@ -36937,10 +36896,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "mjw" = (
-/obj/structure/chair/bench/ultimacouch,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/statue/astrata/gold{
+	pixel_x = -18;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "mjz" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -36984,11 +36945,11 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
 "mkj" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/structure/floordoor/gatehatch/outer{
+	redstone_id = "wallbridge"
 	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "mkn" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt/road,
@@ -37107,8 +37068,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/goblinfort)
 "mmb" = (
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/tile/masonic,
+/area/rogue/indoors/town/vault)
 "mmd" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -37232,10 +37193,10 @@
 /area/rogue/outdoors/beach)
 "mow" = (
 /obj/structure/fluff/railing/border{
-	dir = 6
+	dir = 5
 	},
 /obj/effect/decal/cobbleedge{
-	dir = 9
+	dir = 10
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
@@ -37343,20 +37304,10 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/skeletoncrypt)
 "mqT" = (
-/obj/structure/closet/crate/roguecloset{
-	name = "Chainmail"
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 4
 	},
-/obj/item/clothing/gloves/roguetown/chain/iron,
-/obj/item/clothing/gloves/roguetown/chain/iron,
-/obj/item/clothing/neck/roguetown/chaincoif/iron,
-/obj/item/clothing/neck/roguetown/chaincoif/iron,
-/obj/item/clothing/under/roguetown/chainlegs/iron,
-/obj/item/clothing/under/roguetown/chainlegs/iron,
-/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
-/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/area/rogue/outdoors/town/roofs)
 "mqV" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/manorguardsman,
@@ -37977,10 +37928,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/magician)
 "mCr" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "mCs" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt,
@@ -38014,12 +37964,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
 "mDc" = (
-/obj/structure/kybraxor{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town/roofs/keep)
 "mDm" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
@@ -38113,12 +38060,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
 "mFr" = (
-/obj/machinery/light/rogue/lanternpost,
-/obj/effect/decal/cobbleedge{
-	dir = 9
+/obj/structure/floordoor/gatehatch/inner{
+	redstone_id = "wallbridge"
 	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "mFt" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -38243,8 +38189,9 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "mHf" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/church,
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
+	dir = 4
+	},
 /area/rogue/indoors/town/manor)
 "mHg" = (
 /obj/structure/mineral_door/wood{
@@ -38349,14 +38296,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "mIU" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace,
-/obj/item/rogueweapon/mace{
-	pixel_x = 2;
-	pixel_y = -4
+/obj/item/roguekey/vault,
+/obj/structure/closet/crate/roguecloset/lord{
+	lockid = "steward"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/item/roguekey/armory,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/manor)
 "mJc" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/floor/rogue/dirt,
@@ -38733,9 +38680,15 @@
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "mON" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/lever/wall{
+	dir = 5;
+	redstone_id = "stewardshutter";
+	pixel_x = 16;
+	pixel_y = 1
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "mOX" = (
 /obj/structure/table/church,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -38792,9 +38745,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
 "mPH" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "mPL" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood,
@@ -39037,6 +38990,12 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
+"mUN" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	dir = 8;
+	icon_state = "iron_joint"
+	},
+/area/rogue/indoors/town/manor)
 "mUP" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -39158,18 +39117,6 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"mWX" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "mWY" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -39264,10 +39211,13 @@
 	},
 /area/rogue/indoors/town/manor)
 "mXZ" = (
-/turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_line"
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	pixel_x = 7;
+	pixel_y = 2
 	},
-/area/rogue/indoors/town/manor)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "mYm" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -39381,23 +39331,22 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "nan" = (
-/obj/machinery/light/rogue/lanternpost{
+/obj/structure/closet/crate/chest/neu_fancy,
+/obj/item/roguecoin/silver/pile,
+/turf/open/floor/rogue/tile/masonic{
 	dir = 1
 	},
-/obj/structure/fluff/littlebanners{
-	pixel_y = -6
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/vault)
 "nar" = (
 /turf/open/water/swamp/deep,
 /area/rogue/indoors/cave)
 "nat" = (
-/obj/structure/stairs/stone{
-	dir = 8
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-n"
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "nay" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -39543,6 +39492,13 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
+"ncQ" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 32
+	},
+/obj/effect/particle_effect/smoke,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "ncY" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -39551,6 +39507,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"ncZ" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "ndb" = (
 /obj/structure/bars/passage/shutter{
 	max_integrity = 15000;
@@ -39966,17 +39928,14 @@
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "njb" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = 8
-	},
-/obj/item/kitchen/spoon/gold{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/inn,
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/bundle/stick,
+/obj/item/natural/bundle/stick,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "njj" = (
 /obj/structure/table/wood{
@@ -40221,12 +40180,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "nnb" = (
-/obj/machinery/light/rogue/firebowl/standing{
-	pixel_x = 8;
-	pixel_y = 2
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/basement)
+/area/rogue/indoors/town/manor)
 "nni" = (
 /obj/effect/decal/mossy{
 	dir = 8
@@ -40269,12 +40229,12 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
 "nnL" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4;
-	icon_state = "wooddir"
+/obj/structure/fluff/railing/border,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/area/rogue/indoors/town/garrison)
 "nnM" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -40679,12 +40639,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "nvU" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = 32
+/obj/structure/bars{
+	color = "#755f48";
+	name = "rusted bars"
 	},
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/basement/keep)
 "nwa" = (
 /obj/effect/landmark/start/wapprentice,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -41534,19 +41494,15 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "nKF" = (
-/obj/structure/rack/rogue,
-/obj/item/quiver/arrows{
-	pixel_x = -2;
-	pixel_y = 1
-	},
-/obj/item/quiver/arrows{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/quiver/arrows{
-	pixel_x = 6;
-	pixel_y = -4
-	},
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/leather/studded,
+/obj/item/clothing/suit/roguetown/armor/leather/studded,
+/obj/item/clothing/suit/roguetown/armor/leather/studded/bikini,
+/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced,
+/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced,
+/obj/item/clothing/wrists/roguetown/bracers/leather,
+/obj/item/clothing/wrists/roguetown/bracers/leather,
+/obj/item/clothing/wrists/roguetown/bracers/leather,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "nKL" = (
@@ -41760,9 +41716,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "nOC" = (
-/obj/structure/fluff/clock,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/wooddark/vertical,
+/area/rogue/indoors/town/garrison)
 "nOD" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grassyel,
@@ -42110,12 +42065,11 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "nTv" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/wood,
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/manor)
 "nTw" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -42444,9 +42398,21 @@
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/town/roofs/keep)
 "nZB" = (
-/obj/effect/landmark/start/apothecary,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/rack/rogue/shelf,
+/obj/item/gwstrap{
+	pixel_x = -12;
+	pixel_y = 13
+	},
+/obj/item/gwstrap{
+	pixel_x = -19;
+	pixel_y = 16
+	},
+/obj/item/gwstrap{
+	pixel_x = -15;
+	pixel_y = 16
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "nZD" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
@@ -42460,18 +42426,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
 "nZP" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword,
-/obj/item/rogueweapon/sword{
-	pixel_x = -3;
-	pixel_y = 1
+/obj/effect/decal/cobbleedge{
+	dir = 7;
+	pixel_x = 13
 	},
-/obj/item/rogueweapon/sword{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "nZS" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -42610,11 +42570,12 @@
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town)
 "ocm" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/lanternpost,
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "oco" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/blocks,
@@ -42703,8 +42664,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "oee" = (
-/turf/closed/wall/mineral/rogue/pipe,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "oef" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/fabric,
@@ -42954,12 +42919,9 @@
 /turf/open/floor/rogue/carpet/lord/center/no_teleport,
 /area/rogue/under/cave/licharena)
 "oic" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/lanternpost{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/chair/bench/ultimacouch/r,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "oih" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/carpet,
@@ -43061,11 +43023,11 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/cave/orcdungeon)
 "ojQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/manor)
 "okc" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/rogue/dirt/road,
@@ -43335,8 +43297,14 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cavewet/bogcaves)
 "orR" = (
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/town/roofs)
+/obj/item/roguecoin/gold/pile,
+/obj/structure/fluff/walldeco/painting{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
+	},
+/area/rogue/indoors/town/vault)
 "orS" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -43723,9 +43691,18 @@
 /turf/open/water/swamp,
 /area/rogue/under/cave/goblindungeon)
 "oyV" = (
-/obj/item/roguestatue/gold/loot,
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/vault)
+/obj/item/candle/skull/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = 11;
+	pixel_y = 1
+	},
+/obj/item/candle/yellow/lit{
+	pixel_x = -13;
+	pixel_y = 3
+	},
+/obj/machinery/light/rogue/wallfire/candle/floorcandle,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "oyW" = (
 /mob/living/carbon/human/species/dwarfskeleton/ambush,
 /turf/open/floor/rogue/hexstone,
@@ -43867,10 +43844,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "oBL" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/tile/bath,
+/turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/town/basement/keep)
 "oBN" = (
 /obj/structure/floordoor/open{
@@ -43979,20 +43953,8 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "oDj" = (
-/obj/item/candle/yellow/lit{
-	pixel_x = 4;
-	pixel_y = 5
-	},
-/obj/item/candle/yellow/lit{
-	pixel_x = -4;
-	pixel_y = -8
-	},
-/obj/item/candle/yellow/lit{
-	pixel_x = -11;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/garrison)
 "oDn" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -44194,7 +44156,7 @@
 "oHt" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
-	lockid = "heir";
+	lockid = "royal";
 	name = "Heir's Apartment"
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -44336,11 +44298,8 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "oJT" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/town/roofs)
+/turf/open/lava/acid,
+/area/rogue/under/town/basement/keep)
 "oJW" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
@@ -44620,14 +44579,10 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "oPf" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/manor)
 "oPj" = (
 /obj/structure/spider/stickyweb/mirespider,
 /turf/open/floor/rogue/naturalstone,
@@ -44776,12 +44731,9 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "oRZ" = (
-/obj/item/paper/scroll{
-	pixel_x = 63;
-	pixel_y = -123
-	},
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/indoors/town/manor)
+/obj/structure/roguemachine/stockpile,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "oSd" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
@@ -44835,14 +44787,17 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/mountains/decap)
 "oSS" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 9
 	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "oSW" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -44883,6 +44838,13 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"oTN" = (
+/obj/machinery/light/rogue/firebowl/standing/blue{
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "oTQ" = (
 /obj/item/reagent_containers/food/snacks/rogue/crackerscooked{
 	pixel_x = 6;
@@ -44953,15 +44915,13 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
 "oVj" = (
-/obj/structure/stairs{
-	dir = 4
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cobbleedge,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/walldeco/wantedposter,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "oVl" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -45016,8 +44976,12 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "oWi" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "oWr" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/wood,
@@ -45050,11 +45014,11 @@
 	},
 /area/rogue/under/cave/dukecourt)
 "oWO" = (
-/obj/structure/stairs{
-	dir = 8
+/turf/open/floor/rogue/rooftop{
+	icon_state = "roof";
+	dir = 1
 	},
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/area/rogue/outdoors/town/roofs/keep)
 "oXa" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -45162,10 +45126,14 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
 "oYo" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/food/snacks/smallrat,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace,
+/obj/item/rogueweapon/mace{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "oYq" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/fluff/railing/border,
@@ -45437,8 +45405,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "pda" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/mannequin/male/female,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "pdb" = (
 /obj/structure/bars/pipe{
@@ -45519,14 +45491,11 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
 "pel" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/halberd,
-/obj/item/rogueweapon/halberd{
-	pixel_x = -13;
-	pixel_y = -19
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/manor)
 "pem" = (
 /obj/structure/flora/newbranch/leafless{
 	dir = 1
@@ -46171,8 +46140,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "pqR" = (
-/turf/closed/wall/mineral/rogue/wooddark/horizontal,
-/area/rogue/indoors/town/garrison)
+/obj/structure/roguemachine/steward,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
+"pqT" = (
+/obj/structure/bars/tough,
+/obj/structure/roguewindow/harem2{
+	density = 0
+	},
+/turf/open/floor/rogue/metal/barograte,
+/area/rogue/under/town/basement/keep)
 "prg" = (
 /mob/living/simple_animal/hostile/rogue/haunt,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -46195,14 +46172,12 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
 "prx" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "prC" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -46526,9 +46501,11 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
 "pxW" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/under/town/basement/keep)
+/obj/structure/roguemachine/scomm{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/outdoors/town/roofs)
 "pxX" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -46813,13 +46790,17 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "pBH" = (
-/obj/machinery/light/rogue/torchholder/c{
-	pixel_y = -32
+/obj/effect/decal/cobbleedge{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
 	},
-/area/rogue/under/town/basement/keep)
+/obj/structure/closet/crate/chest/wicker,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "pBL" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/blocks,
@@ -46850,12 +46831,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "pCd" = (
-/obj/structure/closet/crate/drawer,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/manor)
 "pCk" = (
 /obj/structure/stairs{
 	dir = 8
@@ -46997,8 +46977,17 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "pEB" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/closet/crate/chest/neu,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/quiver/sling/iron,
+/obj/item/quiver/sling/iron,
+/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
+/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "pEO" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/outdoors/mountains)
@@ -47009,13 +46998,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/town)
 "pFh" = (
-/obj/structure/closet/crate/roguecloset/crafted,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
-/obj/item/clothing/under/roguetown/skirt,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/carpet/red,
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 32
+	},
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "pFn" = (
 /obj/structure/roguewindow,
@@ -47183,11 +47170,8 @@
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/manor)
 "pIv" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/tower/metal,
-/obj/item/rogueweapon/shield/buckler,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/exposed/town/keep)
 "pIB" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -47268,9 +47252,12 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
 "pJG" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "pJJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -47360,25 +47347,16 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "pKR" = (
-/obj/structure/roguemachine/noticeboard,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs/keep)
 "pKZ" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "pLb" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 1;
-	locked = 1;
-	lockid = "steward"
-	},
-/obj/structure/fluff/walldeco/alarm{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/hexstone,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "pLc" = (
 /obj/structure/bars/cemetery,
@@ -47455,9 +47433,15 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/goblinfort)
 "pMW" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/structure/lever/wall{
+	pixel_x = 32;
+	redstone_id = "warehouse_shutter"
+	},
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "pNg" = (
 /mob/living/carbon/human/species/dwarfskeleton/ambush,
 /obj/effect/decal/cobbleedge{
@@ -47775,10 +47759,15 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
 "pSy" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/area/rogue/outdoors/town/roofs)
+/obj/item/natural/feather{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/under/town/basement/keep)
 "pSM" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grassred,
@@ -47975,13 +47964,9 @@
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
 "pWB" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt{
-	pixel_x = 0;
-	pixel_y = 8
-	},
-/obj/structure/table/church/m,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/obj/structure/fluff/statue/knight,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "pWJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -48190,10 +48175,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
 "pZw" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/tile,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/town/basement/keep)
 "pZS" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -48222,9 +48204,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "qad" = (
-/obj/effect/particle_effect/smoke/transparent,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/obj/structure/toilet,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "qaf" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/orcdungeon)
@@ -48281,12 +48263,13 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
 "qbr" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5;
-	pixel_x = -6
+/obj/structure/table/wood{
+	icon_state = "map5"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "qbz" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/item/roguecoin/gold,
@@ -48417,41 +48400,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
 "qdH" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/natural/cloth{
-	pixel_x = -2;
-	pixel_y = 7
+/obj/structure/mineral_door/wood/donjon{
+	locked = 1;
+	lockid = "steward";
+	name = "Stewardry Office"
 	},
-/obj/item/natural/cloth{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/natural/cloth{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/natural/cloth{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/obj/item/natural/cloth{
-	pixel_x = 8;
-	pixel_y = 11
-	},
-/obj/item/natural/cloth{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/soap/bath{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/obj/item/soap/bath{
-	pixel_x = 4;
-	pixel_y = 10
-	},
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "qdI" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -48565,18 +48520,6 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"qfy" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/obj/item/candle/yellow/lit,
-/obj/item/candle/yellow/lit{
-	pixel_x = -6;
-	pixel_y = 12
-	},
-/obj/item/candle/yellow/lit{
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
 "qfA" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
@@ -48653,9 +48596,15 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/orcdungeon)
 "qgS" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "qha" = (
 /obj/effect/decal/mossy{
 	dir = 1
@@ -48751,6 +48700,7 @@
 	pixel_x = 11;
 	pixel_y = 8
 	},
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "qjc" = (
@@ -49472,19 +49422,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves)
 "qvp" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/roguegrass/bush{
-	pixel_x = 5;
-	pixel_y = 0
-	},
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/roguemachine/noticeboard,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "qvr" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road,
@@ -50155,14 +50096,9 @@
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/under/cave)
 "qHm" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/effect/landmark/start/steward,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "qHt" = (
 /obj/item/storage/bag/tray{
 	pixel_y = 32
@@ -50706,11 +50642,16 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/licharena)
 "qQj" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/town/basement/keep)
+/obj/item/roguegem/blue,
+/obj/item/roguegem/green,
+/obj/item/roguegem/yellow,
+/obj/item/roguegem/violet,
+/obj/item/roguegem/ruby,
+/obj/item/roguegem/ruby,
+/obj/structure/closet/crate/chest/neu_fancy,
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/tile/masonic,
+/area/rogue/indoors/town/vault)
 "qQm" = (
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
@@ -50858,11 +50799,17 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/shop)
 "qSC" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 8
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/item/candle/yellow/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = -6;
+	pixel_y = 12
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/manor)
+/obj/item/candle/yellow/lit{
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "qSD" = (
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/herringbone,
@@ -51104,19 +51051,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "qXJ" = (
-/obj/item/candle/yellow/lit{
-	pixel_x = -70;
-	pixel_y = 47
-	},
-/obj/item/candle/yellow/lit{
-	pixel_x = -14;
-	pixel_y = 41
-	},
-/obj/structure/table/church{
-	icon_state = "churchtable_end"
-	},
 /turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/area/rogue/indoors/town/manor)
 "qXR" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -51271,9 +51207,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "qZN" = (
-/obj/effect/landmark/start/clerk,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/tile/tilerg,
+/area/rogue/outdoors/exposed/town/keep)
 "raa" = (
 /obj/item/natural/worms/leech{
 	pixel_x = 5
@@ -51689,6 +51624,25 @@
 /obj/structure/flora/mushroomcluster,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"rgY" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = 8
+	},
+/obj/item/kitchen/spoon/gold{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
+"rhf" = (
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs/keep)
 "rhD" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/mineral_door/wood/donjon/stone/broken,
@@ -51781,35 +51735,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "rjK" = (
-/obj/structure/closet/crate/chest,
-/obj/item/roguekey/manor,
-/obj/item/roguekey/walls,
-/obj/item/roguekey/crafterguild,
-/obj/item/roguekey/steward,
-/obj/item/roguekey/church,
-/obj/item/roguekey/dungeon,
-/obj/item/roguekey/graveyard,
-/obj/item/roguekey/garrison{
-	name = "garrison key"
-	},
-/obj/item/roguekey/mercenary,
-/obj/item/roguekey/nightmaiden,
-/obj/item/roguekey/tavern,
-/obj/item/roguekey/physician,
-/obj/item/roguekey/knight,
-/obj/item/roguekey/armory,
-/obj/item/roguekey/tower,
-/obj/item/roguekey/sergeant,
-/obj/item/roguekey/sheriff,
-/obj/item/roguekey/royal,
-/obj/item/roguekey/lord,
-/obj/item/roguekey/merchant,
-/obj/item/roguekey/warden,
-/obj/item/roguekey/hand,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
-/area/rogue/indoors/town/vault)
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "rjO" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sickle/copper,
@@ -51846,9 +51774,18 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
 "rkS" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/rollie/nicotine{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/clothing/mask/cigarette/rollie/nicotine/cheroot{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "rkT" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -51869,10 +51806,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "rlj" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/wood,
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "rlk" = (
 /obj/machinery/light/rogue/wallfire/candle/off/r,
@@ -51896,6 +51835,12 @@
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
+"rlE" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "rlH" = (
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/churchmarble,
@@ -52041,9 +51986,17 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
 "rnI" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "rnN" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -52097,7 +52050,7 @@
 "rov" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
-	lockid = "heir";
+	lockid = "royal";
 	name = "Heir's Apartment"
 	},
 /turf/open/floor/rogue/wood/herringbone,
@@ -52237,6 +52190,12 @@
 "rqY" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/bath)
+"rrn" = (
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/fabric_double,
+/obj/effect/landmark/start/clerk,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/manor)
 "rrq" = (
 /mob/living/carbon/human/species/human/northern/searaider/ambush,
 /turf/open/floor/rogue/naturalstone,
@@ -52324,14 +52283,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/basement)
 "rtc" = (
-/obj/item/roguecoin/gold/pile,
-/obj/structure/fluff/walldeco/painting/queen{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
-/area/rogue/indoors/town/vault)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "rth" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/carpet/red,
@@ -52388,10 +52342,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
 "rtL" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "rtM" = (
 /turf/open/floor/rogue/grass,
@@ -52544,7 +52497,9 @@
 /area/rogue/under/cave/dukecourt)
 "rwM" = (
 /obj/structure/floordoor{
-	redstone_id = "thronegrille"
+	redstone_id = "thronegrille";
+	icon = 'icons/turf/roguefloor.dmi';
+	icon_state = "carpet_c"
 	},
 /obj/structure/chair/wood/rogue,
 /turf/open/transparent/openspace,
@@ -52981,15 +52936,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "rDO" = (
-/obj/structure/table/wood{
-	icon_state = "map4"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/beer/voddena{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "rEo" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -53114,9 +53063,8 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/beach)
 "rGx" = (
-/obj/structure/chair/wood/rogue{
-	pixel_x = 0;
-	pixel_y = -3
+/obj/structure/table/wood{
+	icon_state = "map2"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
@@ -53370,11 +53318,12 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
 "rLn" = (
-/obj/effect/decal/cobbleedge{
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/closet/crate/drawer,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "rLp" = (
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/dirt,
@@ -53437,10 +53386,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
 "rLU" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "rLW" = (
 /obj/structure/chair/stool/rogue,
@@ -53612,12 +53561,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "rPN" = (
-/obj/structure/mineral_door/wood/violet{
-	locked = 1;
-	lockid = "steward";
-	name = "Clerk Bedroom"
+/obj/structure/floordoor{
+	redstone_id = "thronegrille";
+	icon = 'icons/turf/roguefloor.dmi';
+	icon_state = "carpet_c"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "rPT" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
@@ -53746,16 +53695,21 @@
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "rSH" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
-	pixel_y = -32
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = 1
 	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/town)
 "rSJ" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 1
-	},
-/area/rogue/indoors/town/manor)
+/obj/structure/closet/crate/chest,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/item/flint,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/basement)
 "rSK" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/clothing/cloak/matron,
@@ -53874,8 +53828,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
 "rTT" = (
-/turf/closed/wall/mineral/rogue/pipe,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 5
+	},
+/obj/structure/fluff/canopy/booth/booth02,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "rTU" = (
 /obj/structure/table/wood{
 	icon_state = "largetable";
@@ -53885,12 +53843,13 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "rUb" = (
-/obj/structure/roguemachine/mail,
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rUd" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -54340,9 +54299,8 @@
 	},
 /area/rogue/indoors/town)
 "scw" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/roofwall/middle,
+/area/rogue/outdoors/town/roofs)
 "scE" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -54365,13 +54323,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
 "scT" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5;
-	pixel_x = -10
-	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/closed,
+/area/rogue/outdoors/town/roofs)
 "scU" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grassyel,
@@ -54494,18 +54447,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "sfH" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/shirt/tunic/white,
-/obj/item/clothing/suit/roguetown/shirt/tunic/white,
-/obj/item/clothing/suit/roguetown/shirt/tunic/white,
-/obj/item/clothing/suit/roguetown/shirt/tunic/white,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/undies/bikini,
-/obj/item/undies/bikini,
-/turf/open/floor/rogue/church,
+/obj/structure/roguemachine/mail,
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "sfM" = (
 /obj/structure/fluff/railing/border{
@@ -54590,12 +54536,8 @@
 	},
 /area/rogue/indoors/town/dwarfin)
 "shc" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5;
-	pixel_x = -6
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "shf" = (
 /obj/structure/stairs{
 	dir = 1
@@ -54685,12 +54627,13 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "siF" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/under/town/basement/keep)
 "siI" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = -32
@@ -54841,11 +54784,14 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
 "skw" = (
-/obj/structure/stairs/stone{
+/obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "skz" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -55020,17 +54966,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/sewer)
 "smR" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/roguegrass,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "smS" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/dirt,
@@ -55045,8 +54985,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "smZ" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/wood,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "sna" = (
 /obj/structure/roguewindow/openclose/reinforced{
@@ -55801,15 +55745,10 @@
 /area/rogue/indoors/town)
 "syb" = (
 /obj/structure/fluff/railing/border{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/light/rogue/torchholder/c{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "syc" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -55850,8 +55789,19 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "syz" = (
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "syA" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -55890,11 +55840,14 @@
 /turf/closed,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "szy" = (
-/obj/structure/stairs/stone{
-	dir = 4
+/obj/effect/decal/cobbleedge{
+	dir = 8
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "szF" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
@@ -56352,10 +56305,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "sKU" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/machinery/light/rogue/wallfire/candle/blue{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "sKW" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -56384,8 +56337,14 @@
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "sLa" = (
 /obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot{
+	pixel_x = 5;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot{
+	pixel_x = -4;
+	pixel_y = 13
+	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "sLe" = (
@@ -56561,15 +56520,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "sOa" = (
-/obj/structure/table/wood{
-	icon_state = "longtable_mid";
+/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "sOc" = (
 /obj/structure/bars{
@@ -56817,18 +56771,14 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "sRD" = (
-/obj/structure/stairs/stone{
-	dir = 4
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
 	},
-/turf/closed,
-/area/rogue/indoors/town/manor)
+/area/rogue/indoors/town/vault)
 "sRJ" = (
-/obj/machinery/light/rogue/firebowl/standing/blue{
-	pixel_x = 0;
-	pixel_y = 10
-	},
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "sRL" = (
 /mob/living/carbon/human/species/goblin/npc/ambush/sea,
 /turf/open/floor/rogue/dirt/road,
@@ -57116,8 +57066,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "sXr" = (
-/obj/structure/roguemachine/steward,
-/turf/open/floor/rogue/concrete,
+/obj/structure/stairs/stone{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "sXv" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -57154,11 +57106,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/woods)
 "sXL" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/flashlight/flare/torch/lantern,
-/obj/item/flashlight/flare/torch/lantern,
-/obj/item/flashlight/flare/torch/lantern,
-/turf/open/floor/rogue/concrete,
+/turf/closed/wall/mineral/rogue/roofwall/middle{
+	dir = 8
+	},
 /area/rogue/indoors/town/manor)
 "sXR" = (
 /obj/machinery/light/rogue/oven/south,
@@ -57260,11 +57210,26 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "sZH" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = -32
+/obj/structure/mineral_door/wood{
+	name = "Throne Room";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
 	},
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"sZI" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "sZK" = (
 /obj/item/kitchen/spoon,
 /obj/item/kitchen/rollingpin,
@@ -57326,9 +57291,14 @@
 /area/rogue/indoors/town/tavern)
 "taV" = (
 /obj/effect/decal/cobbleedge{
-	pixel_y = 1
+	dir = 7;
+	pixel_x = 13
 	},
-/turf/open/floor/rogue/cobblerock,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "tbg" = (
 /turf/closed/wall/mineral/rogue/wood,
@@ -57727,6 +57697,18 @@
 /obj/structure/mirror,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
+"thZ" = (
+/obj/structure/mannequin,
+/obj/item/clothing/suit/roguetown/armor/leather/studded{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/roguetown/helmet/kettle{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "tib" = (
 /obj/structure/fermentation_keg/beer,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -57853,9 +57835,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "tkB" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/roofwall/outercorner,
+/area/rogue/outdoors/town/roofs)
 "tkE" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
@@ -57908,16 +57889,18 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "tlQ" = (
-/obj/structure/mannequin,
-/obj/item/clothing/suit/roguetown/armor/plate/half{
-	pixel_x = 0;
-	pixel_y = -4
+/obj/item/candle/candlestick/silver/single/lit{
+	pixel_x = 9;
+	pixel_y = 10
 	},
-/obj/item/clothing/head/roguetown/helmet/sallet{
-	pixel_x = 0;
-	pixel_y = 8
+/obj/item/tablecloth/silk{
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/under/town/basement/keep)
 "tlS" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -58077,11 +58060,14 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/bog)
 "tod" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/structure/mineral_door/wood{
+	name = "Bath";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/town/roofs/keep)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "toh" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/flora/roguegrass/bush/wall,
@@ -58123,8 +58109,14 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "toG" = (
-/turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/indoors/town/garrison)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "toI" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/church,
@@ -58151,9 +58143,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "tpg" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "tpj" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/churchrough,
@@ -58212,9 +58206,39 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/woods)
 "tqO" = (
-/obj/structure/chair/bench/church/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/basement)
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "steward"
+	},
+/obj/item/roguekey/manor,
+/obj/item/roguekey/walls,
+/obj/item/roguekey/crafterguild,
+/obj/item/roguekey/steward,
+/obj/item/roguekey/church,
+/obj/item/roguekey/dungeon,
+/obj/item/roguekey/graveyard,
+/obj/item/roguekey/garrison{
+	name = "garrison key"
+	},
+/obj/item/roguekey/mercenary,
+/obj/item/roguekey/nightmaiden,
+/obj/item/roguekey/tavern,
+/obj/item/roguekey/physician,
+/obj/item/roguekey/knight,
+/obj/item/roguekey/armory,
+/obj/item/roguekey/tower,
+/obj/item/roguekey/apartments/stable1,
+/obj/item/roguekey/apartments/stable2,
+/obj/item/roguekey/tailor,
+/obj/item/roguekey/shop,
+/obj/item/roguekey/archive,
+/obj/item/paper{
+	info = "Hand Key, Lord's Key, Knight Captain's Key, Marshall Key, Sergeant Key, Royal Key kept in Vault."
+	},
+/obj/item/storage/keyring,
+/obj/item/storage/keyring,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "tqQ" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/blocks,
@@ -58952,9 +58976,9 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/woods)
 "tDn" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "tDu" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 4
@@ -59049,10 +59073,6 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
-"tEW" = (
-/obj/structure/foxpelt,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
 "tFd" = (
 /obj/structure/rack/rogue/shelf,
 /obj/item/natural/bundle/stick{
@@ -59436,10 +59456,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/underdark)
 "tMd" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "tMg" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/woodstaff,
@@ -59467,15 +59486,8 @@
 	},
 /area/rogue/indoors/town/garrison)
 "tMv" = (
-/obj/structure/table/wood{
-	icon_state = "map1"
-	},
-/obj/item/reagent_containers/glass/cup/silver{
-	pixel_x = 6;
-	pixel_y = 11
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/wooddark/horizontal,
+/area/rogue/indoors/town/garrison)
 "tMN" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -59916,8 +59928,14 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "tUx" = (
-/turf/closed,
-/area/rogue/outdoors/town/roofs)
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/exposed/town/keep)
 "tUy" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
@@ -60060,15 +60078,13 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "tWO" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "tWP" = (
 /obj/structure/flora/roguegrass,
 /obj/effect/decal/mossy{
@@ -60183,6 +60199,15 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
+"tYi" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/flail,
+/obj/item/rogueweapon/flail{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "tYj" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -60371,10 +60396,9 @@
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/outdoors/beach)
 "ubv" = (
-/obj/structure/roguewindow,
-/obj/structure/fluff/statue/knightalt,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/dwarfin)
+/obj/effect/landmark/start/clerk,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "ubH" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/grasscold,
@@ -61048,28 +61072,16 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/skeletoncrypt)
 "umt" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
-	pixel_y = -32
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/turf/open/floor/rogue/tile/bath,
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/under/town/basement/keep)
 "umv" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/obj/structure/rack/rogue/shelf,
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = -5;
-	pixel_y = 39
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 7;
-	pixel_y = 39
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/handcart,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "umA" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -61179,7 +61191,7 @@
 /area/rogue/indoors/town/church/basement)
 "uoI" = (
 /turf/open/floor/rogue/tile/masonic{
-	dir = 4
+	dir = 1
 	},
 /area/rogue/indoors/town/vault)
 "uoM" = (
@@ -61768,14 +61780,12 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "uxY" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/structure/chair/wood/rogue{
+	pixel_x = 2;
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "uxZ" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/mountains)
@@ -61946,10 +61956,12 @@
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
 "uAL" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/structure/stairs/stone/d{
+	dir = 1
+	},
+/obj/structure/stairs/stone/d,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "uBc" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
@@ -62237,10 +62249,14 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "uEw" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/stoneaxe/woodcut/steel,
+/obj/item/rogueweapon/stoneaxe/woodcut/steel{
+	pixel_x = -1;
+	pixel_y = -8
 	},
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "uEJ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt/road,
@@ -62678,22 +62694,12 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/mountains)
 "uMM" = (
-/obj/structure/flora/roguegrass/bush,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/roguewindow/openclose/reinforced,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "uMN" = (
-/obj/structure/stairs/stone/d{
-	dir = 1
-	},
-/obj/structure/stairs/stone/d,
-/turf/open/floor/rogue/tile,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement/keep)
 "uMO" = (
 /obj/structure/table/wood{
@@ -62733,25 +62739,14 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
 "uNj" = (
-/obj/structure/table/wood{
-	dir = 2;
-	icon_state = "longtable"
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "uNt" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/outdoors/beach)
-"uNz" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 15
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
 "uNE" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -62816,18 +62811,18 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave/orcdungeon)
 "uPI" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
+/obj/structure/mineral_door/wood/violet{
+	locked = 1;
+	lockid = "steward";
+	name = "Clerk Bedroom"
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "uPP" = (
-/obj/effect/decal/cobbleedge{
+/turf/open/floor/rogue/tile/masonic{
 	dir = 8
 	},
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/vault)
 "uPS" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -63224,13 +63219,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
 "uWd" = (
-/obj/machinery/light/rogue/torchholder/c{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "uWo" = (
 /obj/structure/chair/wood/rogue/throne,
 /turf/open/floor/rogue/blocks/platform,
@@ -63302,11 +63293,9 @@
 /turf/open/water/swamp,
 /area/rogue/under/town/sewer)
 "uWU" = (
-/obj/structure/fluff/littlebanners{
-	pixel_y = -6
-	},
-/turf/open/floor/rogue/rooftop/green,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "uXf" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/sword,
@@ -63494,9 +63483,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "uZN" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
-	},
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "uZQ" = (
 /obj/effect/decal/cobbleedge{
@@ -63597,19 +63585,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
 "vbt" = (
-/obj/item/candle/yellow/lit,
-/obj/item/candle/yellow/lit{
-	pixel_x = -6;
-	pixel_y = 8
+/obj/structure/stairs{
+	dir = 8
 	},
-/obj/item/candle/yellow/lit,
-/obj/item/candle/yellow/lit{
-	pixel_x = 8;
-	pixel_y = 13
-	},
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/garrison)
 "vbD" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -63689,15 +63669,9 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/orcdungeon)
 "vdf" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = 16;
-	pixel_y = 32
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "vdj" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/water/ocean,
@@ -63780,9 +63754,10 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "vfl" = (
-/obj/structure/fluff/canopy/booth/booth02,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
+	dir = 1
+	},
+/area/rogue/indoors/town/manor)
 "vfz" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -63959,13 +63934,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves)
 "viS" = (
-/obj/structure/closet/crate/roguecloset/crafted,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
-/obj/item/clothing/suit/roguetown/armor/silkcoat,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "viW" = (
 /obj/structure/lever/wall{
 	redstone_id = "trader_stock_shutter"
@@ -64202,10 +64175,11 @@
 	},
 /area/rogue/indoors/town)
 "vmI" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 4
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/manor)
+/area/rogue/indoors/town/garrison)
 "vmL" = (
 /obj/item/bedsheet/rogue/double_pelt,
 /obj/structure/bed/rogue/inn/wooldouble,
@@ -64242,9 +64216,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "vnq" = (
-/obj/structure/bookcase/random/archive,
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
 /turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/town/roofs)
+/area/rogue/indoors/town/manor)
 "vnx" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -64265,6 +64241,22 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
+"vnO" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 1
+	},
+/obj/item/cooking/platter/silver,
+/obj/item/kitchen/fork/silver{
+	pixel_x = 12;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = -13;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "vnS" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -64283,14 +64275,14 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/mazedungeon)
 "voe" = (
-/obj/structure/stairs{
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
 	dir = 1
 	},
-/turf/closed/wall/mineral/rogue/pipe{
-	dir = 4;
-	icon_state = "iron_line"
-	},
-/area/rogue/under/town/basement/keep)
+/obj/item/natural/feather,
+/obj/item/candle/yellow/lit,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "vow" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassyel,
@@ -64403,15 +64395,6 @@
 	},
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
-"vqB" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 9
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/manor)
 "vqD" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "nightmaiden"
@@ -64453,6 +64436,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
+"vrd" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "vrg" = (
 /obj/structure/table/church{
 	icon_state = "churchtable_mid_alt"
@@ -64576,6 +64569,7 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = -32
 	},
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "vti" = (
@@ -64588,6 +64582,19 @@
 "vto" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/mazedungeon)
+"vtw" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword,
+/obj/item/rogueweapon/sword{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/rogueweapon/sword{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "vtx" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/basement/keep)
@@ -64792,12 +64799,12 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "vwp" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/item/kitchen/spoon/tin,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/manor)
+/area/rogue/indoors/town/garrison)
 "vwA" = (
 /obj/structure/table/wood,
 /obj/item/clothing/neck/roguetown/psicross/malum,
@@ -64970,11 +64977,11 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/physician)
 "vAg" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/manor)
 "vAn" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -65088,12 +65095,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "vBu" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
-	},
-/turf/open/floor/rogue/hexstone,
+/obj/effect/particle_effect/smoke,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "vBB" = (
 /obj/structure/fluff/railing/fence,
@@ -65165,11 +65168,18 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "vCO" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/effect/landmark/start/clerk,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/manor)
+/obj/structure/bed/rogue/inn/double{
+	dir = 1
+	},
+/obj/item/bedsheet/rogue/fabric_double{
+	dir = 1
+	},
+/obj/effect/landmark/start/apothecary,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/outdoors/town/roofs)
 "vCP" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -65257,10 +65267,14 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
 "vDT" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
-	dir = 1
-	},
-/area/rogue/indoors/town/manor)
+/obj/structure/closet/crate/chest/neu,
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/storage/belt/rogue/pouch,
+/obj/item/storage/belt/rogue/pouch,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "vDV" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter)
@@ -65345,13 +65359,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
 "vFt" = (
-/obj/structure/flora/roguegrass,
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
+/obj/structure/chair/wood/rogue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 15
 	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "vFx" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/tile,
@@ -65374,10 +65388,12 @@
 	},
 /area/rogue/indoors/shelter)
 "vFY" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
-	dir = 4
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = -5;
+	pixel_y = 2
 	},
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/basement)
 "vGa" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
@@ -65464,12 +65480,17 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
 "vHy" = (
-/obj/structure/closet/crate/chest/neu_fancy,
-/obj/item/roguecoin/silver/pile,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = 1
 	},
-/area/rogue/indoors/town/vault)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "vHB" = (
 /obj/item/seeds/cabbage,
 /obj/item/seeds/cabbage,
@@ -65522,8 +65543,16 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cave/orcdungeon)
 "vIv" = (
-/turf/closed,
-/area/rogue/under/cave)
+/obj/structure/floordoor/gatehatch/inner{
+	redstone_id = "wallbridge"
+	},
+/obj/structure/kybraxor{
+	pixel_x = -32;
+	pixel_y = -32;
+	redstone_id = "wallbridge"
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "vIw" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -65554,13 +65583,11 @@
 /area/rogue/indoors/shelter/woods)
 "vII" = (
 /obj/structure/rack/rogue/shelf/biggest,
-/obj/item/fishingrod/crafted,
-/obj/item/bait/bloody,
-/obj/item/bait/bloody,
-/obj/item/bait/bloody,
-/obj/item/bait/bloody,
-/obj/item/bait/bloody,
-/obj/item/bait/bloody,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "vIP" = (
@@ -65583,10 +65610,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "vJa" = (
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
+/obj/structure/mineral_door/wood/fancywood{
+	name = "Sauna"
 	},
-/area/rogue/indoors/town/vault)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "vJj" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -66016,11 +66044,14 @@
 	},
 /area/rogue/indoors/town/physician)
 "vPR" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/water/bath,
-/area/rogue/under/town/basement/keep)
+/obj/item/candle/candlestick/silver/lit{
+	pixel_y = 9
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "vPZ" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 1;
@@ -66143,8 +66174,12 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "vTb" = (
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/garrison)
+/obj/structure/kybraxor{
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "vTc" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/tunic,
@@ -66188,14 +66223,13 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "vTJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	pixel_x = -8;
+	pixel_y = 8
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 5
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "vTN" = (
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/indoors/town/garrison)
@@ -66262,9 +66296,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "vUZ" = (
-/obj/structure/fluff/walldeco/stone,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town/manor)
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "manor";
+	name = "Chapel"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "vVa" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/dirt,
@@ -66518,12 +66556,11 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "vYL" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5;
-	pixel_x = -6
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "vYO" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -66591,9 +66628,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
 "vZI" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/rogue/trophy/deer,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "vZU" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -66606,16 +66643,9 @@
 	},
 /area/rogue/indoors/town/manor)
 "wag" = (
-/obj/effect/decal/cobbleedge{
-	dir = 7;
-	pixel_x = 13
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "wat" = (
 /obj/structure/fluff/railing/border{
 	dir = 5;
@@ -66802,6 +66832,7 @@
 	pixel_x = 54;
 	pixel_y = -85
 	},
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "wdB" = (
@@ -66937,6 +66968,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/marshal,
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -67090,12 +67122,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "whK" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+	dir = 8
 	},
+/obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "whR" = (
@@ -67128,12 +67158,11 @@
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "wij" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n"
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
 	},
-/obj/effect/decal/cobbleedge,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/outdoors/town/roofs/keep)
 "wik" = (
 /obj/structure/rack/rogue,
 /obj/item/flashlight/flare/torch/metal,
@@ -67315,17 +67344,19 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
 "wkv" = (
-/obj/structure/mineral_door/wood/fancywood{
-	name = "Sauna"
+/obj/structure/chair/wood/rogue{
+	pixel_x = 0;
+	pixel_y = -3
 	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "wkx" = (
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roof";
-	dir = 1
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
-/area/rogue/outdoors/town/roofs/keep)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "wkz" = (
 /obj/structure/bars{
 	color = "#755f48";
@@ -67624,13 +67655,6 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"wpb" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = 32
-	},
-/obj/effect/particle_effect/smoke/transparent,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
 "wpd" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield/eora)
@@ -67869,15 +67893,14 @@
 /area/rogue/indoors/town/garrison)
 "wtb" = (
 /obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
+	icon_state = "map1"
 	},
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 14;
-	pixel_x = 0
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = 6;
+	pixel_y = 11
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "wtd" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
@@ -68225,9 +68248,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter)
 "wzF" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/exposed/town/keep)
 "wzO" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -68284,18 +68309,35 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
 "wAx" = (
-/obj/structure/bed/rogue/inn/double{
-	dir = 1
+/obj/structure/closet/crate/chest/neu,
+/obj/item/natural/bundle/cloth{
+	amount = 8
 	},
-/obj/item/bedsheet/rogue/fabric_double{
-	dir = 1
+/obj/item/natural/bundle/cloth{
+	amount = 8
 	},
-/obj/effect/landmark/start/apothecary,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/item/natural/bundle/cloth{
+	amount = 8
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/town/roofs)
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "wAG" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 4
@@ -68510,10 +68552,7 @@
 	dir = 1
 	},
 /obj/structure/stairs/stone/d,
-/turf/closed/wall/mineral/rogue/pipe{
-	dir = 8;
-	icon_state = "iron_joint"
-	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement/keep)
 "wEQ" = (
 /obj/structure/fluff/railing/border{
@@ -68696,6 +68735,15 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
+"wHe" = (
+/obj/item/roguecoin/gold/pile,
+/obj/structure/fluff/walldeco/painting/queen{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
+	},
+/area/rogue/indoors/town/vault)
 "wHi" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/mountains/decap)
@@ -69199,9 +69247,11 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/shelter/mountains/decap)
 "wQL" = (
-/obj/structure/roguemachine/stockpile,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/tile/bfloorz,
+/area/rogue/under/town/basement/keep)
 "wQO" = (
 /obj/machinery/light/roguestreet/midlamp{
 	pixel_y = 10
@@ -69221,11 +69271,12 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/cave)
 "wQW" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
+/obj/item/roguecoin/gold/pile,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
 	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/area/rogue/indoors/town/vault)
 "wRe" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -69328,7 +69379,7 @@
 	dir = 8;
 	max_integrity = 3000
 	},
-/turf/closed/wall/mineral/rogue/craftstone,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "wSO" = (
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/pink,
@@ -69342,8 +69393,15 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "wTi" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
-/area/rogue/indoors/town/manor)
+/obj/structure/table/wood{
+	icon_state = "map3"
+	},
+/obj/item/candle/silver/lit{
+	pixel_x = -2;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "wTp" = (
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
 /obj/machinery/light/rogue/wallfire/candle/floorcandle{
@@ -69964,14 +70022,14 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/mountains)
 "xdz" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n";
+	pixel_x = 2;
+	pixel_y = 8
 	},
-/obj/item/natural/feather,
-/obj/item/candle/yellow/lit,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "xdA" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -70103,12 +70161,16 @@
 	},
 /area/rogue/indoors/town)
 "xfz" = (
-/obj/structure/bars/tough,
-/obj/structure/roguewindow/harem2{
-	density = 0
-	},
-/turf/open/floor/rogue/metal/barograte,
-/area/rogue/under/town/basement/keep)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/fishingrod/crafted,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "xfC" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -70239,11 +70301,19 @@
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/mountains/decap)
 "xhH" = (
-/obj/structure/floordoor/gatehatch/outer{
-	redstone_id = "wallbridge"
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag{
+	pixel_x = -7;
+	pixel_y = 5
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/item/storage/roguebag{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "xhL" = (
 /obj/item/roguecoin/silver/pile,
 /turf/open/floor/rogue/blocks,
@@ -71169,9 +71239,6 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/woods)
-"xzG" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner,
-/area/rogue/indoors/town/manor)
 "xzO" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = 16;
@@ -71291,8 +71358,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
 "xBq" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/stairs/stone{
+	dir = 8
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "xBE" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder/spear,
 /turf/open/floor/rogue/church,
@@ -71772,6 +71842,21 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
+"xJR" = (
+/obj/structure/flora/roguegrass/bush/wall/tall{
+	pixel_x = -11;
+	pixel_y = 0
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "xJW" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -72238,11 +72323,13 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
 "xSh" = (
-/obj/structure/table/wood{
-	icon_state = "map2"
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xSj" = (
 /obj/structure/chair/bench/couch,
 /obj/machinery/light/rogue/wallfire{
@@ -72388,11 +72475,10 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap)
 "xUY" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/clock,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "xVg" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
@@ -72491,11 +72577,9 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
 "xXA" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town/roofs)
 "xXC" = (
 /obj/effect/decal/wood/herringbone2{
 	dir = 6
@@ -72507,16 +72591,13 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "xXW" = (
-/obj/item/candle/yellow/lit{
-	pixel_x = 19;
-	pixel_y = -1
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "steward";
+	name = "Clerk's Bedroom"
 	},
-/obj/machinery/light/rogue/firebowl/standing{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/basement)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "xYj" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
@@ -72930,6 +73011,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"ydD" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/effect/decal/carpet/square,
+/turf/open/floor/rogue/tile/masonic/inverted,
+/area/rogue/indoors/town/manor)
 "ydT" = (
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /obj/structure/bed/rogue/shit,
@@ -72971,11 +73057,16 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/roofs)
 "yeu" = (
-/obj/structure/stairs/stone/d{
-	dir = 8
+/obj/structure/table/wood{
+	icon_state = "longtable_mid";
+	dir = 1
 	},
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "yew" = (
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
@@ -73037,13 +73128,17 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
 "yfn" = (
-/obj/structure/closet/crate/chest/neu_fancy,
-/obj/item/roguecoin/gold/pile,
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/area/rogue/indoors/town/vault)
+/obj/structure/flora/roguegrass/bush/wall/tall,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "yfs" = (
 /obj/structure/flora/roguegrass/herb/hypericum,
 /turf/open/floor/rogue/grassred,
@@ -73095,17 +73190,8 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave/skeletoncrypt)
 "ygd" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/leather/studded,
-/obj/item/clothing/suit/roguetown/armor/leather/studded,
-/obj/item/clothing/suit/roguetown/armor/leather/studded/bikini,
-/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced,
-/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced,
-/obj/item/clothing/wrists/roguetown/bracers/leather,
-/obj/item/clothing/wrists/roguetown/bracers/leather,
-/obj/item/clothing/wrists/roguetown/bracers/leather,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/roofwall/middle,
+/area/rogue/indoors/town/manor)
 "ygf" = (
 /obj/structure/hotspring,
 /turf/open/floor/rogue/grass,
@@ -73277,9 +73363,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "yju" = (
-/obj/structure/roguemachine/vaultbank,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/vault)
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "yjw" = (
 /mob/living/carbon/human/species/human/northern/searaider/ambush,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -73359,10 +73447,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "ykK" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
+/obj/structure/roguemachine/scomm{
+	pixel_y = -32
 	},
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "ykT" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/effect/decal/cobbleedge{
@@ -163121,11 +163210,11 @@ cxZ
 cxZ
 vtx
 bYC
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
 bYC
-hMB
+oJT
 bYC
 whB
 qlM
@@ -163573,11 +163662,11 @@ cxZ
 cxZ
 vtx
 vtx
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
 bYC
-hMB
+oJT
 bYC
 oPy
 wCC
@@ -164025,11 +164114,11 @@ leX
 bYC
 bYC
 bYC
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
 bYC
-hMB
+oJT
 bYC
 bZj
 wCC
@@ -164459,29 +164548,29 @@ xCK
 xCK
 skC
 bYC
-fRL
+bhE
 bHV
+yju
+mXZ
+tWO
+bHV
+pWB
+iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+iad
+ogs
 pZw
-hUf
-iSQ
-bHV
-jOP
-iad
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-iad
-ogs
-lDn
-lDn
-lDn
+pZw
+pZw
 bYC
-hMB
+oJT
 bYC
 loK
 qhq
@@ -164910,13 +164999,13 @@ vVx
 vVx
 vVx
 dlK
-voe
+jxg
 bHV
 bHV
-ept
-rDO
-tMv
-uNz
+uxY
+lkJ
+wtb
+vFt
 bHV
 iad
 ogs
@@ -164927,13 +165016,13 @@ ogs
 ogs
 ogs
 ogs
-lDn
-lDn
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
+pZw
+pZw
 bYC
-hMB
+oJT
 bYC
 uqC
 eWv
@@ -165363,13 +165452,13 @@ mMx
 ylh
 xAN
 iad
-lGl
+jmj
 bHV
-bdw
-iGT
-xSh
-jfm
-fvA
+dNO
+qbr
+rGx
+bqk
+kMx
 iad
 ogs
 ogs
@@ -165380,12 +165469,12 @@ ogs
 ogs
 ogs
 iBO
-lDn
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
+pZw
 bYC
-hMB
+oJT
 bYC
 cjR
 eWv
@@ -165815,12 +165904,12 @@ mMx
 ylh
 xAN
 iad
-aVE
+vZI
 bHV
-rGx
-ijk
-mhx
-fSB
+wkv
+jrn
+wTi
+ivq
 bHV
 iad
 ogs
@@ -165832,10 +165921,10 @@ ogs
 ogs
 ogs
 iBO
-lDn
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
+pZw
 bYC
 bYC
 bYC
@@ -166267,13 +166356,13 @@ mMx
 ylh
 xAN
 iad
-pCd
+rLn
 bHV
-fCk
-qHm
-aOM
+hQj
+ktO
+vTJ
 bHV
-eSn
+jfm
 iad
 ogs
 ogs
@@ -166283,12 +166372,12 @@ ogs
 ogs
 ogs
 ogs
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
 iad
 bYC
 vrC
@@ -166711,8 +166800,8 @@ ogs
 uvk
 skC
 ogs
-vIv
-vIv
+etH
+etH
 dlK
 ylh
 mMx
@@ -166735,12 +166824,12 @@ ogs
 ogs
 ogs
 ogs
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
 iad
 bYC
 gaB
@@ -167167,17 +167256,17 @@ iad
 iad
 iad
 iad
-xfz
+pqT
 iad
 iad
 iad
-iJi
+nZB
 wCC
 eWv
 tUV
 eWv
 tUV
-lll
+wAx
 iad
 ogs
 ogs
@@ -167187,12 +167276,12 @@ ogs
 ogs
 ogs
 ogs
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
 iad
 bYC
 dVC
@@ -167617,7 +167706,7 @@ skC
 ogs
 iad
 iqU
-dFk
+siF
 waK
 sAf
 iad
@@ -167625,11 +167714,11 @@ iad
 iad
 mOz
 wCC
-tlQ
+dKe
 wCC
 bhZ
 wCC
-nZP
+vtw
 iad
 ogs
 ogs
@@ -167639,12 +167728,12 @@ ogs
 ogs
 ogs
 ogs
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
 iad
 bYC
 mIO
@@ -168075,13 +168164,13 @@ mmB
 aoD
 tYZ
 iad
-eMi
+elZ
 wCC
-kMx
+thZ
 wCC
-pIv
+bdw
 wCC
-fbW
+tYi
 iad
 ogs
 ogs
@@ -168091,12 +168180,12 @@ ogs
 ogs
 ogs
 ogs
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
 iad
 bYC
 lDp
@@ -168520,20 +168609,20 @@ ogs
 ogs
 ogs
 iad
-lAF
+lSo
 waK
 waK
-sRJ
+oTN
 aoD
 nWc
 iad
 rDx
 wCC
-ygd
+nKF
 wCC
-lVB
+aoM
 wCC
-pel
+iCz
 iad
 ogs
 ogs
@@ -168543,12 +168632,12 @@ ogs
 ogs
 ogs
 ogs
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
 iad
 bYC
 qnQ
@@ -168979,13 +169068,13 @@ iCc
 hzA
 nWc
 iad
-mqT
+gAQ
 wCC
-biX
+iSQ
 wCC
-nKF
+gMS
 wCC
-mIU
+oYo
 iad
 ogs
 ogs
@@ -168995,12 +169084,12 @@ ogs
 ogs
 ogs
 ogs
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
 iad
 bYC
 jZC
@@ -169424,20 +169513,20 @@ ogs
 ogs
 ogs
 iad
-eHY
+tlQ
 bJM
 waK
 qwl
 jnt
 xCr
 iad
-htV
+aoJ
 isB
-jPl
+pEB
 isB
-fVF
+vDT
 isB
-lSh
+uEw
 iad
 ogs
 ogs
@@ -169447,12 +169536,12 @@ ogs
 ogs
 ogs
 ogs
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
 iad
 bYC
 aEr
@@ -169891,20 +169980,20 @@ iad
 iad
 iad
 iad
-lDn
+pZw
 tyL
 qrX
 qrX
 qrX
 qrX
-lZz
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
+juI
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
 iad
 bYC
 bYC
@@ -170326,37 +170415,37 @@ ogs
 ogs
 ogs
 iad
-mPH
-mmb
-mmb
-hhv
-mmb
-mmb
-mPH
+uWU
+kiz
+kiz
+hqc
+kiz
+kiz
+uWU
 eWv
 iXX
-cUk
+aqA
 eWv
 eWv
 eWv
-cUk
+aqA
 eWv
 eWv
 iad
 iad
 qrX
 qrX
-kbS
-hOT
+orR
+llF
 qrX
 qrX
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
 iad
 fAL
 opX
@@ -170777,38 +170866,38 @@ uvk
 ogs
 ogs
 ogs
-mmb
-qQj
-mmb
-mmb
-mmb
-mmb
-mmb
-mmb
+kiz
+cUk
+kiz
+kiz
+kiz
+kiz
+kiz
+kiz
 eWv
 nnq
-eXA
+bKp
 nnq
 nnq
-eXA
+bKp
 nnq
 nnq
 eWv
 eWv
 iad
 qrX
-fvC
-ivq
-erO
-kqG
+sRD
+mmb
+uPP
+qQj
 qrX
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
-lDn
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
+pZw
 iad
 xAN
 ylh
@@ -171230,9 +171319,9 @@ orc
 ogs
 ogs
 iad
-mmb
-mmb
-uMN
+kiz
+kiz
+uAL
 iad
 iad
 iad
@@ -171240,21 +171329,21 @@ iad
 eWv
 uWE
 aal
-dEP
+fPZ
 bqw
-iUW
+pSy
 rGK
 nnq
-kUH
+vdf
 eWv
-cUk
+aqA
 qrX
+cVo
 uoI
-vJa
-uoI
-rjK
+cVo
+aIi
 qrX
-lDn
+pZw
 aal
 aal
 iad
@@ -171682,31 +171771,31 @@ orc
 ogs
 ogs
 iad
-mmb
-mmb
-uMN
-iad
-iad
-iad
 kiz
+kiz
+uAL
+iad
+iad
+iad
+ffL
 eDO
 wqC
 aal
 qJZ
 toX
 qJZ
-pBH
+fLP
 nnq
 ijI
 ijI
 ijI
 iqX
-els
-els
-els
-yju
+aEu
+aEu
+aEu
+jph
 qrX
-lDn
+pZw
 iad
 iad
 iad
@@ -172134,8 +172223,8 @@ mdL
 ogs
 ogs
 iad
-mmb
-mmb
+kiz
+kiz
 wEL
 iad
 iad
@@ -172145,20 +172234,20 @@ eWv
 uWE
 aal
 fgq
-ebP
+djh
 fgq
 qYk
 nnq
-kUH
+vdf
 eWv
-tkB
+kRO
 qrX
-erO
-ivq
-erO
-oyV
+uPP
+mmb
+uPP
+aOM
 qrX
-oee
+oBL
 opX
 opX
 opX
@@ -172586,16 +172675,16 @@ orc
 ogs
 ogs
 iad
-qQj
-mmb
-mmb
-mmb
-mmb
-mmb
-mmb
+cUk
+kiz
+kiz
+kiz
+kiz
+kiz
+kiz
 eWv
 nnq
-eXA
+bKp
 nnq
 nnq
 nnq
@@ -172605,12 +172694,12 @@ eWv
 eWv
 iad
 qrX
-llF
-vJa
+wQW
 uoI
-yfn
+cVo
+iLV
 qrX
-esm
+nvU
 ylh
 urZ
 mMx
@@ -173038,31 +173127,31 @@ orc
 ogs
 ogs
 iad
-mPH
-mmb
+uWU
+kiz
 lOy
-scw
-mmb
-mmb
-mPH
+uMN
+kiz
+kiz
+uWU
 eWv
 iXX
-tkB
+kRO
 eWv
 eWv
 eWv
-tkB
+kRO
 eWv
 eWv
 iad
 iad
 qrX
 qrX
-rtc
-vHy
+wHe
+nan
 qrX
 qrX
-oee
+oBL
 opX
 opX
 opX
@@ -173494,7 +173583,7 @@ iad
 iad
 iad
 iad
-hmx
+vUZ
 iad
 iad
 iad
@@ -173514,7 +173603,7 @@ qrX
 qrX
 qrX
 qrX
-lDn
+pZw
 ogs
 ogs
 ogs
@@ -173944,12 +174033,12 @@ ogs
 idG
 iad
 iad
-xXW
+kqG
 nSG
 nSG
 nSG
 nSG
-fHg
+vFY
 nSG
 iad
 pnA
@@ -173958,7 +174047,7 @@ eWv
 eWv
 eWv
 eWv
-bHv
+aOc
 eWv
 iad
 dlK
@@ -174396,15 +174485,15 @@ ogs
 idG
 iad
 iad
-qfy
+qSC
 dWW
-hof
+bpF
 qBO
-jKf
+ekz
 qBO
-jKf
+ekz
 iad
-cWR
+kAv
 eWv
 eWv
 eWv
@@ -174848,22 +174937,22 @@ ogs
 ogs
 idG
 iad
-aEj
-bgr
-pWB
+mjw
+oyV
+jiZ
 qBO
-dNO
+fRL
 qBO
-dNO
+fRL
 iad
-aqz
+deO
 eWv
 fXM
-nnL
+ept
 fXM
-nnL
+ept
 fXM
-nnL
+ept
 iad
 dlK
 opX
@@ -175300,22 +175389,22 @@ ogs
 ogs
 ogs
 iad
-oDj
-vbt
-qXJ
+iJp
+bdV
+dTu
 qBO
-tqO
+aEj
 qBO
-tqO
+aEj
 iad
 eWv
 eWv
 dMk
-aqz
+deO
 dMk
-aqz
+deO
 dMk
-aqz
+deO
 iad
 ogs
 ogs
@@ -175752,22 +175841,22 @@ orc
 ogs
 ogs
 iad
-dha
+jOP
 nSG
 nSG
 nSG
 nSG
-nnb
-jZa
+hUf
+rSJ
 iad
 eWv
 eWv
 dMk
-lcZ
+qad
 dMk
-lcZ
+qad
 dMk
-lcZ
+qad
 iad
 ogs
 ogs
@@ -176658,13 +176747,13 @@ ogs
 ogs
 ogs
 iad
-qdH
+dgz
 dIX
-yeu
-yeu
-yeu
+lVB
+lVB
+lVB
 dIX
-oBL
+ykK
 iad
 ogs
 ogs
@@ -177110,13 +177199,13 @@ ogs
 ogs
 ogs
 iad
-eKr
-xUY
+tMd
+umt
 iBO
 iBO
 iBO
 pWX
-umt
+fVF
 iad
 ogs
 ogs
@@ -177562,13 +177651,13 @@ ogs
 ogs
 ogs
 iad
-bpF
-hDh
-oWO
-oWO
-oWO
+rkS
+ffz
+wQL
+wQL
+wQL
 iRq
-cke
+fNC
 iad
 ogs
 ogs
@@ -178014,13 +178103,13 @@ ogs
 ogs
 ogs
 iad
-cUj
+bsx
 hzA
 nWc
 nWc
 nWc
-vPR
-cUj
+loz
+bsx
 iad
 ogs
 ogs
@@ -178466,7 +178555,7 @@ xCK
 ogs
 ogs
 iad
-pxW
+iHI
 nWc
 nWc
 nWc
@@ -178919,11 +179008,11 @@ ogs
 ogs
 iad
 nWc
-cvU
+aft
 nWc
-cvU
+aft
 nWc
-cvU
+aft
 nWc
 iad
 ogs
@@ -260289,8 +260378,8 @@ sns
 vOG
 sns
 sns
-agd
-iCz
+eRG
+rSH
 wyE
 wyE
 fpx
@@ -260742,7 +260831,7 @@ phl
 eBq
 sns
 sns
-taV
+viS
 exD
 wyE
 qyR
@@ -261194,7 +261283,7 @@ phl
 sns
 sns
 sns
-taV
+viS
 exD
 exD
 oSE
@@ -261646,7 +261735,7 @@ uBc
 sns
 sns
 sns
-taV
+viS
 exD
 wRJ
 sGj
@@ -262098,9 +262187,9 @@ uBc
 sns
 sns
 sns
-taV
+viS
 exD
-vYL
+prx
 sGj
 eRd
 aiM
@@ -262550,9 +262639,9 @@ phl
 sns
 sns
 sns
-taV
+viS
 exD
-fjY
+nZP
 sGj
 mqz
 hoS
@@ -263002,7 +263091,7 @@ cDX
 eBq
 sns
 sns
-taV
+viS
 exD
 ehB
 dkS
@@ -263454,9 +263543,9 @@ veW
 sns
 sns
 sns
-taV
+viS
 exD
-vYL
+prx
 sGj
 por
 hoS
@@ -263906,8 +263995,8 @@ jCu
 sns
 sns
 sns
-exS
-siF
+dau
+wkx
 exD
 sGj
 qaK
@@ -264815,7 +264904,7 @@ sns
 sns
 vWX
 nXy
-bsC
+szy
 dQI
 sns
 sns
@@ -266175,7 +266264,7 @@ vOG
 sns
 sns
 xYz
-nan
+fBd
 sns
 sns
 sns
@@ -266633,8 +266722,8 @@ smL
 smL
 vgn
 qKs
-rnI
-pKR
+aUk
+qvp
 sns
 sns
 sns
@@ -267085,16 +267174,16 @@ awX
 ehv
 bUt
 ggT
-ojQ
+uNj
 rUQ
 sns
 sns
 sns
+bHv
+iCY
+aSm
+eGS
 mow
-jrn
-cEN
-jfF
-adV
 sns
 sns
 fpx
@@ -267544,9 +267633,9 @@ sns
 dWk
 eva
 cne
-oVj
+hMB
 cne
-cDw
+fHg
 sns
 sns
 exO
@@ -268894,7 +268983,7 @@ ehv
 bUt
 ate
 ntM
-vfl
+hsS
 sns
 sns
 sns
@@ -269346,7 +269435,7 @@ oCF
 bUt
 bwJ
 sns
-vfl
+hsS
 sns
 sns
 sns
@@ -269354,7 +269443,7 @@ tGR
 vmk
 bUt
 ylp
-whK
+drE
 sns
 sns
 saG
@@ -269797,8 +269886,8 @@ pcB
 ehv
 bUt
 ggT
-eRr
-lAt
+oee
+rTT
 sns
 sns
 sns
@@ -269810,7 +269899,7 @@ xZU
 sns
 sns
 pZZ
-ocm
+lDn
 llx
 arI
 arI
@@ -270258,11 +270347,11 @@ tGR
 bUt
 eNp
 xSH
-cVo
+oVj
 sns
 sns
 hpr
-uAL
+exS
 llx
 hcv
 mAr
@@ -270714,7 +270803,7 @@ xZU
 sns
 sns
 hpr
-mCr
+jkr
 llx
 rLJ
 cuJ
@@ -271162,11 +271251,11 @@ eva
 cne
 hYo
 cne
-cDw
+fHg
 sns
 sns
 hpr
-uAL
+exS
 llx
 arI
 arI
@@ -271610,10 +271699,10 @@ sns
 sns
 sns
 sns
-vTJ
-oPf
-bYk
-mWX
+crj
+skw
+oSS
+kac
 dHe
 sns
 sns
@@ -272057,7 +272146,7 @@ smL
 smL
 xvq
 qKs
-jph
+umv
 sns
 sns
 sns
@@ -272516,8 +272605,8 @@ sns
 sns
 sns
 sns
-hfn
-wag
+qgS
+taV
 sns
 sns
 sns
@@ -272963,12 +273052,12 @@ exD
 exD
 sns
 sns
-gAQ
-qbr
+jGc
+gtR
 wFK
 sns
-hSA
-gAH
+vrd
+dFk
 sns
 sns
 sns
@@ -273407,7 +273496,7 @@ qIJ
 rxp
 hgX
 gKR
-ubv
+ajc
 ryO
 qUB
 exD
@@ -273415,9 +273504,9 @@ exD
 exD
 aWT
 sns
-wij
+nat
 hLv
-scT
+cVX
 sns
 sns
 uvR
@@ -273867,9 +273956,9 @@ dnE
 hEh
 wRJ
 sns
-hmp
+vHy
 cBf
-aEu
+dkt
 sns
 sns
 sns
@@ -274782,7 +274871,7 @@ xAF
 xAF
 xAF
 exD
-siF
+wkx
 exD
 exD
 exD
@@ -275218,7 +275307,7 @@ exD
 exD
 pWT
 pWT
-lPk
+hhv
 rgV
 lAO
 sns
@@ -275233,9 +275322,9 @@ exD
 exD
 exD
 exD
-jAe
+pBH
 sns
-uPP
+whK
 exD
 exD
 exD
@@ -277494,7 +277583,7 @@ bge
 bge
 bge
 rUQ
-iCY
+fjY
 rUQ
 sns
 sns
@@ -277916,7 +278005,7 @@ pgL
 vAo
 kRA
 vAo
-tpg
+cNi
 bZC
 ruD
 uWp
@@ -280186,13 +280275,13 @@ iZi
 vxe
 cpa
 pyE
-weQ
+hog
 weQ
 iWa
 iWa
 cIt
 dXR
-shc
+oWi
 qIg
 rBm
 bgY
@@ -281095,7 +281184,7 @@ gzy
 uqB
 jWw
 jWw
-laF
+xdz
 fOB
 jWw
 xOI
@@ -282422,7 +282511,7 @@ jWn
 amM
 bIg
 jWl
-uWp
+fmU
 uWp
 vxe
 uWp
@@ -282898,7 +282987,7 @@ hao
 bHU
 bIg
 oIo
-hkj
+sZH
 aVY
 aHM
 nTh
@@ -283353,7 +283442,7 @@ iND
 vSw
 vSw
 bIg
-lSR
+xJR
 nTh
 kAx
 kAx
@@ -283805,7 +283894,7 @@ nDt
 vSw
 mQw
 bIg
-crj
+syz
 pww
 jJH
 rMf
@@ -284230,7 +284319,7 @@ amM
 pWT
 bIg
 jWl
-uWp
+fmU
 uWp
 vxe
 tXs
@@ -284257,8 +284346,8 @@ jiA
 jiA
 jxB
 bIg
-deO
-iaB
+mcU
+mbG
 rMf
 rMf
 rMf
@@ -284709,7 +284798,7 @@ fZT
 fZT
 hGk
 bIg
-deO
+mcU
 njP
 msF
 rMf
@@ -285161,7 +285250,7 @@ lzQ
 lzQ
 eNM
 bIg
-gei
+rnI
 nTh
 kAx
 kAx
@@ -285586,7 +285675,7 @@ pWT
 pWT
 bIg
 eIK
-fAA
+lPk
 uWp
 uWp
 uWp
@@ -285613,7 +285702,7 @@ nDt
 vSw
 mQw
 bIg
-gei
+rnI
 pww
 jJH
 rMf
@@ -286065,7 +286154,7 @@ vSw
 agm
 kCs
 bIg
-uMM
+jdv
 pww
 kAx
 rMf
@@ -286494,7 +286583,7 @@ hbx
 uWp
 vxe
 fSz
-dgz
+kSj
 mvH
 gjv
 oyx
@@ -286517,7 +286606,7 @@ wsf
 wsf
 wsf
 wWq
-deO
+mcU
 pww
 kAx
 rMf
@@ -286968,7 +287057,7 @@ bIg
 rGA
 rMf
 cGC
-qvp
+foK
 usN
 njP
 ppQ
@@ -287424,7 +287513,7 @@ fSG
 noW
 vQt
 vAw
-mFr
+ocm
 xDj
 weQ
 weQ
@@ -288300,15 +288389,15 @@ bIg
 vxe
 snb
 cXk
-uPI
+vAg
 cXk
 cXk
-uPI
+vAg
 cXk
 cXk
-uPI
+vAg
 cXk
-mcU
+gei
 ovY
 ovY
 ovY
@@ -288771,15 +288860,15 @@ ovY
 wWq
 ovY
 wWq
-sZH
+pel
 wWq
-rkS
+eSn
 noW
 agp
 noW
 noW
 njP
-mkj
+jlB
 fXm
 vAw
 vAw
@@ -289205,29 +289294,29 @@ uqB
 uqB
 weQ
 weQ
-lkJ
-dkt
-lkJ
-dkt
-lkJ
-dkt
-lkJ
-dkt
-lkJ
-gmR
-lkJ
+kbS
+eyl
+kbS
+eyl
+kbS
+eyl
+kbS
+eyl
+kbS
+mhx
+kbS
 rMf
 rMf
-qgS
-rMf
-rMf
-rMf
-qgS
+fvA
 rMf
 rMf
 rMf
+fvA
 rMf
-smR
+rMf
+rMf
+rMf
+sZI
 fSG
 noW
 nTh
@@ -289657,17 +289746,17 @@ uqB
 uqB
 weQ
 weQ
-dkt
-pEB
-dkt
-pEB
-dkt
-pEB
-dkt
-pEB
-dkt
-pEB
-dkt
+eyl
+dJv
+eyl
+dJv
+eyl
+dJv
+eyl
+dJv
+eyl
+dJv
+eyl
 dPu
 dPu
 dPu
@@ -289679,7 +289768,7 @@ dPu
 rMf
 rMf
 rMf
-crj
+syz
 noW
 noW
 nTh
@@ -290109,29 +290198,29 @@ uqB
 uqB
 oPm
 weQ
-lkJ
-dkt
-hqc
-hqc
-hqc
-hqc
-hqc
-hqc
-hqc
-dkt
-lkJ
+kbS
+eyl
+qZN
+fyA
+qZN
+qZN
+qZN
+fyA
+qZN
+eyl
+kbS
 dPu
-sXr
-tDn
+pqR
+iGT
 sLn
 sRn
-wzF
+uWd
 sLn
-pLb
+lqY
 rMf
 rMf
-mbG
-deO
+cCJ
+mcU
 noW
 noW
 nTh
@@ -290561,29 +290650,29 @@ uqB
 jdk
 weQ
 weQ
-dkt
-pEB
-wTi
-oWi
-aoM
 eyl
-ida
-oWi
-wTi
-pEB
-dkt
+dJv
+gmR
+gAH
+ezM
+tod
+jGg
+gAH
+gmR
+dJv
+eyl
 dPu
-dZz
+sRJ
 dPu
-iFA
+jdB
 sLn
-byI
+qHm
 sLn
 dPu
-lLV
-lLV
+agd
+agd
 njP
-jkr
+pIv
 noW
 noW
 nTh
@@ -291013,28 +291102,28 @@ uqB
 jdk
 weQ
 weQ
-lkJ
-dkt
-vDT
-mHf
-syz
-syz
-syz
-rSH
-vDT
-dkt
-lkJ
+kbS
+eyl
+vfl
+htV
+qXJ
+qXJ
+qXJ
+sKU
+vfl
+eyl
+kbS
 dPu
 sLn
-skw
+xBq
 sLn
 sLn
-pJG
+rjK
 sLn
-sOa
-dKe
-dKe
-ezM
+yeu
+shc
+shc
+rlE
 njP
 cOh
 noW
@@ -291465,29 +291554,29 @@ uqB
 uqB
 weQ
 weQ
-dkt
-pEB
-vDT
-syz
-foK
-foK
-foK
-syz
-vDT
-pEB
-dkt
+eyl
+dJv
+vfl
+qXJ
+jsG
+jsG
+jsG
+qXJ
+vfl
+dJv
+eyl
 dPu
 haq
 sLn
 sLn
 sLn
-oYo
+els
 sLn
-sOa
-dKe
-dKe
-dKe
-lLV
+yeu
+shc
+shc
+shc
+agd
 noW
 noW
 nTh
@@ -291917,29 +292006,29 @@ uqB
 uqB
 weQ
 weQ
-lkJ
-dkt
-vDT
-sfH
+kbS
+eyl
+vfl
+iaB
 fSz
-drE
+kUH
 fSz
-rSH
-vDT
-dkt
-lkJ
+sKU
+vfl
+eyl
+kbS
 dPu
-rUb
+sfH
 sLn
-ibZ
+vnq
 sLn
-qZN
+ubv
 sLn
-sOa
-dKe
-dKe
-dKe
-lLV
+yeu
+shc
+shc
+shc
+agd
 noW
 noW
 nTh
@@ -292369,31 +292458,31 @@ uqB
 jdk
 weQ
 weQ
-dkt
-pEB
-vDT
-oWi
-oWi
-oWi
-aoM
-wkv
-vDT
-pEB
-dkt
+eyl
+dJv
+vfl
+gAH
+gAH
+gAH
+ezM
+vJa
+vfl
+dJv
+eyl
 dPu
-xdz
+voe
 sLn
-vBu
-aOc
+nnb
+bko
 sLn
-bhE
-dPu
-wQL
-dKe
 mON
+dPu
+oRZ
+shc
+mPH
 njP
 noW
-rkS
+eSn
 nTh
 nII
 xQT
@@ -292821,29 +292910,29 @@ uqB
 jdk
 weQ
 weQ
-lkJ
-dkt
-kac
-mXZ
-mXZ
-mXZ
-rTT
-syz
-vDT
-dkt
-lkJ
+kbS
+eyl
+mUN
+dZz
+dZz
+dZz
+cDw
+qXJ
+vfl
+eyl
+kbS
 dPu
 dPu
-vUZ
+lZz
 dPu
 dPu
-kRO
+hvV
 dPu
-vUZ
-lLV
-lLV
+lZz
+agd
+agd
 njP
-jkr
+pIv
 tKV
 nTh
 njP
@@ -293273,28 +293362,28 @@ uqB
 uqB
 weQ
 weQ
-dkt
-pEB
-vFY
-mca
-qad
-syz
-syz
-qad
-vDT
-pEB
-dkt
+eyl
+dJv
+mHf
+njb
+vBu
+qXJ
+qXJ
+vBu
+vfl
+dJv
+eyl
 dPu
 xZf
+dha
 xZf
 xZf
 xZf
-xZf
-rtL
-iLV
+mca
+hkj
 weQ
-rLn
-bko
+tpg
+jBH
 tOx
 noW
 noW
@@ -293725,17 +293814,17 @@ uqB
 uqB
 weQ
 weQ
-lkJ
-dkt
-vDT
-dTu
-fBn
-nvU
-wpb
-gDG
-vDT
-dkt
-lkJ
+kbS
+eyl
+vfl
+dEP
+pFh
+fbW
+ncQ
+ncZ
+vfl
+eyl
+kbS
 dPu
 xZf
 neg
@@ -293743,10 +293832,10 @@ neg
 neg
 neg
 xZf
-iLV
+hkj
 weQ
-rLn
-tMd
+tpg
+fht
 fXg
 noW
 noW
@@ -294177,17 +294266,17 @@ uqB
 jdk
 weQ
 weQ
-dkt
-pEB
-wTi
-oWi
-oWi
-oWi
-oWi
-oWi
-wTi
-pEB
-dkt
+eyl
+dJv
+gmR
+gAH
+gAH
+gAH
+gAH
+gAH
+gmR
+dJv
+eyl
 dPu
 xZf
 neg
@@ -294195,9 +294284,9 @@ neg
 neg
 neg
 xZf
-iLV
+hkj
 weQ
-rLn
+tpg
 rMf
 fXg
 noW
@@ -294629,27 +294718,27 @@ uqB
 jdk
 weQ
 weQ
-lkJ
-dkt
-lkJ
-dkt
-lkJ
-dkt
-lkJ
-dkt
-lkJ
-dkt
-lkJ
+kbS
+eyl
+kbS
+eyl
+kbS
+eyl
+kbS
+eyl
+kbS
+eyl
+kbS
 dPu
 xZf
+rLU
 xZf
 xZf
 xZf
-xZf
-hQj
-iLV
-gMS
-rLn
+pMW
+hkj
+wzF
+tpg
 rGA
 fXg
 noW
@@ -295097,13 +295186,13 @@ dPu
 dPu
 dPu
 dPu
-kRO
+hvV
 dPu
 dPu
 weQ
-rLn
-vFt
-igz
+tpg
+eXA
+yfn
 noW
 noW
 rMf
@@ -295551,7 +295640,7 @@ weQ
 weQ
 weQ
 nEd
-gMS
+wzF
 weQ
 weQ
 weQ
@@ -295993,10 +296082,10 @@ nwG
 nwG
 nwG
 weQ
-eja
-etH
+tDn
+rDO
 rni
-oic
+pJG
 weQ
 tWl
 weQ
@@ -296007,7 +296096,7 @@ pZi
 weQ
 weQ
 weQ
-dyx
+tUx
 noW
 nRv
 gqP
@@ -380525,7 +380614,7 @@ bGf
 bGf
 bGf
 bGf
-ajc
+hDh
 pYP
 pYP
 pYP
@@ -388639,7 +388728,7 @@ bGf
 bGf
 bGf
 bGf
-mDc
+vTb
 bGf
 bGf
 bGf
@@ -394981,15 +395070,15 @@ jWw
 qer
 dqE
 lvT
+mCr
 sLn
 sLn
 sLn
-sLn
-sLn
+mCr
 sRn
 sLn
 sLn
-sLn
+mCr
 sLn
 sLn
 jwe
@@ -395433,15 +395522,15 @@ iWa
 qer
 dMi
 jwe
+rtc
 sLn
 sLn
 sLn
+rtc
 sLn
 sLn
 sLn
-sLn
-sLn
-sLn
+rtc
 sLn
 sLn
 nFf
@@ -396787,7 +396876,7 @@ pIl
 vUp
 aaE
 pIl
-frA
+ydD
 heB
 dPu
 lfb
@@ -404915,19 +405004,19 @@ bGf
 bGf
 iVE
 wBK
-pMW
+dyx
 vmi
 vmi
 vmi
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
 vmi
 dPu
 dPu
@@ -405366,29 +405455,29 @@ bGf
 bGf
 bGf
 vgL
-tod
+wij
 rBQ
 vmi
 vmi
 vmi
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
 vmi
 dPu
 uWp
 crD
-rlj
+eja
 crD
-aSm
-prx
-dau
+iMQ
+vII
+rlj
 dPu
 vmi
 vmi
@@ -405819,28 +405908,28 @@ bGf
 bGf
 iVE
 wBK
-pMW
+dyx
 vmi
 vmi
 vmi
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
 vmi
 dPu
-szy
-nat
-kAv
+lmP
+sXr
+sOa
 vAo
 vAo
 vAo
-hPG
+cqj
 dPu
 vmi
 vmi
@@ -406270,29 +406359,29 @@ bGf
 bGf
 bGf
 vgL
-aft
+jxC
 rBQ
 vmi
 vmi
 vmi
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
 vmi
 dPu
 dPu
 fSz
-sKU
+jPl
 uWp
-vII
-ekz
-ekz
+xfz
+cvU
+cvU
 dPu
 vmi
 vmi
@@ -406723,24 +406812,24 @@ bGf
 bGf
 iVE
 wBK
-pMW
+dyx
 vmi
 vmi
 vmi
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
 vmi
 dPu
-tWO
-fFz
-rLU
+lAF
+pda
+gFm
 uWp
 lfb
 kFL
@@ -407174,29 +407263,29 @@ bGf
 bGf
 bGf
 vgL
-tod
+wij
 rBQ
 vmi
 vmi
 vmi
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
 vmi
 dPu
 vAo
 vAo
 vAo
 vAo
-laf
-lnu
-njb
+cEN
+jKf
+rgY
 dPu
 vmi
 vmi
@@ -407627,28 +407716,28 @@ bGf
 bGf
 iVE
 wBK
-pMW
+dyx
 vmi
 vmi
 vmi
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
 vmi
 dPu
-uxY
-kcz
+toG
+xhH
 uWp
 uWp
-laf
-vwp
-vqB
+cEN
+iUW
+vPR
 dPu
 vmi
 vmi
@@ -408078,20 +408167,20 @@ bGf
 bGf
 bGf
 vgL
-aft
+jxC
 rBQ
 vmi
 vmi
 vmi
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
 vmi
 dPu
 uWp
@@ -408099,8 +408188,8 @@ uWp
 uWp
 uWp
 lfb
-cqj
-oSS
+smR
+atr
 dPu
 vmi
 vmi
@@ -408531,25 +408620,25 @@ bGf
 bGf
 iVE
 wBK
-pMW
+dyx
 vmi
 vmi
 vmi
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
 vmi
 dPu
-sXL
+eYZ
 vAo
 uEt
-elZ
+wag
 uEt
 vAo
 vAo
@@ -408982,28 +409071,28 @@ bGf
 bGf
 bGf
 vgL
-tod
+wij
 rBQ
 vmi
 vmi
 vmi
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
 vmi
 dPu
 pIl
-rPN
+uPI
 pIl
 dPu
 pIl
-rPN
+uPI
 pIl
 dPu
 vmi
@@ -409435,28 +409524,28 @@ bGf
 bGf
 iVE
 wBK
-pMW
+dyx
 vmi
 vmi
 vmi
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
-wkx
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
+oWO
 vmi
 dPu
 hox
 hox
-cVX
+ojQ
 pIl
 hox
 hox
-cVX
+ojQ
 dPu
 vmi
 vmi
@@ -409886,7 +409975,7 @@ bGf
 bGf
 bGf
 vgL
-aft
+jxC
 rBQ
 vmi
 vmi
@@ -409902,13 +409991,13 @@ vmi
 vmi
 vmi
 dPu
-vCO
-pFh
-gij
+rrn
+cke
+nTv
 pIl
-vCO
-pFh
-gij
+rrn
+cke
+nTv
 dPu
 vmi
 vmi
@@ -410339,7 +410428,7 @@ bGf
 bGf
 rCV
 wBK
-pMW
+dyx
 vmi
 vmi
 vmi
@@ -410354,13 +410443,13 @@ vmi
 vmi
 vmi
 dPu
-qSC
+pCd
 dPu
-qSC
+pCd
 dPu
-qSC
+pCd
 dPu
-qSC
+pCd
 dPu
 vmi
 vmi
@@ -411689,17 +411778,17 @@ jWw
 vvv
 jWw
 hrE
-xhH
-lSo
-xhH
+mkj
+mFr
+mkj
 jWw
 mnC
 iWa
 iWa
 jWw
-dMM
+bYk
 osX
-dMM
+bYk
 osX
 gHO
 qNT
@@ -412141,22 +412230,22 @@ iWa
 iWa
 iWa
 eps
-xhH
-bsx
-xhH
-blj
+mkj
+vIv
+mkj
+esm
 iWa
 iWa
 dJt
 eps
-vTb
-smZ
-vTb
+oDj
+fCk
+oDj
 nBo
 vVX
 wBK
 eas
-aUk
+pKR
 ixL
 wBK
 vVX
@@ -412593,9 +412682,9 @@ jWw
 tca
 jWw
 jWw
-xhH
-lSo
-xhH
+mkj
+mFr
+mkj
 jWw
 qJz
 iWa
@@ -490358,18 +490447,18 @@ bGf
 bGf
 bGf
 bGf
-tUx
-tUx
-tUx
-tUx
+scT
+scT
+scT
+scT
 rqW
 rqW
 rqW
 rqW
-jdB
-cLX
-cLX
-ykK
+tkB
+hOT
+hOT
+mqT
 bGf
 bGf
 bGf
@@ -490810,10 +490899,10 @@ bGf
 bGf
 bGf
 bGf
-kAF
-kAF
-kAF
-kAF
+fiP
+fiP
+fiP
+fiP
 fnN
 vrN
 fVk
@@ -490823,10 +490912,10 @@ gxX
 iDj
 vPO
 vrN
-cLX
-cLX
-pSy
-ykK
+hOT
+hOT
+hMA
+mqT
 bGf
 bGf
 bGf
@@ -491262,10 +491351,10 @@ oOM
 oOM
 oOM
 bGf
-kAF
-kAF
-kAF
-kAF
+fiP
+fiP
+fiP
+fiP
 hyE
 sPu
 hoS
@@ -491277,8 +491366,8 @@ rqW
 tIs
 aUO
 aUO
-bdV
-xBq
+kAF
+scw
 bGf
 bGf
 bGf
@@ -491714,10 +491803,10 @@ oOM
 oOM
 oOM
 bGf
-kAF
-kAF
-kAF
-kAF
+fiP
+fiP
+fiP
+fiP
 hyE
 rpt
 ncE
@@ -491729,8 +491818,8 @@ rqW
 tIs
 aUO
 aUO
-bdV
-xBq
+kAF
+scw
 bGf
 bGf
 bGf
@@ -492166,10 +492255,10 @@ oOM
 oOM
 oOM
 bGf
-kAF
-kAF
-kAF
-kAF
+fiP
+fiP
+fiP
+fiP
 hyE
 eLe
 aUl
@@ -492179,10 +492268,10 @@ pbq
 sen
 fzm
 fzm
-vAg
+lLV
 aUO
-vnq
-xBq
+iJi
+scw
 bGf
 bGf
 bGf
@@ -492618,10 +492707,10 @@ oOM
 oOM
 oOM
 bGf
-kAF
-kAF
-kAF
-kAF
+fiP
+fiP
+fiP
+fiP
 hyE
 pwV
 xqr
@@ -492632,9 +492721,9 @@ kgY
 pbq
 pbq
 aUO
-vZI
-elC
-xBq
+xXA
+gDG
+scw
 bGf
 bGf
 bGf
@@ -493070,10 +493159,10 @@ oOM
 oOM
 oOM
 bGf
-kAF
-kAF
-kAF
-kAF
+fiP
+fiP
+fiP
+fiP
 hyE
 tYa
 jXF
@@ -493083,10 +493172,10 @@ tYa
 wkR
 tYa
 tbn
-jdv
-jdv
-jdv
-xBq
+aCu
+aCu
+aCu
+scw
 bGf
 bGf
 bGf
@@ -493522,10 +493611,10 @@ oOM
 oOM
 oOM
 bGf
-kAF
-kAF
-kAF
-kAF
+fiP
+fiP
+fiP
+fiP
 hyE
 gxX
 xqr
@@ -493535,10 +493624,10 @@ pzu
 mZP
 fff
 xqr
-nZB
-orR
-wAx
-xBq
+cLX
+hPG
+vCO
+scw
 bGf
 bGf
 bGf
@@ -493974,10 +494063,10 @@ oOM
 bGf
 bGf
 bGf
-kAF
-kAF
-kAF
-kAF
+fiP
+fiP
+fiP
+fiP
 hyE
 vDd
 xqr
@@ -493987,10 +494076,10 @@ hoS
 mZP
 seI
 xqr
-bKp
-orR
-atr
-xBq
+laF
+hPG
+eHY
+scw
 bGf
 bGf
 bGf
@@ -494426,10 +494515,10 @@ oOM
 bGf
 bGf
 bGf
-kAF
-kAF
-kAF
-kAF
+fiP
+fiP
+fiP
+fiP
 hyE
 iis
 xqr
@@ -494439,10 +494528,10 @@ xqr
 mZP
 fdZ
 dnn
-bKp
-orR
-aIi
-xBq
+laF
+hPG
+erO
+scw
 bGf
 bGf
 bGf
@@ -494878,10 +494967,10 @@ bGf
 bGf
 bGf
 bGf
-kAF
-kAF
-kAF
-kAF
+fiP
+fiP
+fiP
+fiP
 opr
 xkI
 bIu
@@ -494891,10 +494980,10 @@ yib
 mZP
 fSD
 wcX
-bKp
-eGS
-hsS
-uEw
+laF
+pxW
+hof
+lGl
 bGf
 bGf
 bGf
@@ -495330,10 +495419,10 @@ bGf
 bGf
 bGf
 bGf
-tUx
-kAF
-kAF
-kAF
+scT
+fiP
+fiP
+fiP
 rqW
 opr
 dgd
@@ -495342,10 +495431,10 @@ dgd
 rgj
 rgj
 rgj
-oJT
-oJT
-oJT
-uEw
+ebP
+ebP
+ebP
+lGl
 bGf
 bGf
 bGf
@@ -508437,7 +508526,7 @@ sOx
 vxe
 bmn
 uQS
-awz
+ixs
 eFM
 hFO
 vxe
@@ -509349,7 +509438,7 @@ uyd
 khf
 lfb
 lfb
-dDx
+fvC
 vxe
 vmi
 vmi
@@ -509374,7 +509463,7 @@ lMc
 vgL
 jAV
 iVE
-toG
+nOC
 iVE
 jAV
 vgL
@@ -509791,7 +509880,7 @@ pyE
 pyE
 pyE
 vxe
-ixs
+cyA
 ftV
 dsv
 uIr
@@ -509823,13 +509912,13 @@ lMc
 lMc
 lMc
 lMc
-pqR
-ktO
+tMv
+aqz
 iCo
-jiZ
+vmI
 iCo
-fLP
-pqR
+dBS
+tMv
 lMc
 lMc
 lMc
@@ -510727,13 +510816,13 @@ lMc
 lMc
 lMc
 lMc
-pqR
-nTv
+tMv
+vwp
 iCo
 iCo
 iCo
-uWd
-pqR
+frA
+tMv
 lMc
 lMc
 lMc
@@ -511180,11 +511269,11 @@ lMc
 lMc
 lMc
 iVE
-aRC
+ibZ
 iCo
 iCo
 iCo
-gtR
+xSh
 iVE
 lMc
 lMc
@@ -511595,7 +511684,7 @@ wfS
 vxe
 vxe
 vxe
-oRZ
+vxe
 vxe
 vxe
 gyY
@@ -511631,13 +511720,13 @@ lMc
 lMc
 lMc
 lMc
-pqR
-jxC
-hvV
-hvV
-hvV
-syb
-pqR
+tMv
+nnL
+vbt
+vbt
+vbt
+hmp
+tMv
 lMc
 lMc
 lMc
@@ -512084,11 +512173,11 @@ lMc
 lMc
 lMc
 iVE
-gFm
+lnu
 rCV
 rCV
 rCV
-djh
+smZ
 iVE
 lMc
 lMc
@@ -512535,13 +512624,13 @@ lMc
 lMc
 lMc
 lMc
-pqR
-umv
-cNi
-cNi
-cNi
-aqA
-pqR
+tMv
+gij
+rUb
+rUb
+rUb
+lAt
+tMv
 lMc
 lMc
 lMc
@@ -512952,7 +513041,7 @@ kBl
 pIl
 pqi
 lyG
-aoO
+aRC
 aoO
 aoO
 uDa
@@ -512990,7 +513079,7 @@ lMc
 vgL
 jAV
 iVE
-toG
+jQJ
 iVE
 jAV
 vgL
@@ -513400,7 +513489,7 @@ vxe
 vxe
 vxe
 kpN
-iMQ
+pIl
 pIl
 pIl
 rnN
@@ -513849,11 +513938,11 @@ bGf
 uwf
 vfL
 vxe
-xXA
+vxe
 pIl
+sWI
 bcB
-bcB
-bcB
+lSh
 bcB
 bcB
 vxe
@@ -513862,7 +513951,7 @@ lqJ
 pIl
 dPu
 wLC
-bcB
+lSh
 bcB
 oih
 bcB
@@ -514761,7 +514850,7 @@ cjs
 wSh
 fAA
 pIl
-fSz
+pLb
 iol
 jiA
 dPu
@@ -515218,7 +515307,7 @@ eKq
 fZT
 stR
 fZT
-fZT
+rPN
 rwM
 pYz
 gzi
@@ -515665,7 +515754,7 @@ jiV
 wSh
 fAA
 pIl
-fSz
+pLb
 oAc
 lzQ
 dPu
@@ -516561,11 +516650,11 @@ bGf
 uwf
 hAe
 vxe
-xXA
+vxe
 pIl
+sWI
 bcB
-bcB
-bcB
+trl
 bcB
 bcB
 vxe
@@ -517016,12 +517105,12 @@ vxe
 vxe
 vxe
 vxe
-iMQ
+pIl
 pIl
 pIl
 oHt
 pIl
-lyG
+lcZ
 lyG
 weS
 vxe
@@ -517465,24 +517554,24 @@ bGf
 uwf
 isS
 iqT
-ank
+mDc
 ank
 vxe
 wzy
-uQS
+awz
 uQS
 uQS
 rov
 lyG
 lyG
-lyG
+vYL
 dPu
 lLL
+riq
 jiA
 jiA
 jiA
-jiA
-jiA
+riq
 fat
 vxe
 uQL
@@ -518375,7 +518464,7 @@ rov
 aLW
 fAA
 oKr
-fAA
+kwQ
 pIl
 qjb
 wSh
@@ -519292,7 +519381,7 @@ uQL
 uQL
 uQL
 uQL
-uWU
+jAe
 uQL
 uQL
 vmi
@@ -519744,7 +519833,7 @@ vmi
 vmi
 vmi
 vmi
-dTQ
+rhf
 vmi
 vmi
 vmi
@@ -520190,14 +520279,14 @@ vmi
 vmi
 vmi
 vmi
-xzG
-bqk
-bqk
-bqk
-bqk
-bqk
-bqk
-uZN
+ijk
+sXL
+sXL
+sXL
+sXL
+sXL
+sXL
+laf
 uQL
 vmi
 vmi
@@ -520642,14 +520731,14 @@ vmi
 vmi
 vmi
 vmi
-aCu
-eRG
-rlj
+blj
+syb
+eja
 pIl
-nOC
+xUY
 myt
-lmP
-loz
+tqO
+ygd
 uQL
 vmi
 vmi
@@ -521094,12 +521183,12 @@ vmi
 vmi
 vmi
 vmi
-aCu
-fSz
-sKU
+blj
+pLb
+jPl
 pIl
-fNC
-uNj
+jCA
+bJB
 lyG
 oZk
 uQL
@@ -521546,14 +521635,14 @@ vmi
 vmi
 vmi
 vmi
-aCu
-sRD
-sKU
+blj
+lmP
+jPl
 pIl
-fBd
-fPZ
-wQW
-loz
+uZN
+vnO
+cRi
+ygd
 uQL
 vmi
 vmi
@@ -521998,10 +522087,10 @@ vmi
 vmi
 vmi
 vmi
-bJB
+uMM
 uWp
-rLU
-fiP
+gFm
+qdH
 lyG
 lyG
 lyG
@@ -522450,14 +522539,14 @@ vmi
 vmi
 vmi
 vmi
-aCu
-uWp
+blj
+fmU
 uWp
 pIl
-pda
+fBn
 fAA
-ine
-loz
+fFz
+ygd
 uQL
 vmi
 vmi
@@ -522902,14 +522991,14 @@ vmi
 vmi
 vmi
 vmi
-aCu
+blj
 pIl
 pIl
 pIl
 pIl
-eeK
+xXW
 pIl
-loz
+ygd
 uQL
 vmi
 vmi
@@ -523354,14 +523443,14 @@ vmi
 vmi
 vmi
 vmi
-aCu
-mjw
+blj
+aVE
 fAA
-ffL
+fSB
+dTQ
 lyG
-lyG
-lyG
-loz
+dTQ
+ygd
 uQL
 vmi
 vmi
@@ -523806,12 +523895,12 @@ vmi
 vmi
 vmi
 vmi
-bJB
-aoJ
+uMM
+oic
 fAA
-wtb
+ida
 lyG
-jQJ
+eMi
 lyG
 oZk
 uQL
@@ -524258,14 +524347,14 @@ vmi
 vmi
 vmi
 vmi
-aCu
+blj
 lyG
 lyG
 lyG
 lyG
 lyG
 lyG
-loz
+ygd
 uQL
 vmi
 vmi
@@ -524710,13 +524799,13 @@ vmi
 vmi
 vmi
 vmi
-aCu
-vdf
+blj
+iFA
 hox
 hox
 hox
 lyG
-tEW
+hmx
 oZk
 uQL
 vmi
@@ -525162,14 +525251,14 @@ vmi
 vmi
 vmi
 vmi
-aCu
-dJv
-jlB
-fyA
-iJp
-hog
-viS
-loz
+blj
+cUj
+oPf
+eeK
+mIU
+hfn
+bgr
+ygd
 uQL
 vmi
 vmi
@@ -525614,14 +525703,14 @@ vmi
 vmi
 vmi
 vmi
-rSJ
-vmI
-vmI
-vmI
-vmI
-vmI
-vmI
-jsG
+rtL
+igz
+igz
+igz
+igz
+igz
+igz
+eTw
 uQL
 vmi
 vmi
@@ -526506,9 +526595,9 @@ jWw
 yjG
 jWw
 jWw
-lMc
-lMc
-lMc
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -526958,10 +527047,10 @@ iWa
 iWa
 iWa
 iVE
-lMc
-lMc
-lMc
-lMc
+vmi
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -527409,11 +527498,11 @@ vgL
 iWa
 iWa
 dJt
-eps
-lMc
-lMc
-lMc
-lMc
+vgL
+vmi
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -527862,10 +527951,10 @@ iWa
 iWa
 iWa
 iVE
-lMc
-lMc
-lMc
-lMc
+iXc
+iXc
+iXc
+iXc
 iXc
 iXc
 iXc
@@ -528314,9 +528403,9 @@ jWw
 iWa
 jWw
 jWw
-lMc
-lMc
-lMc
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -74,6 +74,18 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"abP" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "abR" = (
 /obj/effect/decal/cleanable/debris/woody,
 /turf/open/floor/rogue/ruinedwood{
@@ -228,6 +240,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"aeP" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "afb" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
@@ -252,12 +270,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "aft" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/water/bath,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/walldeco/customflag,
+/turf/closed/wall/mineral/rogue/wooddark/vertical,
+/area/rogue/indoors/town/garrison)
 "afv" = (
 /obj/structure/chair/wood/rogue/fancy,
 /obj/effect/landmark/start/guildmaster,
@@ -298,11 +313,35 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/woods)
 "agd" = (
-/obj/structure/bars/passage/shutter/open{
-	redstone_id = "stewardshutter"
+/obj/structure/closet/crate/chest/neu,
+/obj/item/natural/bundle/cloth{
+	amount = 8
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "agh" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -518,10 +557,8 @@
 	},
 /area/rogue/indoors/town)
 "ajc" = (
-/obj/structure/roguewindow,
-/obj/structure/fluff/statue/knightalt,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/dwarfin)
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/vault)
 "ajm" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -896,31 +933,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "aoJ" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/clothing/shoes/roguetown/boots/armor/iron,
-/obj/item/clothing/shoes/roguetown/boots/armor/iron,
-/obj/item/clothing/gloves/roguetown/angle,
-/obj/item/clothing/gloves/roguetown/angle,
-/obj/item/clothing/shoes/roguetown/boots/leather/atgervi,
-/obj/item/clothing/shoes/roguetown/boots/leather/atgervi,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 8
+	},
+/area/rogue/outdoors/town/roofs)
 "aoM" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5
+/turf/open/floor/rogue/rooftop{
+	icon_state = "roof";
+	dir = 1
 	},
-/obj/structure/rack/rogue,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve{
-	pixel_x = -14;
-	pixel_y = -13
-	},
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve{
-	pixel_x = -21;
-	pixel_y = -18
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/area/rogue/outdoors/town/roofs/keep)
 "aoO" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -1006,14 +1028,26 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/indoors)
 "aqz" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
 	},
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "aqA" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/blocks,
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/rollie/nicotine{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/clothing/mask/cigarette/rollie/nicotine/cheroot{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/turf/open/floor/rogue/tile/bath,
 /area/rogue/under/town/basement/keep)
 "aqC" = (
 /obj/structure/winch{
@@ -1178,14 +1212,15 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/beach)
 "atr" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/item/natural/feather{
+	pixel_x = -2;
+	pixel_y = 6
 	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/carpet,
+/area/rogue/under/town/basement/keep)
 "atx" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mossback,
 /turf/open/water/ocean,
@@ -1698,8 +1733,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "aCu" = (
-/turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/outdoors/town/roofs)
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/manor)
 "aCJ" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/rogue/AzureSand,
@@ -1792,9 +1830,18 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
 "aEj" = (
-/obj/structure/chair/bench/church/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/basement)
+/obj/structure/bed/rogue/inn/double{
+	dir = 1
+	},
+/obj/item/bedsheet/rogue/fabric_double{
+	dir = 1
+	},
+/obj/effect/landmark/start/apothecary,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/outdoors/town/roofs)
 "aEn" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 4
@@ -1804,6 +1851,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"aEq" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town/vault)
 "aEr" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/wrists/roguetown/bracers/leather,
@@ -1814,8 +1867,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "aEu" = (
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/vault)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "aEz" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
@@ -2015,37 +2071,8 @@
 /turf/open/floor/rogue/concrete/bronze,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "aIi" = (
-/obj/structure/closet/crate/chest,
-/obj/item/roguekey/manor,
-/obj/item/roguekey/walls,
-/obj/item/roguekey/crafterguild,
-/obj/item/roguekey/steward,
-/obj/item/roguekey/church,
-/obj/item/roguekey/dungeon,
-/obj/item/roguekey/graveyard,
-/obj/item/roguekey/garrison{
-	name = "garrison key"
-	},
-/obj/item/roguekey/mercenary,
-/obj/item/roguekey/nightmaiden,
-/obj/item/roguekey/tavern,
-/obj/item/roguekey/physician,
-/obj/item/roguekey/knight,
-/obj/item/roguekey/armory,
-/obj/item/roguekey/tower,
-/obj/item/roguekey/sergeant,
-/obj/item/roguekey/sheriff,
-/obj/item/roguekey/royal,
-/obj/item/roguekey/lord,
-/obj/item/roguekey/merchant,
-/obj/item/roguekey/warden,
-/obj/item/roguekey/hand,
-/obj/item/storage/keyring,
-/obj/item/storage/keyring,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
-/area/rogue/indoors/town/vault)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/outdoors/town/roofs)
 "aIn" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grassyel,
@@ -2340,6 +2367,15 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"aNs" = (
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = "manor";
+	name = "Service Halls"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/manor)
 "aNB" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -2365,9 +2401,37 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "aOc" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/closet/crate/chest,
+/obj/item/roguekey/manor,
+/obj/item/roguekey/walls,
+/obj/item/roguekey/crafterguild,
+/obj/item/roguekey/steward,
+/obj/item/roguekey/church,
+/obj/item/roguekey/dungeon,
+/obj/item/roguekey/graveyard,
+/obj/item/roguekey/garrison{
+	name = "garrison key"
+	},
+/obj/item/roguekey/mercenary,
+/obj/item/roguekey/nightmaiden,
+/obj/item/roguekey/tavern,
+/obj/item/roguekey/physician,
+/obj/item/roguekey/knight,
+/obj/item/roguekey/armory,
+/obj/item/roguekey/tower,
+/obj/item/roguekey/sergeant,
+/obj/item/roguekey/sheriff,
+/obj/item/roguekey/royal,
+/obj/item/roguekey/lord,
+/obj/item/roguekey/merchant,
+/obj/item/roguekey/warden,
+/obj/item/roguekey/hand,
+/obj/item/storage/keyring,
+/obj/item/storage/keyring,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 1
+	},
+/area/rogue/indoors/town/vault)
 "aOg" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor5-old"
@@ -2388,9 +2452,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach)
 "aOM" = (
-/obj/item/roguestatue/gold/loot,
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/vault)
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/candlestick/silver/lit{
+	pixel_y = 9
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "aOO" = (
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/alt/pink,
 /turf/open/floor/rogue/churchbrick,
@@ -2595,13 +2664,20 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
 "aRC" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
+/obj/structure/flora/roguegrass/bush/wall/tall{
+	pixel_x = -11;
+	pixel_y = 0
 	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "aRF" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -2627,17 +2703,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "aSm" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
 /obj/effect/decal/cobbleedge{
-	dir = 8
+	pixel_y = 1
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "aSu" = (
 /obj/structure/closet/crate/chest/wicker{
 	opened = 1
@@ -2697,9 +2767,11 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cave/skeletoncrypt)
 "aUk" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/tile/bfloorz,
+/area/rogue/under/town/basement/keep)
 "aUl" = (
 /obj/effect/landmark/start/physician,
 /turf/open/floor/carpet/red,
@@ -2760,9 +2832,8 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/mazedungeon)
 "aVE" = (
-/obj/structure/chair/bench/ultimacouch,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/carpet/royalblack,
+/obj/effect/decal/carpet,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "aVL" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -3290,11 +3361,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "bdw" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/tower/metal,
-/obj/item/rogueweapon/shield/buckler,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/wallfire/candle/blue{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/manor)
 "bdx" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt/road,
@@ -3318,19 +3390,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/magician)
 "bdV" = (
-/obj/item/candle/yellow/lit,
-/obj/item/candle/yellow/lit{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/candle/yellow/lit,
-/obj/item/candle/yellow/lit{
-	pixel_x = 8;
-	pixel_y = 13
-	},
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
+/area/rogue/indoors/town/manor)
 "bdZ" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/mazedungeon)
@@ -3432,12 +3493,8 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/cave)
 "bgr" = (
-/obj/structure/closet/crate/roguecloset/crafted,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
-/obj/item/clothing/suit/roguetown/armor/silkcoat,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/turf/open/floor/rogue/wood/herringbone,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "bgG" = (
 /obj/structure/fluff/railing/border{
@@ -3509,9 +3566,10 @@
 /turf/closed/wall/mineral/rogue/roofwall/middle,
 /area/rogue/indoors)
 "bhE" = (
-/obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/roguemachine/noticeboard,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "bhJ" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cave)
@@ -3627,12 +3685,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/physician)
 "bko" = (
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/walldeco/steward,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "bkv" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -3656,10 +3711,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "blj" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 1
-	},
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town/roofs)
 "blp" = (
 /mob/living/carbon/human/species/dwarfskeleton/ambush,
 /turf/open/floor/rogue/concrete,
@@ -3891,9 +3945,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
 "bpF" = (
-/obj/structure/table/church,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "bpK" = (
 /obj/structure/table/wood{
 	icon_state = "longtable";
@@ -3925,13 +3979,11 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "bqk" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 11
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 8
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/manor)
 "bqp" = (
 /obj/structure/fluff/walldeco/chains{
 	icon_state = "chains3"
@@ -4071,10 +4123,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "bsx" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/water/bath,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "bsz" = (
 /obj/structure/fluff/railing/border{
@@ -4993,14 +5043,12 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
 "bHv" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 9
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/structure/closet/crate/drawer,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "bHE" = (
 /mob/living/simple_animal/hostile/rogue/mirespider_lurker,
 /turf/open/floor/rogue/dirt,
@@ -5156,13 +5204,9 @@
 /turf/open/water/swamp,
 /area/rogue/indoors/cave)
 "bJB" = (
-/obj/structure/table/wood{
-	dir = 2;
-	icon_state = "longtable"
-	},
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/wood/herringbone,
+/obj/structure/chair/bench/ultimacouch,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "bJH" = (
 /obj/structure/table/wood,
@@ -5198,10 +5242,14 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "bKp" = (
-/turf/closed/wall/mineral/rogue/stonebrick{
-	density = 0
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "bKv" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -6024,12 +6072,12 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
 "bYk" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+/obj/structure/chair/wood/rogue{
+	pixel_x = 1;
+	pixel_y = -6
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "bYr" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt/road,
@@ -6601,14 +6649,19 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield/eora)
 "cke" = (
-/obj/structure/closet/crate/roguecloset/crafted,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
-/obj/item/clothing/under/roguetown/skirt,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/manor)
+/obj/item/candle/yellow/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/candle/yellow/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = 8;
+	pixel_y = 13
+	},
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "ckm" = (
 /turf/open/water/ocean,
 /area/rogue/under/cavewet/bogcaves)
@@ -6925,10 +6978,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/cell)
 "cqj" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/woodturned,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "cqn" = (
 /turf/closed/wall/mineral/rogue/tent{
@@ -6983,14 +7034,8 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "crj" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 5
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/closed/wall/mineral/rogue/roofwall/middle,
+/area/rogue/outdoors/town/roofs)
 "crl" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/beach)
@@ -7282,11 +7327,11 @@
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
 "cvU" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "cvV" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
@@ -7668,12 +7713,6 @@
 /obj/item/bedsheet/rogue/pelt,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
-"cCJ" = (
-/obj/structure/fluff/walldeco/steward{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
 "cCT" = (
 /obj/machinery/light/roguestreet,
 /turf/open/floor/rogue/dirt/road,
@@ -7702,7 +7741,10 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "cDw" = (
-/turf/closed/wall/mineral/rogue/pipe,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "cDB" = (
 /turf/closed/wall/mineral/rogue/decowood,
@@ -7751,9 +7793,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "cEN" = (
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/roofwall/outercorner,
+/area/rogue/outdoors/town/roofs)
 "cEP" = (
 /obj/structure/rack/rogue/shelf/big{
 	icon_state = "shelf_biggest";
@@ -8177,9 +8218,15 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "cLX" = (
-/obj/effect/landmark/start/apothecary,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "cMc" = (
 /obj/structure/stairs{
 	dir = 1
@@ -8302,9 +8349,9 @@
 	},
 /area/rogue/indoors/town)
 "cNi" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "cNn" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -8575,15 +8622,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
-"cRi" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
 "cRk" = (
 /obj/item/clothing/neck/roguetown/psicross/necra,
 /obj/structure/table/wood/fancy/black,
@@ -8708,16 +8746,18 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach)
 "cUj" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/wood/herringbone,
+/obj/structure/bed/rogue/inn/double,
+/obj/structure/fluff/wallclock/r,
+/obj/item/bedsheet/rogue/fabric_double,
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "cUk" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/structure/chair/wood/rogue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 12
 	},
-/turf/open/floor/rogue/hexstone,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
 "cUm" = (
 /obj/structure/fluff/walldeco/chains{
@@ -8788,10 +8828,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "cVo" = (
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
-/area/rogue/indoors/town/vault)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/manor)
 "cVp" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -8810,13 +8850,24 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "cVX" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5;
-	pixel_x = -10
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "garrison"
 	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "cWe" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/cobble,
@@ -9069,15 +9120,13 @@
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/manor)
 "dau" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt{
+	pixel_x = 0;
+	pixel_y = 8
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/structure/table/church/m,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "daw" = (
 /obj/structure/fluff/railing/border{
 	dir = 5;
@@ -9280,8 +9329,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "deO" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/blocks,
+/turf/closed/wall/mineral/rogue/stonebrick{
+	density = 0
+	},
 /area/rogue/under/town/basement/keep)
 "deQ" = (
 /obj/structure/fluff/clock,
@@ -9365,40 +9415,12 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "dgz" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/natural/cloth{
-	pixel_x = -2;
-	pixel_y = 7
-	},
-/obj/item/natural/cloth{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/natural/cloth{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/natural/cloth{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/obj/item/natural/cloth{
-	pixel_x = 8;
-	pixel_y = 11
-	},
-/obj/item/natural/cloth{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/soap/bath{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/obj/item/soap/bath{
-	pixel_x = 4;
-	pixel_y = 10
-	},
-/turf/open/floor/rogue/tile/bath,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
+/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
+/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
+/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "dgC" = (
 /obj/structure/plasticflaps,
@@ -9427,8 +9449,9 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/mountains/decap)
 "dha" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/cobble,
+/obj/structure/fluff/clock,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "dhf" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -9525,16 +9548,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "djh" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/gold/lit{
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
+/area/rogue/outdoors/exposed/town/keep)
 "djl" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder,
 /turf/open/floor/rogue/dirt,
@@ -9585,12 +9600,12 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/shelter/mountains/decap)
 "dkt" = (
-/obj/effect/decal/cobbleedge{
-	dir = 7;
-	pixel_x = 13
+/obj/structure/chair/wood/rogue{
+	pixel_x = 2;
+	pixel_y = -5
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "dky" = (
 /obj/item/natural/rock/salt,
 /turf/open/floor/rogue/hexstone,
@@ -9713,6 +9728,17 @@
 "dnh" = (
 /turf/open/floor/rogue/volcanic,
 /area/rogue/under/cave/dragonden)
+"dni" = (
+/obj/item/candle/yellow/lit{
+	pixel_x = 19;
+	pixel_y = -1
+	},
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/basement)
 "dnk" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
@@ -9813,6 +9839,9 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
+"doL" = (
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "doY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/royalblack,
@@ -9988,14 +10017,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "drE" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/effect/decal/cobbleedge,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/bundle/stick,
+/obj/item/natural/bundle/stick,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "drN" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/magician)
@@ -10092,6 +10122,11 @@
 "dsD" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter/mountains)
+"dsL" = (
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 8
+	},
+/area/rogue/indoors/town/manor)
 "dtb" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -10315,9 +10350,9 @@
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "dyx" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/manor)
 "dyA" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
@@ -10476,6 +10511,22 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
+"dBg" = (
+/obj/effect/decal/cobbleedge{
+	dir = 5
+	},
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve{
+	pixel_x = -14;
+	pixel_y = -13
+	},
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve{
+	pixel_x = -21;
+	pixel_y = -18
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "dBl" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -10514,17 +10565,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"dBS" = (
-/obj/structure/closet/crate/chest,
-/obj/item/quiver,
-/obj/item/quiver,
-/obj/item/quiver,
-/obj/item/quiver/sling/iron,
-/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "dBW" = (
 /obj/structure/chair/wood/rogue,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10646,8 +10686,6 @@
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = 32
 	},
-/obj/effect/particle_effect/smoke,
-/obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "dEQ" = (
@@ -10688,12 +10726,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "dFk" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-sread"
-	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/table/church,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "dFp" = (
 /obj/structure/bars/pipe,
 /obj/structure/bars/pipe{
@@ -10916,8 +10951,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "dJv" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/food/snacks/smallrat,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "dJx" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -10949,17 +10986,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/underdark)
 "dKe" = (
-/obj/structure/mannequin,
-/obj/item/clothing/suit/roguetown/armor/plate/half{
-	pixel_x = 0;
-	pixel_y = -4
-	},
-/obj/item/clothing/head/roguetown/helmet/sallet{
-	pixel_x = 0;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "dKf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -11177,12 +11205,9 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "dNO" = (
-/obj/structure/chair/wood/rogue{
-	pixel_x = 1;
-	pixel_y = -6
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/structure/feedinghole,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "dOd" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia,
 /turf/open/floor/rogue/naturalstone,
@@ -11201,6 +11226,17 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town)
+"dOz" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/candle/candlestick/silver/lit{
+	pixel_y = 14;
+	pixel_x = 0
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "dOI" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -11498,19 +11534,10 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cavewet/bogcaves)
 "dTu" = (
-/obj/item/candle/yellow/lit{
-	pixel_x = -70;
-	pixel_y = 47
-	},
-/obj/item/candle/yellow/lit{
-	pixel_x = -14;
-	pixel_y = 41
-	},
-/obj/structure/table/church{
-	icon_state = "churchtable_end"
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "dTv" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
@@ -11544,8 +11571,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "dTQ" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/herringbone,
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "dTS" = (
 /obj/structure/table/wood{
@@ -11867,10 +11897,15 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/church/basement)
 "dZz" = (
-/turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_line"
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
 	},
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "dZC" = (
 /obj/structure/table/church,
 /obj/item/reagent_containers/glass/cup/golden{
@@ -11989,11 +12024,13 @@
 	},
 /area/rogue/indoors)
 "ebP" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
+/obj/structure/mineral_door/wood/donjon{
+	dir = 8;
+	locked = 1;
+	lockid = "steward"
 	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "ebQ" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -12151,10 +12188,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
 "eeK" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/structure/fluff/wallclock/r,
-/obj/item/bedsheet/rogue/fabric_double,
-/turf/open/floor/carpet/red,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "eeL" = (
 /turf/open/floor/rogue/dirt,
@@ -12453,11 +12490,13 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "eja" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/table/wood{
+	icon_state = "map5"
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "ejb" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
@@ -12571,9 +12610,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "ekz" = (
-/obj/structure/chair/bench/church,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/basement)
+/obj/structure/roguewindow/openclose/reinforced,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "ekF" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -12609,10 +12648,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/goblinfort)
 "els" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/food/snacks/smallrat,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town/roofs)
 "elw" = (
 /obj/structure/table/wood{
 	icon_state = "longtable_mid"
@@ -12642,16 +12682,15 @@
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/woods)
 "elZ" = (
-/obj/structure/closet/crate/roguecloset{
-	name = "Ropes and Chains"
+/obj/structure/mannequin,
+/obj/item/clothing/suit/roguetown/armor/plate/half{
+	pixel_x = 0;
+	pixel_y = -4
 	},
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope,
-/obj/item/rope,
-/obj/item/rogueweapon/whip,
+/obj/item/clothing/head/roguetown/helmet/sallet{
+	pixel_x = 0;
+	pixel_y = 8
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "emg" = (
@@ -12888,10 +12927,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "ept" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4;
-	icon_state = "wooddir"
-	},
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "epy" = (
@@ -13005,16 +13041,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
 "erO" = (
-/obj/structure/bed/rogue/inn/double{
+/turf/open/floor/rogue/tile/masonic{
 	dir = 4
 	},
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/effect/landmark/start/apothecary,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/town/roofs)
+/area/rogue/indoors/town/vault)
 "erP" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/mountains/decap)
@@ -13044,12 +13074,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "esm" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/exposed/town/keep)
 "esn" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -13123,8 +13149,12 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "etH" = (
-/turf/closed,
-/area/rogue/under/cave)
+/obj/item/roguecoin/gold/pile,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
+	},
+/area/rogue/indoors/town/vault)
 "etM" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/spider/stickyweb,
@@ -13445,9 +13475,11 @@
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/outdoors/exposed/bath/vault)
 "exS" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
 /obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "exT" = (
 /obj/structure/rack/rogue/shelf,
@@ -13468,6 +13500,15 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"exY" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	dir = 1
+	},
+/obj/item/natural/feather,
+/obj/item/candle/yellow/lit,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "exZ" = (
 /obj/effect/spawner/roguemap/stump,
 /obj/structure/fluff/walldeco/customflag{
@@ -13479,8 +13520,15 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/underdark)
 "eyl" = (
-/turf/open/floor/rogue/blocks/bluestone,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/wood{
+	layer = 4.51
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "eyn" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -13553,10 +13601,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
 "ezM" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ezQ" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -13718,6 +13769,40 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
+"eDw" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "steward"
+	},
+/obj/item/roguekey/manor,
+/obj/item/roguekey/walls,
+/obj/item/roguekey/crafterguild,
+/obj/item/roguekey/steward,
+/obj/item/roguekey/church,
+/obj/item/roguekey/dungeon,
+/obj/item/roguekey/graveyard,
+/obj/item/roguekey/garrison{
+	name = "garrison key"
+	},
+/obj/item/roguekey/mercenary,
+/obj/item/roguekey/nightmaiden,
+/obj/item/roguekey/tavern,
+/obj/item/roguekey/physician,
+/obj/item/roguekey/knight,
+/obj/item/roguekey/armory,
+/obj/item/roguekey/tower,
+/obj/item/roguekey/apartments/stable1,
+/obj/item/roguekey/apartments/stable2,
+/obj/item/roguekey/tailor,
+/obj/item/roguekey/shop,
+/obj/item/roguekey/archive,
+/obj/item/paper{
+	info = "Hand Key, Lord's Key, Knight Captain's Key, Marshall Key, Sergeant Key, Royal Key kept in Vault."
+	},
+/obj/item/storage/keyring,
+/obj/item/storage/keyring,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "eDx" = (
 /obj/item/grown/log/tree/small{
 	pixel_y = 7
@@ -13940,15 +14025,13 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/forest)
 "eGS" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/chair/wood/rogue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 15
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "eHa" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
@@ -13973,14 +14056,14 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/shelter/woods)
 "eHY" = (
-/obj/structure/closet/crate/drawer,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/natural/feather,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 5
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "eIa" = (
 /obj/machinery/light/rogue/oven{
 	desc = "...?";
@@ -14196,9 +14279,12 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/physician)
 "eMi" = (
-/obj/effect/decal/carpet,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "eMl" = (
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/tile,
@@ -14462,13 +14548,18 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "eRG" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/town)
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = 8
+	},
+/obj/item/kitchen/spoon/gold{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "eRS" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -14491,8 +14582,8 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "eSn" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/exposed/town/keep)
 "eSo" = (
 /obj/structure/table/wood,
@@ -14573,11 +14664,6 @@
 "eTj" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/underdark)
-"eTw" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
-	},
-/area/rogue/indoors/town/manor)
 "eTA" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -14782,13 +14868,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/goblindungeon)
 "eXA" = (
-/obj/structure/flora/roguegrass,
 /obj/effect/decal/cobbleedge{
 	dir = 10;
-	icon_state = "cobbleedge-e"
+	icon_state = "cobbleedge-w"
 	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "eXE" = (
 /obj/structure/table/cooling,
 /obj/structure/bars{
@@ -14862,13 +14948,6 @@
 	dir = 4
 	},
 /area/rogue/indoors/shelter/woods)
-"eYZ" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/flashlight/flare/torch/lantern,
-/obj/item/flashlight/flare/torch/lantern,
-/obj/item/flashlight/flare/torch/lantern,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
 "eZb" = (
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town)
@@ -15040,12 +15119,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
 "fbW" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = 32
+/turf/closed/wall/mineral/rogue/roofwall/middle{
+	dir = 8
 	},
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/town/roofs)
 "fbZ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -15362,17 +15439,9 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/woods)
-"ffz" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
 "ffL" = (
-/turf/closed/wall/mineral/rogue/decostone/cand,
+/obj/structure/toilet,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "ffN" = (
 /obj/structure/table/wood{
@@ -15452,11 +15521,6 @@
 /obj/structure/roguewindow/stained/zizo,
 /turf/closed/wall/mineral/rogue/stone/red_moss,
 /area/rogue/indoors/shelter/mountains/decap)
-"fht" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
 "fhv" = (
 /obj/structure/fluff/wallclock,
 /obj/structure/closet/crate/drawer,
@@ -15526,8 +15590,9 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "fiP" = (
-/turf/closed,
-/area/rogue/indoors/town/physician)
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "fiU" = (
 /obj/structure/chair/bench/coucha{
 	can_buckle = 0
@@ -15610,14 +15675,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "fjY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/machinery/light/rogue/firebowl/standing,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/garrison)
 "fkc" = (
 /obj/structure/bars,
 /obj/structure/roguewindow,
@@ -15884,19 +15946,11 @@
 	},
 /area/rogue/indoors)
 "foK" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/flora/roguegrass/bush{
-	pixel_x = 5;
-	pixel_y = 0
-	},
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/indoors/town/garrison)
 "foN" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -16120,13 +16174,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
 "frA" = (
-/obj/machinery/light/rogue/torchholder/c{
-	pixel_y = -32
+/obj/structure/bars/passage/shutter{
+	redstone_id = "warehouse_shutter"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "frN" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16327,17 +16379,16 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "fvA" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/grass,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
 "fvC" = (
-/obj/structure/fluff/statue/tdummy,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/effect/decal/cobbleedge{
+	dir = 6
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "fvE" = (
 /obj/structure/closet/crate/roguecloset/dark,
@@ -16522,9 +16573,13 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblindungeon)
 "fyA" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile/tilerg,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fyQ" = (
 /obj/item/bedsheet/rogue/double_pelt,
 /obj/structure/bed/rogue/inn/wooldouble,
@@ -16673,23 +16728,32 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/cave)
 "fBd" = (
-/obj/machinery/light/rogue/lanternpost{
-	dir = 1
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag{
+	pixel_x = -7;
+	pixel_y = 5
 	},
-/obj/structure/fluff/littlebanners{
-	pixel_y = -6
+/obj/item/storage/roguebag{
+	pixel_x = 7;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "fBm" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/mazedungeon)
 "fBn" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace,
+/obj/item/rogueweapon/mace{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "fBq" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/potion_vitals,
@@ -16729,9 +16793,28 @@
 	},
 /area/rogue/indoors/town/magician)
 "fCk" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/wood,
+/obj/structure/fluff/railing/border,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
+"fCn" = (
+/obj/structure/rack/rogue/shelf,
+/obj/item/gwstrap{
+	pixel_x = -12;
+	pixel_y = 13
+	},
+/obj/item/gwstrap{
+	pixel_x = -19;
+	pixel_y = 16
+	},
+/obj/item/gwstrap{
+	pixel_x = -15;
+	pixel_y = 16
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "fCr" = (
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/blocks,
@@ -16911,14 +16994,11 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "fFz" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 32
+	},
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "fFF" = (
 /obj/structure/table/wood{
@@ -16994,19 +17074,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/underdark)
 "fHg" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/machinery/light/rogue/torchholder/c{
+	pixel_y = -32
 	},
-/obj/effect/decal/cobbleedge,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/pillory/reinforced{
-	lockid = list("garrison")
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "fHh" = (
 /obj/structure/stairs{
 	dir = 8
@@ -17282,13 +17354,15 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "fLP" = (
-/obj/machinery/light/rogue/torchholder/c{
-	pixel_y = -32
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = -6;
+	pixel_y = 5
 	},
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "fLQ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17428,13 +17502,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "fNC" = (
-/obj/item/tablecloth/silk{
-	pixel_x = -6;
-	pixel_y = 6
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
+	dir = 4
 	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/under/town/basement/keep)
+/area/rogue/indoors/town/manor)
 "fNH" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/dirt/road,
@@ -17546,16 +17617,11 @@
 	},
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "fPZ" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/obj/item/candle/silver/lit,
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 10;
-	pixel_y = -70
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "fQb" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -17666,9 +17732,15 @@
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
 "fRL" = (
-/obj/structure/chair/bench/church/mid,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/basement)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "fRM" = (
 /mob/living/simple_animal/pet/cat/rogue/black,
 /turf/open/floor/rogue/blocks,
@@ -17721,18 +17793,14 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "fSB" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/structure/lever/wall{
+	dir = 5;
+	redstone_id = "stewardshutter";
+	pixel_x = 16;
+	pixel_y = 1
 	},
-/obj/item/reagent_containers/glass/cup/golden{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/beer/stonebeardreserve{
-	pixel_x = 13;
-	pixel_y = 11
-	},
-/turf/open/floor/rogue/wood,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "fSD" = (
 /obj/structure/table/wood{
@@ -17922,11 +17990,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "fVF" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
-	pixel_y = -32
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
+	dir = 7
 	},
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/under/town/basement/keep)
+/area/rogue/indoors/town/manor)
 "fVR" = (
 /obj/structure/closet/crate/drawer,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -18177,6 +18244,14 @@
 /obj/structure/fermentation_keg/random/water,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"fZo" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "fZu" = (
 /obj/structure/table/wood{
 	icon_state = "largetable";
@@ -18414,14 +18489,16 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
 "gei" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 1;
-	locked = 1;
-	lockid = "manor";
-	name = "Service Halls"
+/obj/effect/decal/cobbleedge{
+	dir = 7;
+	pixel_x = 13
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "gem" = (
 /obj/structure/mineral_door/bars{
 	lockid = "manor"
@@ -18583,6 +18660,18 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"ghC" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = 1
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "ghJ" = (
 /mob/living/carbon/human/species/goblin/npc/hell,
 /turf/open/floor/rogue/grasscold,
@@ -18601,22 +18690,12 @@
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
 "gij" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/machinery/light/rogue/firebowl/standing/blue{
+	pixel_x = 0;
+	pixel_y = 10
 	},
-/obj/structure/rack/rogue/shelf,
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = -5;
-	pixel_y = 39
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 7;
-	pixel_y = 39
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "gik" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 1
@@ -18842,8 +18921,17 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
 "gmR" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "gmZ" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
@@ -19244,15 +19332,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "gtR" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5;
-	pixel_x = -6
-	},
-/obj/machinery/light/rogue/lanternpost{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/closed/wall/mineral/rogue/roofwall/outercorner,
+/area/rogue/indoors/town/manor)
 "gtY" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/effect/decal/cleanable/blood,
@@ -19753,8 +19834,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "gAH" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/outdoors/town/roofs/keep)
 "gAL" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/dirt,
@@ -19767,20 +19849,17 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/magician)
 "gAQ" = (
-/obj/structure/closet/crate/roguecloset{
-	name = "Chainmail"
+/obj/structure/fluff/railing/border{
+	dir = 9
 	},
-/obj/item/clothing/gloves/roguetown/chain/iron,
-/obj/item/clothing/gloves/roguetown/chain/iron,
-/obj/item/clothing/neck/roguetown/chaincoif/iron,
-/obj/item/clothing/neck/roguetown/chaincoif/iron,
-/obj/item/clothing/under/roguetown/chainlegs/iron,
-/obj/item/clothing/under/roguetown/chainlegs/iron,
-/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
-/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "gAZ" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 1
@@ -19871,9 +19950,13 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "gDG" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "gDJ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -19980,11 +20063,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/sewer)
 "gFm" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/under/town/basement/keep)
 "gFt" = (
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/rogue/herringbone,
@@ -20147,6 +20227,12 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter/mountains/decap)
+"gHr" = (
+/obj/structure/roguemachine/scomm{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "gHx" = (
 /obj/structure/fluff/railing/border{
 	dir = 5;
@@ -20469,21 +20555,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "gMS" = (
-/obj/structure/rack/rogue,
-/obj/item/quiver/arrows{
-	pixel_x = -2;
-	pixel_y = 1
-	},
-/obj/item/quiver/arrows{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/quiver/arrows{
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/canopy/booth/booth02,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "gMT" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/roguemachine/mail{
@@ -20577,6 +20651,12 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter)
+"gPF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "gPO" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt/road,
@@ -21161,8 +21241,10 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "haq" = (
-/obj/structure/feedinghole,
-/turf/open/floor/rogue/hexstone,
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "has" = (
 /obj/effect/decal/cobbleedge{
@@ -21535,9 +21617,13 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement)
 "hfn" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/obj/structure/closet/crate/chest/neu_fancy,
+/obj/item/roguecoin/gold/pile,
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 1
+	},
+/area/rogue/indoors/town/vault)
 "hft" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/beach)
@@ -21634,9 +21720,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
 "hhv" = (
-/obj/structure/flora/ausbushes,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle/blue{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/water/bath,
+/area/rogue/under/town/basement/keep)
 "hhG" = (
 /obj/item/roguestatue/iron,
 /obj/structure/table/wood,
@@ -21840,10 +21929,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "hkj" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "warehouse_shutter"
-	},
-/turf/open/floor/rogue/cobble,
+/obj/item/roguemachine/mastermail,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "hkm" = (
 /obj/structure/fluff/statue/gargoyle{
@@ -21966,16 +22053,11 @@
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "hmp" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/c{
+/obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "hmt" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/concrete,
@@ -21987,9 +22069,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "hmx" = (
-/obj/structure/foxpelt,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/turf/closed,
+/area/rogue/outdoors/town/roofs)
 "hmE" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -22070,13 +22151,16 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/dwarfin)
 "hof" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner,
-/area/rogue/outdoors/town/roofs)
-"hog" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cobbleedge,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
+"hog" = (
+/turf/open/floor/rogue/blocks/bluestone,
 /area/rogue/outdoors/exposed/town/keep)
 "hoo" = (
 /obj/structure/flora/rogueshroom{
@@ -22105,6 +22189,15 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin)
+"hpm" = (
+/obj/machinery/light/rogue/wallfire/candle/blue{
+	pixel_y = -32
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "hpr" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/cobble,
@@ -22136,11 +22229,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "hqc" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/town/basement/keep)
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/manor)
 "hqd" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -22381,9 +22475,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
 "hsS" = (
-/obj/structure/fluff/canopy/booth/booth02,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "hsX" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -22457,9 +22553,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "htV" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/metal/barograte,
+/area/rogue/outdoors/exposed/town/keep)
 "htY" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -22628,13 +22724,15 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/fishmandungeon)
 "hvV" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 8;
-	locked = 1;
-	lockid = "steward"
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/structure/mirror,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement/keep)
 "hvW" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -22888,6 +22986,15 @@
 "hzG" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
+"hzN" = (
+/obj/item/roguekey/vault,
+/obj/structure/closet/crate/roguecloset/lord{
+	lockid = "steward"
+	},
+/obj/item/roguekey/armory,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/manor)
 "hzR" = (
 /obj/item/natural/stone,
 /turf/open/water/ocean,
@@ -23108,14 +23215,8 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
 "hDh" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/obj/structure/fluff/littlebanners{
-	pixel_y = -6
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "hDr" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -23474,6 +23575,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"hJN" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "hKh" = (
 /obj/structure/bars/pipe{
 	dir = 9
@@ -23616,22 +23723,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"hMA" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
-	},
-/area/rogue/outdoors/town/roofs)
 "hMB" = (
-/obj/structure/stairs{
-	dir = 4
+/turf/closed/wall/mineral/rogue/pipe{
+	dir = 8;
+	icon_state = "iron_joint"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/walldeco/wantedposter,
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/manor)
 "hMD" = (
 /obj/item/natural/bone,
 /turf/open/floor/rogue/hexstone,
@@ -23728,6 +23825,12 @@
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement)
+"hOq" = (
+/obj/structure/table/wood{
+	icon_state = "map2"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "hOs" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/outdoors/town)
@@ -23746,11 +23849,14 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "hOT" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/halberd,
+/obj/item/rogueweapon/halberd{
+	pixel_x = -13;
+	pixel_y = -19
 	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "hOX" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -23784,8 +23890,19 @@
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "hPG" = (
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/town/roofs)
+/obj/item/candle/candlestick/silver/single/lit{
+	pixel_x = 9;
+	pixel_y = 10
+	},
+/obj/item/tablecloth/silk{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/under/town/basement/keep)
 "hPK" = (
 /obj/structure/chair/stool/rogue,
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -23804,7 +23921,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "hQj" = (
-/obj/machinery/light/rogue/torchholder/r,
+/obj/machinery/light/rogue/torchholder/c{
+	pixel_y = -32
+	},
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "hQq" = (
@@ -23944,6 +24063,18 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet/bogcaves)
+"hSu" = (
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/item/candle/yellow/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/item/candle/yellow/lit{
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "hSE" = (
 /obj/item/natural/bowstring,
 /turf/open/floor/rogue/concrete,
@@ -24022,12 +24153,17 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
 "hUf" = (
-/obj/machinery/light/rogue/firebowl/standing{
-	pixel_x = 8;
-	pixel_y = 2
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/basement)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "hUM" = (
 /mob/living/simple_animal/pet/cat/inn{
 	name = "Bintu"
@@ -24213,6 +24349,19 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dukecourt)
+"hXq" = (
+/obj/item/candle/skull/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = 11;
+	pixel_y = 1
+	},
+/obj/item/candle/yellow/lit{
+	pixel_x = -13;
+	pixel_y = 3
+	},
+/obj/machinery/light/rogue/wallfire/candle/floorcandle,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "hXs" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp,
@@ -24372,19 +24521,13 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "iaB" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/shirt/tunic/white,
-/obj/item/clothing/suit/roguetown/shirt/tunic/white,
-/obj/item/clothing/suit/roguetown/shirt/tunic/white,
-/obj/item/clothing/suit/roguetown/shirt/tunic/white,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/undies/bikini,
-/obj/item/undies/bikini,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "iaL" = (
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
@@ -24449,13 +24592,17 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "ibZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = "steward"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/walldeco/alarm{
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "ica" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
@@ -24537,15 +24684,10 @@
 	},
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ida" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
+/obj/structure/mineral_door/wood/fancywood{
+	name = "Sauna"
 	},
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 14;
-	pixel_x = 0
-	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "idh" = (
 /obj/effect/decal/cobbleedge{
@@ -24780,10 +24922,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "igz" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 4
-	},
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "igJ" = (
 /obj/structure/mineral_door/wood/window{
 	locked = 1;
@@ -24915,8 +25057,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "ijk" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/decostone/cand,
+/area/rogue/under/town/basement/keep)
 "ijo" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -25058,6 +25200,10 @@
 "iln" = (
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/carpet/lord/left,
+/area/rogue/indoors/town/manor)
+"ilr" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "ilx" = (
 /obj/structure/closet/crate/chest,
@@ -25290,6 +25436,10 @@
 	},
 /turf/open/floor/rogue/metal,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"ipx" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "ipy" = (
 /obj/structure/table/vtable/v2,
 /obj/item/clothing/neck/roguetown/psicross/pestra,
@@ -25671,13 +25821,8 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "ivq" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 12
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/turf/closed,
+/area/rogue/indoors/town/physician)
 "ivC" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/herringbone,
@@ -25785,24 +25930,8 @@
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/indoors/town/garrison)
 "ixs" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "garrison"
-	},
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/tabard/knight/guard,
-/obj/item/clothing/cloak/tabard/knight/guard,
-/obj/item/clothing/cloak/tabard/knight/guard,
-/obj/item/clothing/cloak/tabard/knight/guard,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/vault)
 "ixx" = (
 /turf/open/water/river{
 	dir = 4;
@@ -26066,14 +26195,16 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "iCz" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/halberd,
-/obj/item/rogueweapon/halberd{
-	pixel_x = -13;
-	pixel_y = -19
+/obj/structure/table/wood{
+	icon_state = "longtable_mid";
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "iCA" = (
 /obj/machinery/light/small{
 	color = "#b51d12";
@@ -26099,14 +26230,16 @@
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/outdoors/rtfield)
 "iCY" = (
-/obj/structure/fluff/railing/border{
+/obj/structure/bed/rogue/inn/double{
 	dir = 4
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/item/bedsheet/rogue/fabric_double,
+/obj/effect/landmark/start/apothecary,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/outdoors/town/roofs)
 "iCZ" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -26244,13 +26377,10 @@
 /area/rogue/indoors/town/shop)
 "iFA" = (
 /obj/machinery/light/rogue/wallfire{
-	pixel_x = 16;
-	pixel_y = 32
+	pixel_x = 32
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/turf/open/floor/rogue/wood/herringbone,
+/obj/effect/particle_effect/smoke,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "iFF" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -26312,9 +26442,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "iGT" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/stoneaxe/woodcut/steel,
+/obj/item/rogueweapon/stoneaxe/woodcut/steel{
+	pixel_x = -1;
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "iHa" = (
 /obj/machinery/light/rogue/smelter/great{
 	color = "#485775";
@@ -26375,10 +26510,6 @@
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
-"iHI" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/under/town/basement/keep)
 "iHM" = (
 /obj/structure/mineral_door/wood/violet{
 	locked = 1
@@ -26453,24 +26584,19 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/town)
 "iJi" = (
-/obj/structure/bookcase/random/archive,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/town/roofs)
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -10
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "iJp" = (
-/obj/item/candle/yellow/lit{
-	pixel_x = 4;
-	pixel_y = 5
+/obj/structure/stairs/stone/d{
+	dir = 8
 	},
-/obj/item/candle/yellow/lit{
-	pixel_x = -4;
-	pixel_y = -8
-	},
-/obj/item/candle/yellow/lit{
-	pixel_x = -11;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/turf/open/floor/rogue/tile/bfloorz,
+/area/rogue/under/town/basement/keep)
 "iJx" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
 /turf/open/floor/rogue/churchmarble,
@@ -26647,13 +26773,9 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "iLV" = (
-/obj/structure/closet/crate/chest/neu_fancy,
-/obj/item/roguecoin/gold/pile,
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
-/area/rogue/indoors/town/vault)
+/obj/structure/foxpelt,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "iLW" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -26730,13 +26852,12 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/woods)
 "iMQ" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 7;
+	pixel_x = 13
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "iMR" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -27100,13 +27221,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
 "iSQ" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
-/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
-/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
-/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "iSR" = (
 /obj/structure/stairs{
 	dir = 1
@@ -27215,11 +27335,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
 "iUW" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/stairs/fancy/r,
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/obj/item/kitchen/spoon/tin,
-/turf/open/floor/carpet/inn,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "iVn" = (
 /obj/structure/fluff/railing/border{
@@ -27815,23 +27935,21 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "jdv" = (
-/obj/structure/flora/roguegrass/bush,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/roguemachine/mail,
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "jdx" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/beach)
 "jdB" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "jdF" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -27930,9 +28048,13 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/cave/dukecourt)
 "jfm" = (
-/obj/structure/fluff/statue/knight/r,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/town)
 "jfu" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -28163,13 +28285,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "jiZ" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt{
-	pixel_x = 0;
-	pixel_y = 8
-	},
-/obj/structure/table/church/m,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "jja" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /obj/item/clothing/ring/silver,
@@ -28233,10 +28351,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "jkr" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "jkC" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -28286,11 +28403,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
 "jlB" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shield/tower/metal,
+/obj/item/rogueweapon/shield/buckler,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "jlI" = (
 /obj/effect/spawner/roguemap/stump,
 /obj/structure/fluff/railing/fence{
@@ -28324,11 +28441,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"jmj" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
 "jmp" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/naturalstone,
@@ -28454,9 +28566,14 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
 "jph" = (
-/obj/structure/roguemachine/vaultbank,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/vault)
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
+	},
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "jpn" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/carpet/lord/center/no_teleport,
@@ -28582,11 +28699,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
 "jrn" = (
-/obj/structure/table/wood{
-	icon_state = "map6"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town/roofs/keep)
 "jrv" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -28655,13 +28770,25 @@
 	},
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/under/cave/licharena)
+"jsx" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n";
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "jsA" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "jsG" = (
-/obj/structure/stairs/stone/d{
-	dir = 8
+/obj/structure/mineral_door/wood{
+	name = "Bath";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
@@ -28784,12 +28911,6 @@
 "juE" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/cave)
-"juI" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/indoors/town/vault)
 "jvc" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/greenstone,
@@ -28924,9 +29045,11 @@
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "jxC" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "jxK" = (
 /obj/structure/chair/wood/rogue/chair4,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -29063,11 +29186,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "jAe" = (
-/obj/structure/fluff/littlebanners{
-	pixel_y = -6
-	},
-/turf/open/floor/rogue/rooftop/green,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "jAo" = (
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/naturalstone,
@@ -29091,9 +29212,15 @@
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/under/cave/skeletoncrypt)
 "jAV" = (
-/obj/structure/fluff/walldeco/customflag,
-/turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/roguecloset,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "jBj" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/carpet/red,
@@ -29128,10 +29255,6 @@
 /mob/living/carbon/human/species/elf/dark/drowraider,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"jBH" = (
-/obj/structure/fluff/walldeco/steward,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
 "jCd" = (
 /obj/structure/vine,
 /turf/open/water/swamp/deep,
@@ -29167,10 +29290,6 @@
 /obj/item/natural/rock/salt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"jCA" = (
-/obj/item/roguemachine/mastermail,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
 "jCB" = (
 /obj/structure/hotspring/border/eight,
 /turf/open/floor/rogue/grass,
@@ -29350,27 +29469,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/under/cave/dukecourt)
-"jGc" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
-	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "jGd" = (
 /obj/structure/fluff/pillow/magenta,
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
-"jGg" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
-	dir = 7
-	},
-/area/rogue/indoors/town/manor)
 "jGj" = (
 /obj/structure/fermentation_keg/hagwoodbitter,
 /turf/open/floor/rogue/blocks,
@@ -29442,6 +29544,12 @@
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"jHu" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/manor)
 "jHx" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -29590,14 +29698,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "jKf" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/mineral_door/wood/donjon{
+	locked = 1;
+	lockid = "steward";
+	name = "Stewardry Office"
 	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/inn,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "jKh" = (
 /obj/item/reagent_containers/food/snacks/crow{
@@ -29831,12 +29937,10 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "jOP" = (
-/obj/machinery/light/rogue/firebowl/standing{
-	pixel_x = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/basement)
+/obj/structure/chair/bench/couchablack,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/under/town/basement/keep)
 "jPe" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -29853,11 +29957,41 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "jPl" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/cloth{
+	pixel_x = -2;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/obj/item/natural/cloth{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/natural/cloth{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/natural/cloth{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/natural/cloth{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/natural/cloth{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/soap/bath{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/soap/bath{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "jPs" = (
 /obj/machinery/light/roguestreet{
 	dir = 1
@@ -29931,10 +30065,17 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "jQJ" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 8;
-	locked = 1;
-	lockid = "garrison"
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/obj/structure/rack/rogue/shelf,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = -5;
+	pixel_y = 39
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 7;
+	pixel_y = 39
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -30213,6 +30354,10 @@
 /obj/machinery/light/rogue/cauldron,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cave/skeletoncrypt)
+"jVS" = (
+/obj/structure/bookcase/random/archive,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/town/roofs)
 "jVU" = (
 /obj/effect/decal/remains/human,
 /obj/structure/fluff/walldeco/chains{
@@ -30445,17 +30590,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains/decap)
 "kac" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "kan" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -30556,8 +30693,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kbS" = (
-/turf/open/floor/rogue/church,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "kbV" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/herb/salvia,
@@ -30613,6 +30756,16 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"kcF" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "kcL" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cave/skeletoncrypt)
@@ -30883,6 +31036,10 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
+"khj" = (
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "khy" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -30950,12 +31107,22 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kiz" = (
-/turf/open/floor/rogue/hexstone,
+/obj/structure/stairs/stone/d{
+	dir = 1
+	},
+/obj/structure/stairs/stone/d,
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "kiD" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/skeletoncrypt)
+"kiE" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "kiK" = (
 /obj/item/natural/stone{
 	pixel_y = -14
@@ -31174,6 +31341,9 @@
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
+"kmv" = (
+/turf/closed/wall/mineral/rogue/pipe,
+/area/rogue/indoors/town/manor)
 "kmz" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -31359,16 +31529,11 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
 "kqG" = (
-/obj/item/candle/yellow/lit{
-	pixel_x = 19;
-	pixel_y = -1
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
 	},
-/obj/machinery/light/rogue/firebowl/standing{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/basement)
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "kqL" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -31499,10 +31664,9 @@
 "ktO" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8;
-	pixel_x = -10;
-	pixel_y = 4
+	pixel_x = -8;
+	pixel_y = 8
 	},
-/obj/structure/roguemachine/scomm/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
 "ktV" = (
@@ -31934,14 +32098,13 @@
 /area/rogue/under/cave/goblinfort)
 "kAv" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1"
+	dir = 2;
+	icon_state = "longtable"
 	},
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/structure/mirror,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "kAx" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
@@ -31956,9 +32119,12 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/shelter/mountains/decap)
 "kAF" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/mineral_door/wood/donjon{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "kAI" = (
 /obj/structure/rack/rogue/shelf,
 /obj/item/reagent_containers/glass/cup/wooden{
@@ -32636,11 +32802,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "kMx" = (
-/obj/machinery/light/rogue/torchholder/c{
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "kMF" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
@@ -32935,8 +33104,9 @@
 	},
 /area/rogue/indoors/town/dwarfin)
 "kRO" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/blocks,
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "kRY" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -33099,12 +33269,12 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
 "kUH" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/effect/decal/cobbleedge{
+	dir = 7;
+	pixel_x = 13
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "kUI" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -33388,10 +33558,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains/decap)
 "laf" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/tile/bfloorz,
+/area/rogue/under/town/basement/keep)
 "lal" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -33434,8 +33605,18 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
 "laF" = (
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/closet/crate/roguecloset{
+	name = "Ropes and Chains"
+	},
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rogueweapon/whip,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "laK" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/remains/human,
@@ -33543,8 +33724,11 @@
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
 "lcZ" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/herringbone,
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 32
+	},
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "ldf" = (
 /obj/structure/closet/crate/chest/lootbox,
@@ -33947,15 +34131,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "lkJ" = (
-/obj/structure/table/wood{
-	icon_state = "map4"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/beer/voddena{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "lkT" = (
 /obj/structure/closet/crate/drawer,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -34032,10 +34212,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "llF" = (
-/obj/structure/closet/crate/chest/neu_fancy,
-/obj/item/roguecoin/silver/pile,
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/vault)
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "llI" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
@@ -34101,10 +34280,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "lmP" = (
-/obj/structure/stairs/stone{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/fabric_double,
+/obj/effect/landmark/start/clerk,
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "lmV" = (
 /obj/effect/decal/cobbleedge{
@@ -34132,11 +34311,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "lnu" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "lnx" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -34233,11 +34412,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/skeletoncrypt)
 "loz" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_line"
 	},
-/turf/open/water/bath,
-/area/rogue/under/town/basement/keep)
+/area/rogue/indoors/town/manor)
 "loC" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -34402,18 +34580,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/underdark)
-"lqY" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 1;
-	locked = 1;
-	lockid = "steward"
-	},
-/obj/structure/fluff/walldeco/alarm{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
 "lrc" = (
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/indoors/shelter)
@@ -34994,14 +35160,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/shop)
 "lAt" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "lAw" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/ocean/deep,
@@ -35013,15 +35176,19 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
 "lAF" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/obj/effect/decal/cobbleedge,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/pillory/reinforced{
+	lockid = list("garrison")
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "lAO" = (
 /obj/structure/roguemachine/bounty,
 /turf/open/floor/rogue/concrete,
@@ -35180,11 +35347,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
 "lDn" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/structure/table/wood{
+	icon_state = "map1"
+	},
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "lDp" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/head/roguetown/helmet,
@@ -35333,10 +35504,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "lGl" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
+	dir = 1
 	},
-/area/rogue/outdoors/town/roofs)
+/area/rogue/indoors/town/manor)
 "lGp" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -35657,11 +35828,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "lLV" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/fluff/walldeco/steward{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "lLY" = (
 /obj/structure/table/vtable/v2,
 /obj/item/candle/skull,
@@ -35855,9 +36026,14 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter)
 "lPk" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/obj/structure/stairs{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/bfloorz,
+/area/rogue/under/town/basement/keep)
 "lPm" = (
 /obj/structure/stairs{
 	dir = 1
@@ -35916,6 +36092,12 @@
 /obj/effect/decal/wood/herringbone2,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/shelter/woods)
+"lQz" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/tile/bfloorz,
+/area/rogue/under/town/basement/keep)
 "lQB" = (
 /obj/structure/flora/roguegrass/herb/salvia,
 /obj/structure/flora/roguegrass,
@@ -36000,14 +36182,22 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
 "lSh" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
-"lSo" = (
-/obj/structure/chair/bench/couchablack,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
+"lSo" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "lSt" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -36105,11 +36295,14 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "lVB" = (
-/obj/structure/stairs/stone/d{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "lVE" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/ambush,
@@ -36139,6 +36332,18 @@
 /obj/effect/decal/remains/mole,
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap)
+"lWn" = (
+/obj/structure/mannequin,
+/obj/item/clothing/suit/roguetown/armor/leather/studded{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/roguetown/helmet/kettle{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "lWp" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cave/orcdungeon)
@@ -36291,9 +36496,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/magician)
 "lZz" = (
-/obj/structure/fluff/walldeco/stone,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town/manor)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town/vault)
 "lZA" = (
 /obj/structure/meathook,
 /obj/effect/decal/cleanable/blood,
@@ -36413,9 +36617,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "mbG" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/metal/barograte,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/handcart,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "mbI" = (
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /obj/structure/closet/crate/roguecloset,
@@ -36442,10 +36647,17 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "mca" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4;
+	icon_state = "wooddir"
 	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
+"mcc" = (
+/obj/structure/stairs/stone{
+	dir = 8
+	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "mcl" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -36489,17 +36701,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet/bogcaves)
 "mcU" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/obj/structure/flora/roguegrass,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/roguemachine/steward,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "mcY" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -36806,9 +37010,9 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "mhx" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks/bluestone,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/chair/bench/church,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/basement)
 "mhy" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road,
@@ -36896,12 +37100,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "mjw" = (
-/obj/structure/fluff/statue/astrata/gold{
-	pixel_x = -18;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/turf/closed/wall/mineral/rogue/roofwall/innercorner,
+/area/rogue/outdoors/town/roofs)
 "mjz" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -36945,11 +37145,9 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
 "mkj" = (
-/obj/structure/floordoor/gatehatch/outer{
-	redstone_id = "wallbridge"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "mkn" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt/road,
@@ -37068,8 +37266,12 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/goblinfort)
 "mmb" = (
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/vault)
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/garrison)
 "mmd" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -37208,6 +37410,14 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"mpa" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mpo" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -37304,10 +37514,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/skeletoncrypt)
 "mqT" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
-	},
-/area/rogue/outdoors/town/roofs)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/tile/tilerg,
+/area/rogue/outdoors/exposed/town/keep)
 "mqV" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/manorguardsman,
@@ -37928,9 +38137,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/magician)
 "mCr" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/structure/closet/crate/chest/neu,
+/obj/item/clothing/shoes/roguetown/boots/armor/iron,
+/obj/item/clothing/shoes/roguetown/boots/armor/iron,
+/obj/item/clothing/gloves/roguetown/angle,
+/obj/item/clothing/gloves/roguetown/angle,
+/obj/item/clothing/shoes/roguetown/boots/leather/atgervi,
+/obj/item/clothing/shoes/roguetown/boots/leather/atgervi,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "mCs" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt,
@@ -37964,9 +38179,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
 "mDc" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town/roofs/keep)
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
+	},
+/area/rogue/indoors/town/vault)
 "mDm" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
@@ -38060,11 +38276,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
 "mFr" = (
-/obj/structure/floordoor/gatehatch/inner{
-	redstone_id = "wallbridge"
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "mFt" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -38189,9 +38405,10 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "mHf" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
-	dir = 4
-	},
+/obj/structure/table/wood,
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "mHg" = (
 /obj/structure/mineral_door/wood{
@@ -38296,14 +38513,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "mIU" = (
-/obj/item/roguekey/vault,
-/obj/structure/closet/crate/roguecloset/lord{
-	lockid = "steward"
-	},
-/obj/item/roguekey/armory,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/basement)
 "mJc" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/floor/rogue/dirt,
@@ -38680,14 +38891,8 @@
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "mON" = (
-/obj/structure/lever/wall{
-	dir = 5;
-	redstone_id = "stewardshutter";
-	pixel_x = 16;
-	pixel_y = 1
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/hexstone,
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "mOX" = (
 /obj/structure/table/church,
@@ -38745,8 +38950,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
 "mPH" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/herringbone,
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
 "mPL" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -38990,12 +39195,6 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
-"mUN" = (
-/turf/closed/wall/mineral/rogue/pipe{
-	dir = 8;
-	icon_state = "iron_joint"
-	},
-/area/rogue/indoors/town/manor)
 "mUP" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -39211,12 +39410,8 @@
 	},
 /area/rogue/indoors/town/manor)
 "mXZ" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	pixel_x = 7;
-	pixel_y = 2
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/rogue/trophy/deer,
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "mYm" = (
 /obj/structure/flora/roguegrass,
@@ -39274,6 +39469,18 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town)
+"mYX" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = 1
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "mYZ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -39331,21 +39538,23 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "nan" = (
-/obj/structure/closet/crate/chest/neu_fancy,
-/obj/item/roguecoin/silver/pile,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
-/area/rogue/indoors/town/vault)
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "nar" = (
 /turf/open/water/swamp/deep,
 /area/rogue/indoors/cave)
 "nat" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n"
+	dir = 8
 	},
-/obj/effect/decal/cobbleedge,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/closet/crate/chest/wicker,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "nay" = (
 /obj/structure/stairs/stone{
@@ -39492,13 +39701,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
-"ncQ" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = 32
-	},
-/obj/effect/particle_effect/smoke,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
 "ncY" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -39507,12 +39709,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"ncZ" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = 32
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
 "ndb" = (
 /obj/structure/bars/passage/shutter{
 	max_integrity = 15000;
@@ -39928,15 +40124,9 @@
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "njb" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/natural/bundle/stick,
-/obj/item/natural/bundle/stick,
+/obj/structure/roguemachine/vaultbank,
 /turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/area/rogue/indoors/town/vault)
 "njj" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -40180,12 +40370,18 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "nnb" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
-	},
-/turf/open/floor/rogue/hexstone,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/undies/bikini,
+/obj/item/undies/bikini,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "nni" = (
 /obj/effect/decal/mossy{
@@ -40229,12 +40425,12 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
 "nnL" = (
-/obj/structure/fluff/railing/border,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "nnM" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -40639,11 +40835,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "nvU" = (
-/obj/structure/bars{
-	color = "#755f48";
-	name = "rusted bars"
-	},
-/turf/open/floor/rogue/blocks/green,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
 /area/rogue/under/town/basement/keep)
 "nwa" = (
 /obj/effect/landmark/start/wapprentice,
@@ -41494,17 +41687,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "nKF" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/leather/studded,
-/obj/item/clothing/suit/roguetown/armor/leather/studded,
-/obj/item/clothing/suit/roguetown/armor/leather/studded/bikini,
-/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced,
-/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced,
-/obj/item/clothing/wrists/roguetown/bracers/leather,
-/obj/item/clothing/wrists/roguetown/bracers/leather,
-/obj/item/clothing/wrists/roguetown/bracers/leather,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "nKL" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -41716,8 +41902,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "nOC" = (
-/turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/indoors/town/garrison)
+/obj/structure/roguewindow,
+/obj/structure/fluff/statue/knightalt,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/dwarfin)
 "nOD" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grassyel,
@@ -42065,11 +42253,16 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "nTv" = (
-/obj/structure/table/wood,
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/manor)
+/obj/structure/floordoor/gatehatch/inner{
+	redstone_id = "wallbridge"
+	},
+/obj/structure/kybraxor{
+	pixel_x = -32;
+	pixel_y = -32;
+	redstone_id = "wallbridge"
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "nTw" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -42398,21 +42591,12 @@
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/town/roofs/keep)
 "nZB" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/gwstrap{
-	pixel_x = -12;
-	pixel_y = 13
+/obj/structure/closet/crate/chest/neu_fancy,
+/obj/item/roguecoin/silver/pile,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 1
 	},
-/obj/item/gwstrap{
-	pixel_x = -19;
-	pixel_y = 16
-	},
-/obj/item/gwstrap{
-	pixel_x = -15;
-	pixel_y = 16
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/area/rogue/indoors/town/vault)
 "nZD" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
@@ -42426,12 +42610,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
 "nZP" = (
-/obj/effect/decal/cobbleedge{
-	dir = 7;
-	pixel_x = 13
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs/keep)
 "nZS" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -42570,12 +42751,11 @@
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town)
 "ocm" = (
-/obj/machinery/light/rogue/lanternpost,
-/obj/effect/decal/cobbleedge{
-	dir = 9
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
 	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "oco" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/blocks,
@@ -42664,12 +42844,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "oee" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "oef" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/fabric,
@@ -42919,9 +43096,10 @@
 /turf/open/floor/rogue/carpet/lord/center/no_teleport,
 /area/rogue/under/cave/licharena)
 "oic" = (
-/obj/structure/chair/bench/ultimacouch/r,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 4
+	},
+/area/rogue/outdoors/town/roofs)
 "oih" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/carpet,
@@ -43023,11 +43201,11 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/cave/orcdungeon)
 "ojQ" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/manor)
+/area/rogue/indoors/town/vault)
 "okc" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/rogue/dirt/road,
@@ -43297,14 +43475,11 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cavewet/bogcaves)
 "orR" = (
-/obj/item/roguecoin/gold/pile,
-/obj/structure/fluff/walldeco/painting{
-	pixel_y = 32
+/obj/structure/roguemachine/scomm{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
-/area/rogue/indoors/town/vault)
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/outdoors/town/roofs)
 "orS" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -43691,18 +43866,12 @@
 /turf/open/water/swamp,
 /area/rogue/under/cave/goblindungeon)
 "oyV" = (
-/obj/item/candle/skull/lit,
-/obj/item/candle/yellow/lit{
-	pixel_x = 11;
-	pixel_y = 1
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
 	},
-/obj/item/candle/yellow/lit{
-	pixel_x = -13;
-	pixel_y = 3
-	},
-/obj/machinery/light/rogue/wallfire/candle/floorcandle,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "oyW" = (
 /mob/living/carbon/human/species/dwarfskeleton/ambush,
 /turf/open/floor/rogue/hexstone,
@@ -43844,8 +44013,19 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "oBL" = (
-/turf/closed/wall/mineral/rogue/pipe,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/effect/decal/cobbleedge{
+	icon_state = "borderfall";
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "oBN" = (
 /obj/structure/floordoor/open{
 	name = "Dwarven Bridge";
@@ -43953,8 +44133,14 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "oDj" = (
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/garrison)
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/exposed/town/keep)
 "oDn" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -44298,8 +44484,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "oJT" = (
-/turf/open/lava/acid,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/statue/astrata/gold{
+	pixel_x = -18;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "oJW" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
@@ -44579,9 +44769,12 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "oPf" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/carpet/red,
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "steward";
+	name = "Steward's Bedroom"
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "oPj" = (
 /obj/structure/spider/stickyweb/mirespider,
@@ -44731,9 +44924,13 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "oRZ" = (
-/obj/structure/roguemachine/stockpile,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "oSd" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
@@ -44787,17 +44984,13 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/mountains/decap)
 "oSS" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 8
 	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "oSW" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -44838,13 +45031,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"oTN" = (
-/obj/machinery/light/rogue/firebowl/standing/blue{
-	pixel_x = 0;
-	pixel_y = 10
-	},
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/under/town/basement/keep)
 "oTQ" = (
 /obj/item/reagent_containers/food/snacks/rogue/crackerscooked{
 	pixel_x = 6;
@@ -44915,14 +45101,16 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
 "oVj" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cobbleedge,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/fishingrod/crafted,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "oVl" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/blocks/platform,
@@ -44976,11 +45164,12 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "oWi" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5;
-	pixel_x = -6
+/obj/machinery/light/rogue/torchholder/c{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/cobblerock,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "oWr" = (
 /obj/structure/roguewindow,
@@ -45014,11 +45203,21 @@
 	},
 /area/rogue/under/cave/dukecourt)
 "oWO" = (
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roof";
+/obj/structure/table/wood{
+	icon_state = "longtable";
 	dir = 1
 	},
-/area/rogue/outdoors/town/roofs/keep)
+/obj/item/cooking/platter/silver,
+/obj/item/kitchen/fork/silver{
+	pixel_x = 12;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = -13;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "oXa" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -45126,14 +45325,9 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
 "oYo" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace,
-/obj/item/rogueweapon/mace{
-	pixel_x = 2;
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "oYq" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/fluff/railing/border,
@@ -45394,6 +45588,7 @@
 "pcI" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "pcQ" = (
@@ -45491,10 +45686,7 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
 "pel" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/churchrough,
+/turf/closed/wall/mineral/rogue/roofwall/middle,
 /area/rogue/indoors/town/manor)
 "pem" = (
 /obj/structure/flora/newbranch/leafless{
@@ -45983,8 +46175,15 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "pnA" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/blocks,
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/silver/lit,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 10;
+	pixel_y = -70
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
 "pnE" = (
 /obj/structure/composter/full,
@@ -46140,16 +46339,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "pqR" = (
-/obj/structure/roguemachine/steward,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
-"pqT" = (
-/obj/structure/bars/tough,
-/obj/structure/roguewindow/harem2{
-	density = 0
-	},
-/turf/open/floor/rogue/metal/barograte,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/wooddark/horizontal,
+/area/rogue/indoors/town/garrison)
 "prg" = (
 /mob/living/simple_animal/hostile/rogue/haunt,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -46172,12 +46363,14 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
 "prx" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5;
-	pixel_x = -6
+/obj/structure/fluff/statue/tdummy,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "prC" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -46501,11 +46694,18 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
 "pxW" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword,
+/obj/item/rogueweapon/sword{
+	pixel_x = -3;
+	pixel_y = 1
 	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/town/roofs)
+/obj/item/rogueweapon/sword{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "pxX" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -46791,14 +46991,9 @@
 /area/rogue/indoors/town)
 "pBH" = (
 /obj/effect/decal/cobbleedge{
-	dir = 8
+	dir = 5;
+	pixel_x = -6
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/obj/structure/closet/crate/chest/wicker,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "pBL" = (
@@ -46831,10 +47026,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "pCd" = (
-/obj/structure/roguewindow/openclose/reinforced{
+/turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "pCk" = (
 /obj/structure/stairs{
@@ -46977,17 +47171,14 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "pEB" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
-/obj/item/quiver/sling/iron,
-/obj/item/quiver/sling/iron,
-/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
-/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "pEO" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/outdoors/mountains)
@@ -46998,11 +47189,14 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/town)
 "pFh" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = 32
+/obj/structure/lever/wall{
+	pixel_x = 32;
+	redstone_id = "warehouse_shutter"
 	},
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/rogue/church,
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "pFn" = (
 /obj/structure/roguewindow,
@@ -47170,7 +47364,8 @@
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/manor)
 "pIv" = (
-/turf/closed/wall/mineral/rogue/craftstone,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/bluestone,
 /area/rogue/outdoors/exposed/town/keep)
 "pIB" = (
 /obj/structure/table/wood{
@@ -47252,12 +47447,10 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
 "pJG" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/lanternpost{
-	dir = 1
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 4
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/indoors/town/manor)
 "pJJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -47347,17 +47540,18 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "pKR" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/structure/stairs/stone{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "pKZ" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "pLb" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/manor)
+/turf/closed,
+/area/rogue/under/cave)
 "pLc" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/hexstone,
@@ -47433,15 +47627,15 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/goblinfort)
 "pMW" = (
-/obj/structure/lever/wall{
-	pixel_x = 32;
-	redstone_id = "warehouse_shutter"
+/obj/structure/mineral_door/wood/donjon{
+	dir = 8;
+	locked = 1;
+	lockid = "garrison"
 	},
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/area/rogue/indoors/town/garrison)
 "pNg" = (
 /mob/living/carbon/human/species/dwarfskeleton/ambush,
 /obj/effect/decal/cobbleedge{
@@ -47759,15 +47953,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
 "pSy" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/natural/feather{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/town/basement/keep)
+/obj/structure/chair/wood/rogue/chair3,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "pSM" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grassred,
@@ -47964,9 +48152,11 @@
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
 "pWB" = (
-/obj/structure/fluff/statue/knight,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/town/roofs)
 "pWJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -47985,9 +48175,9 @@
 /area/rogue/outdoors/town)
 "pWX" = (
 /obj/structure/fluff/railing/border{
-	dir = 6
+	dir = 10
 	},
-/turf/open/floor/rogue/tile/bfloorz,
+/turf/open/water/bath,
 /area/rogue/under/town/basement/keep)
 "pWZ" = (
 /obj/structure/fluff/railing/border{
@@ -48175,7 +48365,12 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
 "pZw" = (
-/turf/closed/mineral/rogue/bedrock,
+/obj/item/tablecloth/silk{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile/bath,
 /area/rogue/under/town/basement/keep)
 "pZS" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -48204,9 +48399,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "qad" = (
-/obj/structure/toilet,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "qaf" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/orcdungeon)
@@ -48264,12 +48459,18 @@
 /area/rogue/outdoors/mountains)
 "qbr" = (
 /obj/structure/table/wood{
-	icon_state = "map5"
+	icon_state = "longtable"
 	},
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/item/reagent_containers/glass/cup/golden{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/beer/stonebeardreserve{
+	pixel_x = 13;
+	pixel_y = 11
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "qbz" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/item/roguecoin/gold,
@@ -48400,12 +48601,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
 "qdH" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "steward";
-	name = "Stewardry Office"
-	},
-/turf/open/floor/rogue/wood,
+/obj/structure/chair/bench/ultimacouch/r,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "qdI" = (
 /obj/structure/fluff/railing/border,
@@ -48597,12 +48794,9 @@
 /area/rogue/under/cave/orcdungeon)
 "qgS" = (
 /obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
+	icon_state = "cobbleedge-n"
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
+/obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "qha" = (
@@ -49227,7 +49421,15 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
 "qrX" = (
-/turf/closed/wall/mineral/rogue/craftstone,
+/obj/item/roguegem/blue,
+/obj/item/roguegem/green,
+/obj/item/roguegem/yellow,
+/obj/item/roguegem/violet,
+/obj/item/roguegem/ruby,
+/obj/item/roguegem/ruby,
+/obj/structure/closet/crate/chest/neu_fancy,
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/vault)
 "qrY" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -49422,10 +49624,19 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves)
 "qvp" = (
-/obj/structure/roguemachine/noticeboard,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "qvr" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road,
@@ -49796,7 +50007,11 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/dwarfin)
 "qBO" = (
-/turf/open/floor/carpet/inn,
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/basement)
 "qBP" = (
 /obj/structure/flora/roguegrass/water,
@@ -50096,9 +50311,14 @@
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/under/cave)
 "qHm" = (
-/obj/effect/landmark/start/steward,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/flail,
+/obj/item/rogueweapon/flail{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "qHt" = (
 /obj/item/storage/bag/tray{
 	pixel_y = 32
@@ -50642,16 +50862,8 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/licharena)
 "qQj" = (
-/obj/item/roguegem/blue,
-/obj/item/roguegem/green,
-/obj/item/roguegem/yellow,
-/obj/item/roguegem/violet,
-/obj/item/roguegem/ruby,
-/obj/item/roguegem/ruby,
-/obj/structure/closet/crate/chest/neu_fancy,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/vault)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/garrison)
 "qQm" = (
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
@@ -50799,17 +51011,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/shop)
 "qSC" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/obj/item/candle/yellow/lit,
-/obj/item/candle/yellow/lit{
-	pixel_x = -6;
-	pixel_y = 12
-	},
-/obj/item/candle/yellow/lit{
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/basement)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "qSD" = (
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/herringbone,
@@ -51051,8 +51255,14 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "qXJ" = (
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/effect/decal/cobbleedge,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "qXR" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -51207,8 +51417,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "qZN" = (
-/turf/open/floor/rogue/tile/tilerg,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/lava/acid,
+/area/rogue/under/town/basement/keep)
 "raa" = (
 /obj/item/natural/worms/leech{
 	pixel_x = 5
@@ -51624,25 +51834,6 @@
 /obj/structure/flora/mushroomcluster,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"rgY" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = 8
-	},
-/obj/item/kitchen/spoon/gold{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/manor)
-"rhf" = (
-/obj/structure/fluff/littlebanners{
-	pixel_y = -6
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs/keep)
 "rhD" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/mineral_door/wood/donjon/stone/broken,
@@ -51735,9 +51926,12 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "rjK" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/lanternpost,
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "rjO" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sickle/copper,
@@ -51774,17 +51968,13 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
 "rkS" = (
-/obj/structure/table/wood,
-/obj/item/clothing/mask/cigarette/rollie/nicotine{
-	pixel_x = 7;
-	pixel_y = 0
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 4
 	},
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/item/clothing/mask/cigarette/rollie/nicotine/cheroot{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/turf/open/floor/rogue/tile/bath,
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
 "rkT" = (
 /obj/structure/table/wood{
@@ -51806,13 +51996,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "rlj" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/obj/structure/fermentation_keg/water,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rlk" = (
 /obj/machinery/light/rogue/wallfire/candle/off/r,
 /obj/effect/decal/cobbleedge{
@@ -51835,12 +52026,6 @@
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
-"rlE" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/exposed/town/keep)
 "rlH" = (
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/churchmarble,
@@ -51986,17 +52171,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
 "rnI" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/obj/structure/flora/roguegrass,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/outdoors/town/roofs)
 "rnN" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -52190,12 +52366,6 @@
 "rqY" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/bath)
-"rrn" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/effect/landmark/start/clerk,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/manor)
 "rrq" = (
 /mob/living/carbon/human/species/human/northern/searaider/ambush,
 /turf/open/floor/rogue/naturalstone,
@@ -52283,9 +52453,13 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/basement)
 "rtc" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/torchholder/c{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/under/town/basement/keep)
 "rth" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/carpet/red,
@@ -52342,9 +52516,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
 "rtL" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "rtM" = (
 /turf/open/floor/rogue/grass,
@@ -52497,9 +52672,7 @@
 /area/rogue/under/cave/dukecourt)
 "rwM" = (
 /obj/structure/floordoor{
-	redstone_id = "thronegrille";
-	icon = 'icons/turf/roguefloor.dmi';
-	icon_state = "carpet_c"
+	redstone_id = "thronegrille"
 	},
 /obj/structure/chair/wood/rogue,
 /turf/open/transparent/openspace,
@@ -52936,8 +53109,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "rDO" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grassyel,
+/turf/open/floor/rogue/tile/tilerg,
 /area/rogue/outdoors/exposed/town/keep)
 "rEo" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -53063,10 +53235,10 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/beach)
 "rGx" = (
-/obj/structure/table/wood{
-	icon_state = "map2"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/water/bath,
 /area/rogue/under/town/basement/keep)
 "rGA" = (
 /obj/structure/flora/roguegrass,
@@ -53318,11 +53490,16 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
 "rLn" = (
-/obj/structure/closet/crate/drawer,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/turf/open/floor/rogue/tile,
+/obj/structure/closet/crate/chest/neu,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/quiver/sling/iron,
+/obj/item/quiver/sling/iron,
+/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
+/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "rLp" = (
 /obj/item/restraints/legcuffs/beartrap/armed,
@@ -53386,11 +53563,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
 "rLU" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/town/roofs)
 "rLW" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -53561,12 +53736,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "rPN" = (
-/obj/structure/floordoor{
-	redstone_id = "thronegrille";
-	icon = 'icons/turf/roguefloor.dmi';
-	icon_state = "carpet_c"
-	},
-/turf/open/transparent/openspace,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "rPT" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
@@ -53695,21 +53866,17 @@
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "rSH" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
-	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/church,
+/area/rogue/outdoors/exposed/town/keep)
 "rSJ" = (
-/obj/structure/closet/crate/chest,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/flint,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/basement)
+/obj/structure/closet/crate/roguecloset/crafted,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
+/obj/item/clothing/under/roguetown/skirt,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/manor)
 "rSK" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/clothing/cloak/matron,
@@ -53828,12 +53995,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
 "rTT" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/fluff/canopy/booth/booth02,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/garrison)
 "rTU" = (
 /obj/structure/table/wood{
 	icon_state = "largetable";
@@ -53843,13 +54010,13 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "rUb" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/chair/wood/rogue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "rUd" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -54299,8 +54466,11 @@
 	},
 /area/rogue/indoors/town)
 "scw" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle,
-/area/rogue/outdoors/town/roofs)
+/obj/machinery/light/rogue/wallfire/candle/blue{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "scE" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -54323,8 +54493,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
 "scT" = (
-/turf/closed,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/fluff/walldeco/stone,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/manor)
 "scU" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grassyel,
@@ -54446,12 +54617,22 @@
 /obj/structure/mineral_door/wood/donjon/stone/broken,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"sfj" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/under/town/basement/keep)
 "sfH" = (
-/obj/structure/roguemachine/mail,
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+/obj/structure/mineral_door/wood{
+	name = "Throne Room";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
 	},
-/turf/open/floor/rogue/hexstone,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "sfM" = (
 /obj/structure/fluff/railing/border{
@@ -54463,6 +54644,20 @@
 /obj/structure/roguewindow/stained/zizo,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/shelter/mountains/decap)
+"sfS" = (
+/obj/item/candle/yellow/lit{
+	pixel_x = -70;
+	pixel_y = 47
+	},
+/obj/item/candle/yellow/lit{
+	pixel_x = -14;
+	pixel_y = 41
+	},
+/obj/structure/table/church{
+	icon_state = "churchtable_end"
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "sgd" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/sword,
@@ -54536,6 +54731,9 @@
 	},
 /area/rogue/indoors/town/dwarfin)
 "shc" = (
+/obj/structure/bars/passage/shutter/open{
+	redstone_id = "stewardshutter"
+	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/exposed/town/keep)
 "shf" = (
@@ -54627,13 +54825,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "siF" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/under/town/basement/keep)
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/town/roofs)
 "siI" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = -32
@@ -54784,13 +54978,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
 "skw" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
 /obj/effect/decal/cobbleedge{
-	dir = 4
+	dir = 5
 	},
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/fluff/canopy/booth/booth02,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "skz" = (
 /obj/structure/table/wood{
@@ -54966,11 +55158,12 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/sewer)
 "smR" = (
-/obj/structure/chair/wood/rogue/chair3{
+/obj/effect/decal/cobbleedge{
 	dir = 8
 	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "smS" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/dirt,
@@ -54985,13 +55178,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "smZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "sna" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 4
@@ -55744,11 +55933,16 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "syb" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/flora/roguegrass/bush,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "syc" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -55789,19 +55983,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "syz" = (
-/obj/structure/flora/roguegrass/bush{
-	pixel_x = 5;
-	pixel_y = 0
+/obj/structure/kybraxor{
+	pixel_x = -32;
+	pixel_y = -32
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "syA" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -55840,14 +56027,20 @@
 /turf/closed,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "szy" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/structure/closet/crate/roguecloset{
+	name = "Chainmail"
 	},
-/obj/structure/fluff/littlebanners{
-	pixel_y = -6
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
+/obj/item/clothing/gloves/roguetown/chain/iron,
+/obj/item/clothing/gloves/roguetown/chain/iron,
+/obj/item/clothing/neck/roguetown/chaincoif/iron,
+/obj/item/clothing/neck/roguetown/chaincoif/iron,
+/obj/item/clothing/under/roguetown/chainlegs/iron,
+/obj/item/clothing/under/roguetown/chainlegs/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "szF" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
@@ -56305,10 +56498,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "sKU" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/church,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "sKW" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -56520,11 +56711,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "sOa" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+/obj/structure/chair/bench/church/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/basement)
 "sOc" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -56771,18 +56960,27 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "sRD" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
+/turf/closed/wall/mineral/rogue/roofwall/middle{
+	dir = 4
 	},
-/area/rogue/indoors/town/vault)
+/area/rogue/indoors/town/manor)
 "sRJ" = (
-/turf/open/floor/rogue/concrete,
+/obj/structure/stairs/fancy/l,
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "sRL" = (
 /mob/living/carbon/human/species/goblin/npc/ambush/sea,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
+"sRO" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "sRR" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/hay,
@@ -57066,11 +57264,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "sXr" = (
-/obj/structure/stairs/stone{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/wooddark/vertical,
+/area/rogue/indoors/town/garrison)
 "sXv" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobblerock,
@@ -57106,10 +57301,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/woods)
 "sXL" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
-	},
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "sXR" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/carpet/red,
@@ -57210,26 +57404,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "sZH" = (
-/obj/structure/mineral_door/wood{
-	name = "Throne Room";
-	icon_state = "wcv";
-	locked = 1;
-	lockid = "manor"
+/obj/item/roguecoin/gold/pile,
+/obj/structure/fluff/walldeco/painting/queen{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
-"sZI" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/roguegrass,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/indoors/town/vault)
 "sZK" = (
 /obj/item/kitchen/spoon,
 /obj/item/kitchen/rollingpin,
@@ -57290,16 +57472,11 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/tavern)
 "taV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 7;
-	pixel_x = 13
+/obj/structure/table/wood{
+	icon_state = "map6"
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "tbg" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/cave/goblindungeon)
@@ -57697,18 +57874,6 @@
 /obj/structure/mirror,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
-"thZ" = (
-/obj/structure/mannequin,
-/obj/item/clothing/suit/roguetown/armor/leather/studded{
-	pixel_x = 0;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/roguetown/helmet/kettle{
-	pixel_x = 0;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
 "tib" = (
 /obj/structure/fermentation_keg/beer,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -57835,8 +58000,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "tkB" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner,
-/area/rogue/outdoors/town/roofs)
+/obj/effect/decal/cobbleedge,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "tkE" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
@@ -57889,19 +58059,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "tlQ" = (
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = 9;
-	pixel_y = 10
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
-/obj/item/tablecloth/silk{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "tlS" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
@@ -58060,13 +58224,7 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/bog)
 "tod" = (
-/obj/structure/mineral_door/wood{
-	name = "Bath";
-	icon_state = "wcv";
-	locked = 1;
-	lockid = "manor"
-	},
-/turf/open/floor/rogue/church,
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
 /area/rogue/indoors/town/manor)
 "toh" = (
 /obj/structure/flora/roguegrass/bush/wall,
@@ -58109,14 +58267,20 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "toG" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/item/candle/yellow/lit{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/candle/yellow/lit{
+	pixel_x = -4;
+	pixel_y = -8
+	},
+/obj/item/candle/yellow/lit{
+	pixel_x = -11;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "toI" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/church,
@@ -58143,15 +58307,21 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "tpg" = (
-/obj/effect/decal/cobbleedge{
-	pixel_y = 1
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
+	dir = 1
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/indoors/town/manor)
 "tpj" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors)
+"tpk" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 10
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "tpm" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/fluff/railing/border{
@@ -58206,38 +58376,9 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/woods)
 "tqO" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "steward"
+/turf/closed/wall/mineral/rogue/roofwall/middle{
+	dir = 1
 	},
-/obj/item/roguekey/manor,
-/obj/item/roguekey/walls,
-/obj/item/roguekey/crafterguild,
-/obj/item/roguekey/steward,
-/obj/item/roguekey/church,
-/obj/item/roguekey/dungeon,
-/obj/item/roguekey/graveyard,
-/obj/item/roguekey/garrison{
-	name = "garrison key"
-	},
-/obj/item/roguekey/mercenary,
-/obj/item/roguekey/nightmaiden,
-/obj/item/roguekey/tavern,
-/obj/item/roguekey/physician,
-/obj/item/roguekey/knight,
-/obj/item/roguekey/armory,
-/obj/item/roguekey/tower,
-/obj/item/roguekey/apartments/stable1,
-/obj/item/roguekey/apartments/stable2,
-/obj/item/roguekey/tailor,
-/obj/item/roguekey/shop,
-/obj/item/roguekey/archive,
-/obj/item/paper{
-	info = "Hand Key, Lord's Key, Knight Captain's Key, Marshall Key, Sergeant Key, Royal Key kept in Vault."
-	},
-/obj/item/storage/keyring,
-/obj/item/storage/keyring,
-/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "tqQ" = (
 /obj/structure/chair/wood/rogue,
@@ -58727,8 +58868,15 @@
 	},
 /area/rogue/indoors/shelter)
 "tyL" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/indoors/town/vault)
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 16;
+	pixel_y = 32
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "tyR" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/water/swamp,
@@ -58976,9 +59124,9 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/woods)
 "tDn" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/fluff/statue/knight/r,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "tDu" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 4
@@ -59139,15 +59287,9 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "tGR" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/wood{
-	layer = 4.51
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/statue/knight,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "tGU" = (
 /obj/structure/closet/crate/chest/gold{
 	locked = 1;
@@ -59457,8 +59599,8 @@
 /area/rogue/under/underdark)
 "tMd" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "tMg" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/woodstaff,
@@ -59486,8 +59628,11 @@
 	},
 /area/rogue/indoors/town/garrison)
 "tMv" = (
-/turf/closed/wall/mineral/rogue/wooddark/horizontal,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/outdoors/town/roofs/keep)
 "tMN" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -59928,14 +60073,21 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "tUx" = (
-/obj/effect/decal/cobbleedge{
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows{
+	pixel_x = -2;
 	pixel_y = 1
 	},
-/obj/machinery/light/rogue/lanternpost{
-	dir = 1
+/obj/item/quiver/arrows{
+	pixel_x = 2;
+	pixel_y = -2
 	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/item/quiver/arrows{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "tUy" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
@@ -60078,12 +60230,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "tWO" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/town/basement/keep)
 "tWP" = (
 /obj/structure/flora/roguegrass,
@@ -60199,15 +60346,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
-"tYi" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/flail,
-/obj/item/rogueweapon/flail{
-	pixel_x = 0;
-	pixel_y = -5
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
 "tYj" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -60396,9 +60534,13 @@
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/outdoors/beach)
 "ubv" = (
-/obj/effect/landmark/start/clerk,
+/obj/structure/closet/crate/chest,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/item/flint,
 /turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/area/rogue/indoors/town/church/basement)
 "ubH" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/grasscold,
@@ -60767,6 +60909,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"uhw" = (
+/obj/effect/landmark/start/steward,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "uhG" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/fluff/railing/border{
@@ -61072,16 +61218,17 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/skeletoncrypt)
 "umt" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 32
 	},
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/obj/effect/particle_effect/smoke,
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "umv" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/handcart,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "umA" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -61780,12 +61927,11 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "uxY" = (
-/obj/structure/chair/wood/rogue{
-	pixel_x = 2;
-	pixel_y = -5
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/rooftop/green,
+/area/rogue/outdoors/town/roofs/keep)
 "uxZ" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/mountains)
@@ -61956,11 +62102,16 @@
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
 "uAL" = (
-/obj/structure/stairs/stone/d{
-	dir = 1
-	},
-/obj/structure/stairs/stone/d,
-/turf/open/floor/rogue/tile,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/leather/studded,
+/obj/item/clothing/suit/roguetown/armor/leather/studded,
+/obj/item/clothing/suit/roguetown/armor/leather/studded/bikini,
+/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced,
+/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced,
+/obj/item/clothing/wrists/roguetown/bracers/leather,
+/obj/item/clothing/wrists/roguetown/bracers/leather,
+/obj/item/clothing/wrists/roguetown/bracers/leather,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "uBc" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
@@ -62249,14 +62400,15 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "uEw" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/stoneaxe/woodcut/steel,
-/obj/item/rogueweapon/stoneaxe/woodcut/steel{
-	pixel_x = -1;
-	pixel_y = -8
+/obj/effect/decal/cobbleedge{
+	dir = 10
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "uEJ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt/road,
@@ -62694,11 +62846,14 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/mountains)
 "uMM" = (
-/obj/structure/roguewindow/openclose/reinforced,
-/turf/open/floor/rogue/concrete,
+/obj/structure/closet/crate/roguecloset/crafted,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
+/obj/item/clothing/suit/roguetown/armor/silkcoat,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "uMN" = (
-/obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement/keep)
 "uMO" = (
@@ -62739,11 +62894,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
 "uNj" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/manor)
 "uNt" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/outdoors/beach)
@@ -62793,6 +62948,13 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
+"uPf" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/kitchen/spoon/tin,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "uPj" = (
 /obj/effect/landmark/mapGenerator/rogue/beach{
 	endTurfX = 255;
@@ -62811,18 +62973,13 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave/orcdungeon)
 "uPI" = (
-/obj/structure/mineral_door/wood/violet{
-	locked = 1;
-	lockid = "steward";
-	name = "Clerk Bedroom"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/manor)
-"uPP" = (
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
+/obj/item/roguestatue/gold/loot,
+/turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/vault)
+"uPP" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/garrison)
 "uPS" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -63219,9 +63376,15 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
 "uWd" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/structure/table/wood{
+	icon_state = "map4"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/beer/voddena{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "uWo" = (
 /obj/structure/chair/wood/rogue/throne,
 /turf/open/floor/rogue/blocks/platform,
@@ -63293,9 +63456,8 @@
 /turf/open/water/swamp,
 /area/rogue/under/town/sewer)
 "uWU" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/wooddark/vertical,
+/area/rogue/outdoors/town/roofs)
 "uXf" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/sword,
@@ -63483,9 +63645,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "uZN" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/exposed/town/keep)
 "uZQ" = (
 /obj/effect/decal/cobbleedge{
 	pixel_y = 1
@@ -63585,11 +63749,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
 "vbt" = (
-/obj/structure/stairs{
-	dir = 8
+/obj/structure/bars{
+	color = "#755f48";
+	name = "rusted bars"
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/basement/keep)
 "vbD" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -63669,9 +63834,9 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/orcdungeon)
 "vdf" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/chair/bench/church/mid,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/basement)
 "vdj" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/water/ocean,
@@ -63754,9 +63919,9 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "vfl" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
-	dir = 1
-	},
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/effect/decal/carpet/square/black,
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "vfz" = (
 /obj/structure/table/wood{
@@ -63935,9 +64100,10 @@
 /area/rogue/under/cavewet/bogcaves)
 "viS" = (
 /obj/effect/decal/cobbleedge{
-	pixel_y = 1
+	icon_state = "cobbleedge-sread"
 	},
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "viW" = (
 /obj/structure/lever/wall{
@@ -64175,11 +64341,9 @@
 	},
 /area/rogue/indoors/town)
 "vmI" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/effect/landmark/start/clerk,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "vmL" = (
 /obj/item/bedsheet/rogue/double_pelt,
 /obj/structure/bed/rogue/inn/wooldouble,
@@ -64216,11 +64380,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "vnq" = (
-/obj/structure/chair/wood/rogue/fancy{
+/obj/structure/roguewindow/openclose{
 	dir = 4
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/town/roofs)
 "vnx" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -64241,22 +64405,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
-"vnO" = (
-/obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
-	},
-/obj/item/cooking/platter/silver,
-/obj/item/kitchen/fork/silver{
-	pixel_x = 12;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/cup/silver{
-	pixel_x = -13;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
 "vnS" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -64275,14 +64423,14 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/mazedungeon)
 "voe" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
-/obj/item/natural/feather,
-/obj/item/candle/yellow/lit,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/firebowl/standing,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "vow" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassyel,
@@ -64436,16 +64584,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
-"vrd" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "vrg" = (
 /obj/structure/table/church{
 	icon_state = "churchtable_mid_alt"
@@ -64582,19 +64720,6 @@
 "vto" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/mazedungeon)
-"vtw" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword,
-/obj/item/rogueweapon/sword{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/rogueweapon/sword{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
 "vtx" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/basement/keep)
@@ -64620,6 +64745,13 @@
 "vtR" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/rtfield)
+"vtS" = (
+/obj/structure/bars/tough,
+/obj/structure/roguewindow/harem2{
+	density = 0
+	},
+/turf/open/floor/rogue/metal/barograte,
+/area/rogue/under/town/basement/keep)
 "vtV" = (
 /mob/living/carbon/human/species/dwarfskeleton/ambush,
 /turf/open/floor/rogue/cobble,
@@ -64799,12 +64931,11 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "vwp" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "vwA" = (
 /obj/structure/table/wood,
 /obj/item/clothing/neck/roguetown/psicross/malum,
@@ -64977,11 +65108,9 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/physician)
 "vAg" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/manor)
+/obj/structure/roguemachine/stockpile,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "vAn" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -65095,8 +65224,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "vBu" = (
-/obj/effect/particle_effect/smoke,
-/turf/open/floor/rogue/church,
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "vBB" = (
 /obj/structure/fluff/railing/fence,
@@ -65168,18 +65297,16 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "vCO" = (
-/obj/structure/bed/rogue/inn/double{
+/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/obj/item/bedsheet/rogue/fabric_double{
-	dir = 1
-	},
-/obj/effect/landmark/start/apothecary,
-/obj/machinery/light/rogue/wallfire/candle{
+/obj/machinery/light/rogue/torchholder/c{
 	pixel_y = -32
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vCP" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -65267,14 +65394,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
 "vDT" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/storage/belt/rogue/pouch,
-/obj/item/storage/belt/rogue/pouch,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/effect/landmark/start/apothecary,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/outdoors/town/roofs)
 "vDV" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter)
@@ -65359,13 +65481,14 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
 "vFt" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 15
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "vFx" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/tile,
@@ -65388,12 +65511,13 @@
 	},
 /area/rogue/indoors/shelter)
 "vFY" = (
-/obj/machinery/light/rogue/firebowl/standing{
-	pixel_x = -5;
-	pixel_y = 2
+/obj/structure/mineral_door/wood/violet{
+	locked = 1;
+	lockid = "steward";
+	name = "Clerk Bedroom"
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/basement)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/manor)
 "vGa" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
@@ -65480,17 +65604,14 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
 "vHy" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
-	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/structure/closet/crate/chest/neu,
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/storage/belt/rogue/pouch,
+/obj/item/storage/belt/rogue/pouch,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "vHB" = (
 /obj/item/seeds/cabbage,
 /obj/item/seeds/cabbage,
@@ -65543,16 +65664,15 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cave/orcdungeon)
 "vIv" = (
-/obj/structure/floordoor/gatehatch/inner{
-	redstone_id = "wallbridge"
+/obj/structure/table/wood{
+	icon_state = "map3"
 	},
-/obj/structure/kybraxor{
-	pixel_x = -32;
-	pixel_y = -32;
-	redstone_id = "wallbridge"
+/obj/item/candle/silver/lit{
+	pixel_x = -2;
+	pixel_y = 15
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "vIw" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -65582,14 +65702,13 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/shelter/woods)
 "vII" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = 1
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/town)
 "vIP" = (
 /obj/effect/landmark/start/servant{
 	dir = 8
@@ -65610,11 +65729,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "vJa" = (
-/obj/structure/mineral_door/wood/fancywood{
-	name = "Sauna"
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "vJj" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -66044,14 +66161,14 @@
 	},
 /area/rogue/indoors/town/physician)
 "vPR" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/item/roguecoin/gold/pile,
+/obj/structure/fluff/walldeco/painting{
+	pixel_y = 32
 	},
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 9
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
 	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/manor)
+/area/rogue/indoors/town/vault)
 "vPZ" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 1;
@@ -66174,12 +66291,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "vTb" = (
-/obj/structure/kybraxor{
-	pixel_x = -32;
-	pixel_y = -32
+/obj/structure/stairs/stone/d{
+	dir = 8
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "vTc" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/tunic,
@@ -66223,13 +66339,15 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "vTJ" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	pixel_x = -8;
-	pixel_y = 8
+/obj/effect/decal/cobbleedge{
+	dir = 6
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "vTN" = (
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/indoors/town/garrison)
@@ -66296,13 +66414,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "vUZ" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "manor";
-	name = "Chapel"
+/obj/structure/floordoor/gatehatch/inner{
+	redstone_id = "wallbridge"
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/town/basement/keep)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "vVa" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/dirt,
@@ -66556,11 +66672,14 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "vYL" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "vYO" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -66628,9 +66747,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
 "vZI" = (
-/obj/structure/rogue/trophy/deer,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/stairs{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "vZU" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -66643,9 +66765,9 @@
 	},
 /area/rogue/indoors/town/manor)
 "wag" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "wat" = (
 /obj/structure/fluff/railing/border{
 	dir = 5;
@@ -67122,12 +67244,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "whK" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/tile/masonic,
+/area/rogue/indoors/town/vault)
 "whR" = (
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/hexstone,
@@ -67158,11 +67276,12 @@
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "wij" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = -5;
+	pixel_y = 2
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/town/roofs/keep)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/basement)
 "wik" = (
 /obj/structure/rack/rogue,
 /obj/item/flashlight/flare/torch/metal,
@@ -67344,19 +67463,17 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
 "wkv" = (
-/obj/structure/chair/wood/rogue{
-	pixel_x = 0;
-	pixel_y = -3
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/structure/closet/crate/chest/neu_fancy,
+/obj/item/roguecoin/silver/pile,
+/turf/open/floor/rogue/tile/masonic,
+/area/rogue/indoors/town/vault)
 "wkx" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = 8;
+	pixel_y = 0
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/basement)
 "wkz" = (
 /obj/structure/bars{
 	color = "#755f48";
@@ -67893,13 +68010,14 @@
 /area/rogue/indoors/town/garrison)
 "wtb" = (
 /obj/structure/table/wood{
-	icon_state = "map1"
+	icon_state = "tablewood1"
 	},
-/obj/item/reagent_containers/glass/cup/silver{
-	pixel_x = 6;
-	pixel_y = 11
+/obj/item/candle/gold/lit{
+	pixel_y = 6
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/under/town/basement/keep)
 "wtd" = (
 /obj/structure/mineral_door/wood/donjon{
@@ -68248,11 +68366,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter)
 "wzF" = (
-/obj/effect/decal/cobbleedge{
-	pixel_y = 1
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "wzO" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -68309,35 +68427,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
 "wAx" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "wAG" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 4
@@ -68735,15 +68827,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
-"wHe" = (
-/obj/item/roguecoin/gold/pile,
-/obj/structure/fluff/walldeco/painting/queen{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
-/area/rogue/indoors/town/vault)
 "wHi" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/mountains/decap)
@@ -69247,11 +69330,10 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/shelter/mountains/decap)
 "wQL" = (
-/obj/structure/stairs{
-	dir = 8
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 1
 	},
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/area/rogue/indoors/town/manor)
 "wQO" = (
 /obj/machinery/light/roguestreet/midlamp{
 	pixel_y = 10
@@ -69271,12 +69353,9 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/cave)
 "wQW" = (
-/obj/item/roguecoin/gold/pile,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
-/area/rogue/indoors/town/vault)
+/obj/structure/flora/ausbushes,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "wRe" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -69393,15 +69472,11 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "wTi" = (
-/obj/structure/table/wood{
-	icon_state = "map3"
+/obj/structure/stairs/stone{
+	dir = 4
 	},
-/obj/item/candle/silver/lit{
-	pixel_x = -2;
-	pixel_y = 15
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "wTp" = (
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
 /obj/machinery/light/rogue/wallfire/candle/floorcandle{
@@ -70023,13 +70098,16 @@
 /area/rogue/outdoors/mountains)
 "xdz" = (
 /obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-n";
-	pixel_x = 2;
-	pixel_y = 8
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/structure/flora/roguegrass/bush/wall/tall,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "xdA" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -70161,16 +70239,17 @@
 	},
 /area/rogue/indoors/town)
 "xfz" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/fishingrod/crafted,
-/obj/item/bait/bloody,
-/obj/item/bait/bloody,
-/obj/item/bait/bloody,
-/obj/item/bait/bloody,
-/obj/item/bait/bloody,
-/obj/item/bait/bloody,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "xfC" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -70301,19 +70380,11 @@
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/mountains/decap)
 "xhH" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag{
-	pixel_x = -7;
-	pixel_y = 5
+/obj/structure/floordoor/gatehatch/outer{
+	redstone_id = "wallbridge"
 	},
-/obj/item/storage/roguebag{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/manor)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "xhL" = (
 /obj/item/roguecoin/silver/pile,
 /turf/open/floor/rogue/blocks,
@@ -71358,11 +71429,16 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
 "xBq" = (
-/obj/structure/stairs/stone{
-	dir = 8
+/obj/structure/stairs{
+	dir = 4
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/walldeco/wantedposter,
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town)
 "xBE" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder/spear,
 /turf/open/floor/rogue/church,
@@ -71677,6 +71753,13 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"xGk" = (
+/obj/structure/chair/wood/rogue{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "xGp" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -71774,7 +71857,7 @@
 /area/rogue/indoors/shelter/woods)
 "xHI" = (
 /obj/machinery/light/rogue/wallfire/candle,
-/obj/effect/decal/carpet/square/black,
+/obj/effect/decal/carpet/square,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "xHQ" = (
@@ -71842,21 +71925,6 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
-"xJR" = (
-/obj/structure/flora/roguegrass/bush/wall/tall{
-	pixel_x = -11;
-	pixel_y = 0
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
 "xJW" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -72323,9 +72391,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
 "xSh" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
+/obj/structure/closet/crate/chest,
+/obj/item/quiver,
+/obj/item/quiver,
+/obj/item/quiver,
+/obj/item/quiver/sling/iron,
+/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -72475,7 +72546,7 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap)
 "xUY" = (
-/obj/structure/fluff/clock,
+/obj/machinery/light/rogue/wallfire/candle/r,
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
@@ -72577,9 +72648,17 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
 "xXA" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "xXC" = (
 /obj/effect/decal/wood/herringbone2{
 	dir = 6
@@ -72591,12 +72670,8 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "xXW" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "steward";
-	name = "Clerk's Bedroom"
-	},
-/turf/open/floor/rogue/wood,
+/obj/effect/particle_effect/smoke,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "xYj" = (
 /obj/structure/fluff/railing/wood,
@@ -72741,13 +72816,13 @@
 	},
 /area/rogue/indoors/town)
 "xZU" = (
-/obj/effect/decal/cobbleedge,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "manor";
+	name = "Chapel"
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "yaf" = (
 /obj/structure/mineral_door/wood/towner/fisher{
 	locked = 0
@@ -73011,11 +73086,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"ydD" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/effect/decal/carpet/square,
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/manor)
 "ydT" = (
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /obj/structure/bed/rogue/shit,
@@ -73057,16 +73127,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/roofs)
 "yeu" = (
-/obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
-	},
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/obj/structure/closet/crate/drawer,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/natural/feather,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/outdoors/town/roofs)
 "yew" = (
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
@@ -73128,17 +73196,11 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
 "yfn" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/stairs{
+	dir = 8
 	},
-/obj/structure/flora/roguegrass/bush/wall/tall,
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
-	},
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/garrison)
 "yfs" = (
 /obj/structure/flora/roguegrass/herb/hypericum,
 /turf/open/floor/rogue/grassred,
@@ -73190,8 +73252,11 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave/skeletoncrypt)
 "ygd" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs/keep)
 "ygf" = (
 /obj/structure/hotspring,
 /turf/open/floor/rogue/grass,
@@ -73363,11 +73428,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "yju" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/exposed/town/keep)
 "yjw" = (
 /mob/living/carbon/human/species/human/northern/searaider/ambush,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -73447,11 +73512,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "ykK" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town/roofs/keep)
 "ykT" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/effect/decal/cobbleedge{
@@ -163210,11 +163273,11 @@ cxZ
 cxZ
 vtx
 bYC
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
 bYC
-oJT
+qZN
 bYC
 whB
 qlM
@@ -163662,11 +163725,11 @@ cxZ
 cxZ
 vtx
 vtx
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
 bYC
-oJT
+qZN
 bYC
 oPy
 wCC
@@ -164114,11 +164177,11 @@ leX
 bYC
 bYC
 bYC
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
 bYC
-oJT
+qZN
 bYC
 bZj
 wCC
@@ -164548,13 +164611,13 @@ xCK
 xCK
 skC
 bYC
-bhE
+khj
 bHV
-yju
-mXZ
-tWO
+wzF
+iaB
+lSh
 bHV
-pWB
+tGR
 iad
 ogs
 ogs
@@ -164566,11 +164629,11 @@ ogs
 ogs
 iad
 ogs
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
 bYC
-oJT
+qZN
 bYC
 loK
 qhq
@@ -165002,10 +165065,10 @@ dlK
 jxg
 bHV
 bHV
-uxY
-lkJ
-wtb
-vFt
+dkt
+uWd
+lDn
+eGS
 bHV
 iad
 ogs
@@ -165016,13 +165079,13 @@ ogs
 ogs
 ogs
 ogs
-pZw
-pZw
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
+gFm
+gFm
 bYC
-oJT
+qZN
 bYC
 uqC
 eWv
@@ -165452,13 +165515,13 @@ mMx
 ylh
 xAN
 iad
-jmj
+kRO
 bHV
-dNO
-qbr
-rGx
-bqk
-kMx
+bYk
+eja
+hOq
+rUb
+hQj
 iad
 ogs
 ogs
@@ -165469,12 +165532,12 @@ ogs
 ogs
 ogs
 iBO
-pZw
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
+gFm
 bYC
-oJT
+qZN
 bYC
 cjR
 eWv
@@ -165904,12 +165967,12 @@ mMx
 ylh
 xAN
 iad
-vZI
+mXZ
 bHV
-wkv
-jrn
-wTi
-ivq
+xGk
+taV
+vIv
+cUk
 bHV
 iad
 ogs
@@ -165921,10 +165984,10 @@ ogs
 ogs
 ogs
 iBO
-pZw
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
+gFm
 bYC
 bYC
 bYC
@@ -166356,13 +166419,13 @@ mMx
 ylh
 xAN
 iad
-rLn
+bHv
 bHV
-hQj
+jkr
+rkS
 ktO
-vTJ
 bHV
-jfm
+tDn
 iad
 ogs
 ogs
@@ -166372,12 +166435,12 @@ ogs
 ogs
 ogs
 ogs
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
 iad
 bYC
 vrC
@@ -166800,8 +166863,8 @@ ogs
 uvk
 skC
 ogs
-etH
-etH
+pLb
+pLb
 dlK
 ylh
 mMx
@@ -166824,12 +166887,12 @@ ogs
 ogs
 ogs
 ogs
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
 iad
 bYC
 gaB
@@ -167256,17 +167319,17 @@ iad
 iad
 iad
 iad
-pqT
+vtS
 iad
 iad
 iad
-nZB
+fCn
 wCC
 eWv
 tUV
 eWv
 tUV
-wAx
+agd
 iad
 ogs
 ogs
@@ -167276,12 +167339,12 @@ ogs
 ogs
 ogs
 ogs
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
 iad
 bYC
 dVC
@@ -167706,7 +167769,7 @@ skC
 ogs
 iad
 iqU
-siF
+sfj
 waK
 sAf
 iad
@@ -167714,11 +167777,11 @@ iad
 iad
 mOz
 wCC
-dKe
+elZ
 wCC
 bhZ
 wCC
-vtw
+pxW
 iad
 ogs
 ogs
@@ -167728,12 +167791,12 @@ ogs
 ogs
 ogs
 ogs
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
 iad
 bYC
 mIO
@@ -168164,13 +168227,13 @@ mmB
 aoD
 tYZ
 iad
-elZ
+laF
 wCC
-thZ
+lWn
 wCC
-bdw
+jlB
 wCC
-tYi
+qHm
 iad
 ogs
 ogs
@@ -168180,12 +168243,12 @@ ogs
 ogs
 ogs
 ogs
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
 iad
 bYC
 lDp
@@ -168609,20 +168672,20 @@ ogs
 ogs
 ogs
 iad
-lSo
+jOP
 waK
 waK
-oTN
+gij
 aoD
 nWc
 iad
 rDx
 wCC
-nKF
+uAL
 wCC
-aoM
+dBg
 wCC
-iCz
+hOT
 iad
 ogs
 ogs
@@ -168632,12 +168695,12 @@ ogs
 ogs
 ogs
 ogs
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
 iad
 bYC
 qnQ
@@ -169068,13 +169131,13 @@ iCc
 hzA
 nWc
 iad
-gAQ
+szy
 wCC
-iSQ
+dgz
 wCC
-gMS
+tUx
 wCC
-oYo
+fBn
 iad
 ogs
 ogs
@@ -169084,12 +169147,12 @@ ogs
 ogs
 ogs
 ogs
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
 iad
 bYC
 jZC
@@ -169513,20 +169576,20 @@ ogs
 ogs
 ogs
 iad
-tlQ
+hPG
 bJM
 waK
 qwl
 jnt
 xCr
 iad
-aoJ
+mCr
 isB
-pEB
+rLn
 isB
-vDT
+vHy
 isB
-uEw
+iGT
 iad
 ogs
 ogs
@@ -169536,12 +169599,12 @@ ogs
 ogs
 ogs
 ogs
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
 iad
 bYC
 aEr
@@ -169980,20 +170043,20 @@ iad
 iad
 iad
 iad
-pZw
-tyL
-qrX
-qrX
-qrX
-qrX
-juI
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
+gFm
+lZz
+ajc
+ajc
+ajc
+ajc
+aEq
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
 iad
 bYC
 bYC
@@ -170415,37 +170478,37 @@ ogs
 ogs
 ogs
 iad
-uWU
-kiz
-kiz
-hqc
-kiz
-kiz
-uWU
+llF
+uMN
+uMN
+aeP
+uMN
+uMN
+llF
 eWv
 iXX
-aqA
+ept
 eWv
 eWv
 eWv
-aqA
+ept
 eWv
 eWv
 iad
 iad
-qrX
-qrX
-orR
-llF
-qrX
-qrX
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
+ajc
+ajc
+vPR
+wkv
+ajc
+ajc
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
 iad
 fAL
 opX
@@ -170866,38 +170929,38 @@ uvk
 ogs
 ogs
 ogs
-kiz
-cUk
-kiz
-kiz
-kiz
-kiz
-kiz
-kiz
+uMN
+mFr
+uMN
+uMN
+uMN
+uMN
+uMN
+uMN
 eWv
 nnq
-bKp
+deO
 nnq
 nnq
-bKp
+deO
 nnq
 nnq
 eWv
 eWv
 iad
+ajc
+ojQ
+whK
+mDc
 qrX
-sRD
-mmb
-uPP
-qQj
-qrX
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
-pZw
+ajc
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
+gFm
 iad
 xAN
 ylh
@@ -171319,9 +171382,9 @@ orc
 ogs
 ogs
 iad
+uMN
+uMN
 kiz
-kiz
-uAL
 iad
 iad
 iad
@@ -171329,21 +171392,21 @@ iad
 eWv
 uWE
 aal
-fPZ
+pnA
 bqw
-pSy
+atr
 rGK
 nnq
-vdf
+bsx
 eWv
-aqA
-qrX
-cVo
+ept
+ajc
+erO
 uoI
-cVo
-aIi
-qrX
-pZw
+erO
+aOc
+ajc
+gFm
 aal
 aal
 iad
@@ -171771,31 +171834,31 @@ orc
 ogs
 ogs
 iad
+uMN
+uMN
 kiz
-kiz
-uAL
 iad
 iad
 iad
-ffL
+ijk
 eDO
 wqC
 aal
 qJZ
 toX
 qJZ
-fLP
+rtc
 nnq
 ijI
 ijI
 ijI
 iqX
-aEu
-aEu
-aEu
-jph
-qrX
-pZw
+ixs
+ixs
+ixs
+njb
+ajc
+gFm
 iad
 iad
 iad
@@ -172223,8 +172286,8 @@ mdL
 ogs
 ogs
 iad
-kiz
-kiz
+uMN
+uMN
 wEL
 iad
 iad
@@ -172234,20 +172297,20 @@ eWv
 uWE
 aal
 fgq
-djh
+wtb
 fgq
 qYk
 nnq
-vdf
+bsx
 eWv
-kRO
-qrX
-uPP
-mmb
-uPP
-aOM
-qrX
-oBL
+cNi
+ajc
+mDc
+whK
+mDc
+uPI
+ajc
+tWO
 opX
 opX
 opX
@@ -172675,16 +172738,16 @@ orc
 ogs
 ogs
 iad
-cUk
-kiz
-kiz
-kiz
-kiz
-kiz
-kiz
+mFr
+uMN
+uMN
+uMN
+uMN
+uMN
+uMN
 eWv
 nnq
-bKp
+deO
 nnq
 nnq
 nnq
@@ -172693,13 +172756,13 @@ nnq
 eWv
 eWv
 iad
-qrX
-wQW
+ajc
+etH
 uoI
-cVo
-iLV
-qrX
-nvU
+erO
+hfn
+ajc
+vbt
 ylh
 urZ
 mMx
@@ -173127,31 +173190,31 @@ orc
 ogs
 ogs
 iad
-uWU
-kiz
-lOy
+llF
 uMN
-kiz
-kiz
-uWU
+lOy
+wag
+uMN
+uMN
+llF
 eWv
 iXX
-kRO
+cNi
 eWv
 eWv
 eWv
-kRO
+cNi
 eWv
 eWv
 iad
 iad
-qrX
-qrX
-wHe
-nan
-qrX
-qrX
-oBL
+ajc
+ajc
+sZH
+nZB
+ajc
+ajc
+tWO
 opX
 opX
 opX
@@ -173583,7 +173646,7 @@ iad
 iad
 iad
 iad
-vUZ
+xZU
 iad
 iad
 iad
@@ -173597,13 +173660,13 @@ iad
 iad
 iad
 iad
-qrX
-tyL
-qrX
-qrX
-qrX
-qrX
-pZw
+ajc
+lZz
+ajc
+ajc
+ajc
+ajc
+gFm
 ogs
 ogs
 ogs
@@ -174033,21 +174096,21 @@ ogs
 idG
 iad
 iad
-kqG
+dni
 nSG
 nSG
 nSG
 nSG
-vFY
+wij
 nSG
 iad
-pnA
+fiP
 eWv
 eWv
 eWv
 eWv
 eWv
-aOc
+sXL
 eWv
 iad
 dlK
@@ -174485,15 +174548,15 @@ ogs
 idG
 iad
 iad
-qSC
+hSu
 dWW
-bpF
-qBO
-ekz
-qBO
-ekz
+dFk
+mIU
+mhx
+mIU
+mhx
 iad
-kAv
+hvV
 eWv
 eWv
 eWv
@@ -174937,22 +175000,22 @@ ogs
 ogs
 idG
 iad
-mjw
-oyV
-jiZ
-qBO
-fRL
-qBO
-fRL
+oJT
+hXq
+dau
+mIU
+vdf
+mIU
+vdf
 iad
-deO
+bpF
 eWv
 fXM
-ept
+mca
 fXM
-ept
+mca
 fXM
-ept
+mca
 iad
 dlK
 opX
@@ -175389,22 +175452,22 @@ ogs
 ogs
 ogs
 iad
-iJp
-bdV
-dTu
-qBO
-aEj
-qBO
-aEj
+toG
+cke
+sfS
+mIU
+sOa
+mIU
+sOa
 iad
 eWv
 eWv
 dMk
-deO
+bpF
 dMk
-deO
+bpF
 dMk
-deO
+bpF
 iad
 ogs
 ogs
@@ -175841,22 +175904,22 @@ orc
 ogs
 ogs
 iad
-jOP
+wkx
 nSG
 nSG
 nSG
 nSG
-hUf
-rSJ
+qBO
+ubv
 iad
 eWv
 eWv
 dMk
-qad
+ffL
 dMk
-qad
+ffL
 dMk
-qad
+ffL
 iad
 ogs
 ogs
@@ -176747,13 +176810,13 @@ ogs
 ogs
 ogs
 iad
-dgz
+jPl
 dIX
-lVB
-lVB
-lVB
+iJp
+iJp
+iJp
 dIX
-ykK
+gHr
 iad
 ogs
 ogs
@@ -177199,13 +177262,13 @@ ogs
 ogs
 ogs
 iad
-tMd
-umt
+nan
+lQz
 iBO
 iBO
 iBO
-pWX
-fVF
+laf
+hmp
 iad
 ogs
 ogs
@@ -177651,13 +177714,13 @@ ogs
 ogs
 ogs
 iad
-rkS
-ffz
-wQL
-wQL
-wQL
+aqA
+lPk
+aUk
+aUk
+aUk
 iRq
-fNC
+pZw
 iad
 ogs
 ogs
@@ -178103,13 +178166,13 @@ ogs
 ogs
 ogs
 iad
-bsx
+rGx
 hzA
 nWc
 nWc
 nWc
-loz
-bsx
+pWX
+rGx
 iad
 ogs
 ogs
@@ -178555,7 +178618,7 @@ xCK
 ogs
 ogs
 iad
-iHI
+nvU
 nWc
 nWc
 nWc
@@ -179008,11 +179071,11 @@ ogs
 ogs
 iad
 nWc
-aft
+hhv
 nWc
-aft
+hhv
 nWc
-aft
+hhv
 nWc
 iad
 ogs
@@ -260378,8 +260441,8 @@ sns
 vOG
 sns
 sns
-eRG
-rSH
+jfm
+vII
 wyE
 wyE
 fpx
@@ -260831,7 +260894,7 @@ phl
 eBq
 sns
 sns
-viS
+jdB
 exD
 wyE
 qyR
@@ -261283,7 +261346,7 @@ phl
 sns
 sns
 sns
-viS
+jdB
 exD
 exD
 oSE
@@ -261735,7 +261798,7 @@ uBc
 sns
 sns
 sns
-viS
+jdB
 exD
 wRJ
 sGj
@@ -262187,9 +262250,9 @@ uBc
 sns
 sns
 sns
-viS
+jdB
 exD
-prx
+pBH
 sGj
 eRd
 aiM
@@ -262639,9 +262702,9 @@ phl
 sns
 sns
 sns
-viS
+jdB
 exD
-nZP
+iMQ
 sGj
 mqz
 hoS
@@ -263091,7 +263154,7 @@ cDX
 eBq
 sns
 sns
-viS
+jdB
 exD
 ehB
 dkS
@@ -263543,9 +263606,9 @@ veW
 sns
 sns
 sns
-viS
+jdB
 exD
-prx
+pBH
 sGj
 por
 hoS
@@ -263995,8 +264058,8 @@ jCu
 sns
 sns
 sns
-dau
-wkx
+vTJ
+eMi
 exD
 sGj
 qaK
@@ -264019,7 +264082,7 @@ pWT
 qgd
 sns
 sns
-vOG
+sns
 sns
 deZ
 udL
@@ -264904,7 +264967,7 @@ sns
 sns
 vWX
 nXy
-szy
+kbS
 dQI
 sns
 sns
@@ -266264,7 +266327,7 @@ vOG
 sns
 sns
 xYz
-fBd
+jph
 sns
 sns
 sns
@@ -266722,8 +266785,8 @@ smL
 smL
 vgn
 qKs
-aUk
-qvp
+mkj
+bhE
 sns
 sns
 sns
@@ -267174,15 +267237,15 @@ awX
 ehv
 bUt
 ggT
-uNj
+cvU
 rUQ
 sns
 sns
 sns
-bHv
-iCY
-aSm
-eGS
+lSo
+bKp
+xfz
+fRL
 mow
 sns
 sns
@@ -267633,9 +267696,9 @@ sns
 dWk
 eva
 cne
-hMB
+xBq
 cne
-fHg
+lAF
 sns
 sns
 exO
@@ -268083,11 +268146,11 @@ sns
 sns
 sns
 sns
-tGR
+eyl
 vmk
 bUt
 raU
-xZU
+tkB
 sns
 sns
 sns
@@ -268535,11 +268598,11 @@ sns
 sns
 sns
 sns
-tGR
+eyl
 vmk
 bUt
 raU
-xZU
+tkB
 sns
 sns
 kFT
@@ -268983,15 +269046,15 @@ ehv
 bUt
 ate
 ntM
-hsS
+gMS
 sns
 sns
 sns
-tGR
+eyl
 vmk
 bUt
 raU
-xZU
+tkB
 sns
 sns
 sns
@@ -269435,15 +269498,15 @@ oCF
 bUt
 bwJ
 sns
-hsS
+gMS
 sns
 sns
 sns
-tGR
+eyl
 vmk
 bUt
 ylp
-drE
+qXJ
 sns
 sns
 saG
@@ -269886,20 +269949,20 @@ pcB
 ehv
 bUt
 ggT
-oee
-rTT
+exS
+skw
 sns
 sns
 sns
-tGR
+eyl
 bUt
 bUt
 raU
-xZU
+tkB
 sns
 sns
 pZZ
-lDn
+kiE
 llx
 arI
 arI
@@ -270343,15 +270406,15 @@ qfA
 sns
 sns
 sns
-tGR
+eyl
 bUt
 eNp
 xSH
-oVj
+hof
 sns
 sns
 hpr
-exS
+dTu
 llx
 hcv
 mAr
@@ -270795,15 +270858,15 @@ rUQ
 sns
 sns
 sns
-tGR
+eyl
 bUt
 bUt
 raU
-xZU
+tkB
 sns
 sns
 hpr
-jkr
+nKF
 llx
 rLJ
 cuJ
@@ -271251,11 +271314,11 @@ eva
 cne
 hYo
 cne
-fHg
+lAF
 sns
 sns
 hpr
-exS
+dTu
 llx
 arI
 arI
@@ -271699,10 +271762,10 @@ sns
 sns
 sns
 sns
-crj
-skw
-oSS
-kac
+eHY
+vYL
+gAQ
+abP
 dHe
 sns
 sns
@@ -272146,7 +272209,7 @@ smL
 smL
 xvq
 qKs
-umv
+mbG
 sns
 sns
 sns
@@ -272605,8 +272668,8 @@ sns
 sns
 sns
 sns
-qgS
-taV
+kcF
+gei
 sns
 sns
 sns
@@ -273052,12 +273115,12 @@ exD
 exD
 sns
 sns
-jGc
-gtR
+mYX
+dZz
 wFK
 sns
-vrd
-dFk
+uEw
+viS
 sns
 sns
 sns
@@ -273496,7 +273559,7 @@ qIJ
 rxp
 hgX
 gKR
-ajc
+nOC
 ryO
 qUB
 exD
@@ -273504,9 +273567,9 @@ exD
 exD
 aWT
 sns
-nat
+qgS
 hLv
-cVX
+iJi
 sns
 sns
 uvR
@@ -273956,9 +274019,9 @@ dnE
 hEh
 wRJ
 sns
-vHy
+ghC
 cBf
-dkt
+kUH
 sns
 sns
 sns
@@ -274871,7 +274934,7 @@ xAF
 xAF
 xAF
 exD
-wkx
+eMi
 exD
 exD
 exD
@@ -275307,7 +275370,7 @@ exD
 exD
 pWT
 pWT
-hhv
+wQW
 rgV
 lAO
 sns
@@ -275322,9 +275385,9 @@ exD
 exD
 exD
 exD
-pBH
+nat
 sns
-whK
+smR
 exD
 exD
 exD
@@ -277583,7 +277646,7 @@ bge
 bge
 bge
 rUQ
-fjY
+voe
 rUQ
 sns
 sns
@@ -278005,7 +278068,7 @@ pgL
 vAo
 kRA
 vAo
-cNi
+smZ
 bZC
 ruD
 uWp
@@ -280275,13 +280338,13 @@ iZi
 vxe
 cpa
 pyE
-hog
+uZN
 weQ
 iWa
 iWa
 cIt
 dXR
-oWi
+oyV
 qIg
 rBm
 bgY
@@ -281184,7 +281247,7 @@ gzy
 uqB
 jWw
 jWw
-xdz
+jsx
 fOB
 jWw
 xOI
@@ -282987,7 +283050,7 @@ hao
 bHU
 bIg
 oIo
-sZH
+sfH
 aVY
 aHM
 nTh
@@ -283442,7 +283505,7 @@ iND
 vSw
 vSw
 bIg
-xJR
+aRC
 nTh
 kAx
 kAx
@@ -283894,7 +283957,7 @@ nDt
 vSw
 mQw
 bIg
-syz
+qvp
 pww
 jJH
 rMf
@@ -284346,8 +284409,8 @@ jiA
 jiA
 jxB
 bIg
-mcU
-mbG
+gmR
+htV
 rMf
 rMf
 rMf
@@ -284798,7 +284861,7 @@ fZT
 fZT
 hGk
 bIg
-mcU
+gmR
 njP
 msF
 rMf
@@ -285250,7 +285313,7 @@ lzQ
 lzQ
 eNM
 bIg
-rnI
+hUf
 nTh
 kAx
 kAx
@@ -285675,7 +285738,7 @@ pWT
 pWT
 bIg
 eIK
-lPk
+oee
 uWp
 uWp
 uWp
@@ -285702,7 +285765,7 @@ nDt
 vSw
 mQw
 bIg
-rnI
+hUf
 pww
 jJH
 rMf
@@ -286154,7 +286217,7 @@ vSw
 agm
 kCs
 bIg
-jdv
+syb
 pww
 kAx
 rMf
@@ -286606,7 +286669,7 @@ wsf
 wsf
 wsf
 wWq
-mcU
+gmR
 pww
 kAx
 rMf
@@ -287057,7 +287120,7 @@ bIg
 rGA
 rMf
 cGC
-foK
+oBL
 usN
 njP
 ppQ
@@ -287513,7 +287576,7 @@ fSG
 noW
 vQt
 vAw
-ocm
+rjK
 xDj
 weQ
 weQ
@@ -288389,15 +288452,15 @@ bIg
 vxe
 snb
 cXk
-vAg
+aCu
 cXk
 cXk
-vAg
+aCu
 cXk
 cXk
-vAg
+aCu
 cXk
-gei
+aNs
 ovY
 ovY
 ovY
@@ -288860,15 +288923,15 @@ ovY
 wWq
 ovY
 wWq
-pel
+jHu
 wWq
-eSn
+mPH
 noW
 agp
 noW
 noW
 njP
-jlB
+fvA
 fXm
 vAw
 vAw
@@ -289294,29 +289357,29 @@ uqB
 uqB
 weQ
 weQ
-kbS
-eyl
-kbS
-eyl
-kbS
-eyl
-kbS
-eyl
-kbS
-mhx
-kbS
+rSH
+hog
+rSH
+hog
+rSH
+hog
+rSH
+hog
+rSH
+pIv
+rSH
 rMf
 rMf
-fvA
-rMf
-rMf
-rMf
-fvA
+jiZ
 rMf
 rMf
 rMf
+jiZ
 rMf
-sZI
+rMf
+rMf
+rMf
+xXA
 fSG
 noW
 nTh
@@ -289746,17 +289809,17 @@ uqB
 uqB
 weQ
 weQ
-eyl
-dJv
-eyl
-dJv
-eyl
-dJv
-eyl
-dJv
-eyl
-dJv
-eyl
+hog
+djh
+hog
+djh
+hog
+djh
+hog
+djh
+hog
+djh
+hog
 dPu
 dPu
 dPu
@@ -289768,7 +289831,7 @@ dPu
 rMf
 rMf
 rMf
-syz
+qvp
 noW
 noW
 nTh
@@ -290198,29 +290261,29 @@ uqB
 uqB
 oPm
 weQ
-kbS
-eyl
-qZN
-fyA
-qZN
-qZN
-qZN
-fyA
-qZN
-eyl
-kbS
+rSH
+hog
+rDO
+mqT
+rDO
+rDO
+rDO
+mqT
+rDO
+hog
+rSH
 dPu
-pqR
-iGT
+mcU
+jAe
 sLn
 sRn
-uWd
+vBu
 sLn
-lqY
+ibZ
 rMf
 rMf
-cCJ
-mcU
+lLV
+gmR
 noW
 noW
 nTh
@@ -290650,29 +290713,29 @@ uqB
 jdk
 weQ
 weQ
-eyl
-dJv
-gmR
-gAH
-ezM
+hog
+djh
+bdV
 tod
-jGg
-gAH
-gmR
-dJv
-eyl
+tpg
+jsG
+fVF
+tod
+bdV
+djh
+hog
 dPu
-sRJ
+doL
 dPu
-jdB
+tMd
 sLn
-qHm
+uhw
 sLn
 dPu
-agd
-agd
+shc
+shc
 njP
-pIv
+esm
 noW
 noW
 nTh
@@ -291102,28 +291165,28 @@ uqB
 jdk
 weQ
 weQ
-kbS
-eyl
-vfl
-htV
-qXJ
-qXJ
-qXJ
-sKU
-vfl
-eyl
-kbS
+rSH
+hog
+lGl
+oYo
+hDh
+hDh
+hDh
+scw
+lGl
+hog
+rSH
 dPu
 sLn
-xBq
+mcc
 sLn
 sLn
-rjK
+bgr
 sLn
-yeu
-shc
-shc
-rlE
+iCz
+dKe
+dKe
+sRO
 njP
 cOh
 noW
@@ -291554,29 +291617,29 @@ uqB
 uqB
 weQ
 weQ
-eyl
-dJv
-vfl
-qXJ
-jsG
-jsG
-jsG
-qXJ
-vfl
-dJv
-eyl
+hog
+djh
+lGl
+hDh
+vTb
+vTb
+vTb
+hJN
+lGl
+djh
+hog
 dPu
-haq
+dNO
 sLn
 sLn
 sLn
-els
+dJv
 sLn
-yeu
+iCz
+dKe
+dKe
+dKe
 shc
-shc
-shc
-agd
 noW
 noW
 nTh
@@ -292006,29 +292069,29 @@ uqB
 uqB
 weQ
 weQ
-kbS
-eyl
-vfl
-iaB
+rSH
+hog
+lGl
+nnb
 fSz
-kUH
+bdw
 fSz
-sKU
-vfl
-eyl
-kbS
+hpm
+lGl
+hog
+rSH
 dPu
-sfH
+jdv
 sLn
-vnq
+ocm
 sLn
-ubv
+vmI
 sLn
-yeu
+iCz
+dKe
+dKe
+dKe
 shc
-shc
-shc
-agd
 noW
 noW
 nTh
@@ -292458,31 +292521,31 @@ uqB
 jdk
 weQ
 weQ
-eyl
-dJv
-vfl
-gAH
-gAH
-gAH
-ezM
+hog
+djh
+lGl
+tod
+tod
+tod
+tpg
+ida
+lGl
+djh
+hog
+dPu
+exY
+sLn
+oSS
+tpk
+sLn
+fSB
+dPu
+vAg
+dKe
 vJa
-vfl
-dJv
-eyl
-dPu
-voe
-sLn
-nnb
-bko
-sLn
-mON
-dPu
-oRZ
-shc
-mPH
 njP
 noW
-eSn
+mPH
 nTh
 nII
 xQT
@@ -292910,29 +292973,29 @@ uqB
 jdk
 weQ
 weQ
-kbS
-eyl
-mUN
-dZz
-dZz
-dZz
-cDw
-qXJ
-vfl
-eyl
-kbS
+rSH
+hog
+hMB
+loz
+loz
+loz
+kmv
+hDh
+lGl
+hog
+rSH
 dPu
 dPu
-lZz
+scT
 dPu
 dPu
-hvV
+ebP
 dPu
-lZz
-agd
-agd
+scT
+shc
+shc
 njP
-pIv
+esm
 tKV
 nTh
 njP
@@ -293362,28 +293425,28 @@ uqB
 uqB
 weQ
 weQ
-eyl
-dJv
-mHf
-njb
-vBu
-qXJ
-qXJ
-vBu
-vfl
-dJv
-eyl
+hog
+djh
+fNC
+drE
+xXW
+hDh
+hDh
+xXW
+lGl
+djh
+hog
 dPu
 xZf
-dha
+cqj
 xZf
 xZf
 xZf
-mca
-hkj
+vwp
+frA
 weQ
-tpg
-jBH
+aSm
+bko
 tOx
 noW
 noW
@@ -293814,17 +293877,17 @@ uqB
 uqB
 weQ
 weQ
-kbS
-eyl
-vfl
+rSH
+hog
+lGl
+umt
+fFz
+lcZ
+iFA
 dEP
-pFh
-fbW
-ncQ
-ncZ
-vfl
-eyl
-kbS
+lGl
+hog
+rSH
 dPu
 xZf
 neg
@@ -293832,10 +293895,10 @@ neg
 neg
 neg
 xZf
-hkj
+frA
 weQ
-tpg
-fht
+aSm
+igz
 fXg
 noW
 noW
@@ -294266,17 +294329,17 @@ uqB
 jdk
 weQ
 weQ
-eyl
-dJv
-gmR
-gAH
-gAH
-gAH
-gAH
-gAH
-gmR
-dJv
-eyl
+hog
+djh
+bdV
+tod
+tod
+tod
+tod
+tod
+bdV
+djh
+hog
 dPu
 xZf
 neg
@@ -294284,9 +294347,9 @@ neg
 neg
 neg
 xZf
-hkj
+frA
 weQ
-tpg
+aSm
 rMf
 fXg
 noW
@@ -294718,27 +294781,27 @@ uqB
 jdk
 weQ
 weQ
-kbS
-eyl
-kbS
-eyl
-kbS
-eyl
-kbS
-eyl
-kbS
-eyl
-kbS
+rSH
+hog
+rSH
+hog
+rSH
+hog
+rSH
+hog
+rSH
+hog
+rSH
 dPu
 xZf
-rLU
+haq
 xZf
 xZf
 xZf
-pMW
-hkj
-wzF
-tpg
+pFh
+frA
+yju
+aSm
 rGA
 fXg
 noW
@@ -295186,13 +295249,13 @@ dPu
 dPu
 dPu
 dPu
-hvV
+ebP
 dPu
 dPu
 weQ
-tpg
-eXA
-yfn
+aSm
+tlQ
+xdz
 noW
 noW
 rMf
@@ -295640,7 +295703,7 @@ weQ
 weQ
 weQ
 nEd
-wzF
+yju
 weQ
 weQ
 weQ
@@ -296082,10 +296145,10 @@ nwG
 nwG
 nwG
 weQ
-tDn
-rDO
+eSn
+qad
 rni
-pJG
+iSQ
 weQ
 tWl
 weQ
@@ -296096,7 +296159,7 @@ pZi
 weQ
 weQ
 weQ
-tUx
+oDj
 noW
 nRv
 gqP
@@ -380614,7 +380677,7 @@ bGf
 bGf
 bGf
 bGf
-hDh
+vFt
 pYP
 pYP
 pYP
@@ -388728,7 +388791,7 @@ bGf
 bGf
 bGf
 bGf
-vTb
+syz
 bGf
 bGf
 bGf
@@ -395070,18 +395133,18 @@ jWw
 qer
 dqE
 lvT
-mCr
+wAx
 sLn
 sLn
 sLn
-mCr
+wAx
 sRn
 sLn
 sLn
-mCr
+wAx
 sLn
 sLn
-jwe
+vZI
 fSz
 dMi
 iWa
@@ -395522,15 +395585,15 @@ iWa
 qer
 dMi
 jwe
-rtc
+qSC
 sLn
 sLn
 sLn
-rtc
+qSC
 sLn
 sLn
 sLn
-rtc
+qSC
 sLn
 sLn
 nFf
@@ -396870,24 +396933,24 @@ pyE
 key
 pyE
 pIl
-xHI
+vfl
 rTE
 pIl
 vUp
 aaE
 pIl
-ydD
+xHI
 heB
 dPu
-lfb
+umv
 fAA
 cpI
 dPu
-lfb
+umv
 fAA
 cpI
 dPu
-lfb
+umv
 fAA
 cpI
 nqr
@@ -405004,19 +405067,19 @@ bGf
 bGf
 iVE
 wBK
-dyx
+jrn
 vmi
 vmi
 vmi
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
 vmi
 dPu
 dPu
@@ -405455,29 +405518,29 @@ bGf
 bGf
 bGf
 vgL
-wij
+tMv
 rBQ
 vmi
 vmi
 vmi
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
 vmi
 dPu
 uWp
 crD
-eja
+lnu
 crD
-iMQ
-vII
-rlj
+gDG
+lVB
+fZo
 dPu
 vmi
 vmi
@@ -405908,28 +405971,28 @@ bGf
 bGf
 iVE
 wBK
-dyx
+jrn
 vmi
 vmi
 vmi
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
 vmi
 dPu
-lmP
-sXr
-sOa
+wTi
+pKR
+eeK
 vAo
 vAo
 vAo
-cqj
+cDw
 dPu
 vmi
 vmi
@@ -406359,29 +406422,29 @@ bGf
 bGf
 bGf
 vgL
-jxC
+gAH
 rBQ
 vmi
 vmi
 vmi
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
 vmi
 dPu
 dPu
 fSz
-jPl
+fPZ
 uWp
-xfz
-cvU
-cvU
+oVj
+lkJ
+lkJ
 dPu
 vmi
 vmi
@@ -406812,24 +406875,24 @@ bGf
 bGf
 iVE
 wBK
-dyx
+jrn
 vmi
 vmi
 vmi
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
 vmi
 dPu
-lAF
+cLX
 pda
-gFm
+jxC
 uWp
 lfb
 kFL
@@ -407263,29 +407326,29 @@ bGf
 bGf
 bGf
 vgL
-wij
+tMv
 rBQ
 vmi
 vmi
 vmi
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
 vmi
 dPu
 vAo
 vAo
 vAo
 vAo
-cEN
-jKf
-rgY
+pSy
+fLP
+eRG
 dPu
 vmi
 vmi
@@ -407716,28 +407779,28 @@ bGf
 bGf
 iVE
 wBK
-dyx
+jrn
 vmi
 vmi
 vmi
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
 vmi
 dPu
-toG
-xhH
+pEB
+fBd
 uWp
 uWp
-cEN
-iUW
-vPR
+pSy
+uPf
+aOM
 dPu
 vmi
 vmi
@@ -408167,20 +408230,20 @@ bGf
 bGf
 bGf
 vgL
-jxC
+gAH
 rBQ
 vmi
 vmi
 vmi
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
 vmi
 dPu
 uWp
@@ -408188,8 +408251,8 @@ uWp
 uWp
 uWp
 lfb
-smR
-atr
+kqG
+aqz
 dPu
 vmi
 vmi
@@ -408620,25 +408683,25 @@ bGf
 bGf
 iVE
 wBK
-dyx
+jrn
 vmi
 vmi
 vmi
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
 vmi
 dPu
-eYZ
+nnL
 vAo
 uEt
-wag
+mON
 uEt
 vAo
 vAo
@@ -409071,28 +409134,28 @@ bGf
 bGf
 bGf
 vgL
-wij
+tMv
 rBQ
 vmi
 vmi
 vmi
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
 vmi
 dPu
 pIl
-uPI
+vFY
 pIl
 dPu
 pIl
-uPI
+vFY
 pIl
 dPu
 vmi
@@ -409524,28 +409587,28 @@ bGf
 bGf
 iVE
 wBK
-dyx
+jrn
 vmi
 vmi
 vmi
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
-oWO
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
+aoM
 vmi
 dPu
 hox
 hox
-ojQ
+uNj
 pIl
 hox
 hox
-ojQ
+uNj
 dPu
 vmi
 vmi
@@ -409975,7 +410038,7 @@ bGf
 bGf
 bGf
 vgL
-jxC
+gAH
 rBQ
 vmi
 vmi
@@ -409991,13 +410054,13 @@ vmi
 vmi
 vmi
 dPu
-rrn
-cke
-nTv
+lmP
+rSJ
+mHf
 pIl
-rrn
-cke
-nTv
+lmP
+rSJ
+mHf
 dPu
 vmi
 vmi
@@ -410428,7 +410491,7 @@ bGf
 bGf
 rCV
 wBK
-dyx
+jrn
 vmi
 vmi
 vmi
@@ -410443,13 +410506,13 @@ vmi
 vmi
 vmi
 dPu
-pCd
+bqk
 dPu
-pCd
+bqk
 dPu
-pCd
+bqk
 dPu
-pCd
+bqk
 dPu
 vmi
 vmi
@@ -411778,17 +411841,17 @@ jWw
 vvv
 jWw
 hrE
-mkj
-mFr
-mkj
+xhH
+vUZ
+xhH
 jWw
 mnC
 iWa
-iWa
+fHg
 jWw
-bYk
+mmb
 osX
-bYk
+mmb
 osX
 gHO
 qNT
@@ -412230,22 +412293,22 @@ iWa
 iWa
 iWa
 eps
-mkj
-vIv
-mkj
-esm
+xhH
+nTv
+xhH
+kAF
 iWa
 iWa
 dJt
 eps
-oDj
-fCk
-oDj
+qQj
+uPP
+qQj
 nBo
 vVX
 wBK
 eas
-pKR
+nZP
 ixL
 wBK
 vVX
@@ -412682,9 +412745,9 @@ jWw
 tca
 jWw
 jWw
-mkj
-mFr
-mkj
+xhH
+vUZ
+xhH
 jWw
 qJz
 iWa
@@ -490447,18 +490510,18 @@ bGf
 bGf
 bGf
 bGf
-scT
-scT
-scT
-scT
+hmx
+hmx
+hmx
+hmx
 rqW
 rqW
 rqW
 rqW
-tkB
-hOT
-hOT
-mqT
+cEN
+vnq
+vnq
+oic
 bGf
 bGf
 bGf
@@ -490899,10 +490962,10 @@ bGf
 bGf
 bGf
 bGf
-fiP
-fiP
-fiP
-fiP
+ivq
+ivq
+ivq
+ivq
 fnN
 vrN
 fVk
@@ -490912,10 +490975,10 @@ gxX
 iDj
 vPO
 vrN
-hOT
-hOT
-hMA
-mqT
+vnq
+vnq
+fbW
+oic
 bGf
 bGf
 bGf
@@ -491351,10 +491414,10 @@ oOM
 oOM
 oOM
 bGf
-fiP
-fiP
-fiP
-fiP
+ivq
+ivq
+ivq
+ivq
 hyE
 sPu
 hoS
@@ -491366,8 +491429,8 @@ rqW
 tIs
 aUO
 aUO
-kAF
-scw
+siF
+crj
 bGf
 bGf
 bGf
@@ -491803,10 +491866,10 @@ oOM
 oOM
 oOM
 bGf
-fiP
-fiP
-fiP
-fiP
+ivq
+ivq
+ivq
+ivq
 hyE
 rpt
 ncE
@@ -491818,8 +491881,8 @@ rqW
 tIs
 aUO
 aUO
-kAF
-scw
+siF
+crj
 bGf
 bGf
 bGf
@@ -492255,10 +492318,10 @@ oOM
 oOM
 oOM
 bGf
-fiP
-fiP
-fiP
-fiP
+ivq
+ivq
+ivq
+ivq
 hyE
 eLe
 aUl
@@ -492268,10 +492331,10 @@ pbq
 sen
 fzm
 fzm
-lLV
+els
 aUO
-iJi
-scw
+jVS
+crj
 bGf
 bGf
 bGf
@@ -492707,10 +492770,10 @@ oOM
 oOM
 oOM
 bGf
-fiP
-fiP
-fiP
-fiP
+ivq
+ivq
+ivq
+ivq
 hyE
 pwV
 xqr
@@ -492721,9 +492784,9 @@ kgY
 pbq
 pbq
 aUO
-xXA
-gDG
-scw
+blj
+rLU
+crj
 bGf
 bGf
 bGf
@@ -493159,10 +493222,10 @@ oOM
 oOM
 oOM
 bGf
-fiP
-fiP
-fiP
-fiP
+ivq
+ivq
+ivq
+ivq
 hyE
 tYa
 jXF
@@ -493172,10 +493235,10 @@ tYa
 wkR
 tYa
 tbn
-aCu
-aCu
-aCu
-scw
+uWU
+uWU
+uWU
+crj
 bGf
 bGf
 bGf
@@ -493611,10 +493674,10 @@ oOM
 oOM
 oOM
 bGf
-fiP
-fiP
-fiP
-fiP
+ivq
+ivq
+ivq
+ivq
 hyE
 gxX
 xqr
@@ -493624,10 +493687,10 @@ pzu
 mZP
 fff
 xqr
-cLX
-hPG
-vCO
-scw
+vDT
+aIi
+aEj
+crj
 bGf
 bGf
 bGf
@@ -494063,10 +494126,10 @@ oOM
 bGf
 bGf
 bGf
-fiP
-fiP
-fiP
-fiP
+ivq
+ivq
+ivq
+ivq
 hyE
 vDd
 xqr
@@ -494076,10 +494139,10 @@ hoS
 mZP
 seI
 xqr
-laF
-hPG
-eHY
-scw
+rnI
+aIi
+yeu
+crj
 bGf
 bGf
 bGf
@@ -494515,10 +494578,10 @@ oOM
 bGf
 bGf
 bGf
-fiP
-fiP
-fiP
-fiP
+ivq
+ivq
+ivq
+ivq
 hyE
 iis
 xqr
@@ -494528,10 +494591,10 @@ xqr
 mZP
 fdZ
 dnn
-laF
-hPG
-erO
-scw
+rnI
+aIi
+iCY
+crj
 bGf
 bGf
 bGf
@@ -494967,10 +495030,10 @@ bGf
 bGf
 bGf
 bGf
-fiP
-fiP
-fiP
-fiP
+ivq
+ivq
+ivq
+ivq
 opr
 xkI
 bIu
@@ -494980,10 +495043,10 @@ yib
 mZP
 fSD
 wcX
-laF
-pxW
-hof
-lGl
+rnI
+orR
+mjw
+aoJ
 bGf
 bGf
 bGf
@@ -495419,10 +495482,10 @@ bGf
 bGf
 bGf
 bGf
-scT
-fiP
-fiP
-fiP
+hmx
+ivq
+ivq
+ivq
 rqW
 opr
 dgd
@@ -495431,10 +495494,10 @@ dgd
 rgj
 rgj
 rgj
-ebP
-ebP
-ebP
-lGl
+pWB
+pWB
+pWB
+aoJ
 bGf
 bGf
 bGf
@@ -508526,7 +508589,7 @@ sOx
 vxe
 bmn
 uQS
-ixs
+cVX
 eFM
 hFO
 vxe
@@ -509438,7 +509501,7 @@ uyd
 khf
 lfb
 lfb
-fvC
+prx
 vxe
 vmi
 vmi
@@ -509461,11 +509524,11 @@ lMc
 lMc
 lMc
 vgL
-jAV
+aft
 iVE
-nOC
+sXr
 iVE
-jAV
+aft
 vgL
 lMc
 lMc
@@ -509912,13 +509975,13 @@ lMc
 lMc
 lMc
 lMc
-tMv
-aqz
+pqR
+aEu
 iCo
-vmI
+fjY
 iCo
-dBS
-tMv
+xSh
+pqR
 lMc
 lMc
 lMc
@@ -510816,13 +510879,13 @@ lMc
 lMc
 lMc
 lMc
-tMv
-vwp
+pqR
+rTT
 iCo
 iCo
 iCo
-frA
-tMv
+oWi
+pqR
 lMc
 lMc
 lMc
@@ -511269,11 +511332,11 @@ lMc
 lMc
 lMc
 iVE
-ibZ
+mpa
 iCo
 iCo
 iCo
-xSh
+oRZ
 iVE
 lMc
 lMc
@@ -511720,13 +511783,13 @@ lMc
 lMc
 lMc
 lMc
-tMv
-nnL
-vbt
-vbt
-vbt
-hmp
-tMv
+pqR
+fCk
+yfn
+yfn
+yfn
+vCO
+pqR
 lMc
 lMc
 lMc
@@ -512173,11 +512236,11 @@ lMc
 lMc
 lMc
 iVE
-lnu
+foK
 rCV
 rCV
 rCV
-smZ
+fyA
 iVE
 lMc
 lMc
@@ -512624,13 +512687,13 @@ lMc
 lMc
 lMc
 lMc
-tMv
-gij
-rUb
-rUb
-rUb
-lAt
-tMv
+pqR
+jQJ
+ezM
+ezM
+ezM
+rlj
+pqR
 lMc
 lMc
 lMc
@@ -513041,7 +513104,7 @@ kBl
 pIl
 pqi
 lyG
-aRC
+eXA
 aoO
 aoO
 uDa
@@ -513077,11 +513140,11 @@ lMc
 lMc
 lMc
 vgL
-jAV
+aft
 iVE
-jQJ
+pMW
 iVE
-jAV
+aft
 vgL
 lMc
 lMc
@@ -513942,7 +514005,7 @@ vxe
 pIl
 sWI
 bcB
-lSh
+rPN
 bcB
 bcB
 vxe
@@ -513951,7 +514014,7 @@ lqJ
 pIl
 dPu
 wLC
-lSh
+rPN
 bcB
 oih
 bcB
@@ -514398,8 +514461,8 @@ pNs
 fAA
 bcB
 kby
-bcB
-bcB
+hsS
+rtL
 bcB
 vxe
 rKa
@@ -514850,8 +514913,8 @@ cjs
 wSh
 fAA
 pIl
-pLb
-iol
+hqc
+sRJ
 jiA
 dPu
 wZp
@@ -515307,7 +515370,7 @@ eKq
 fZT
 stR
 fZT
-rPN
+fZT
 rwM
 pYz
 gzi
@@ -515754,8 +515817,8 @@ jiV
 wSh
 fAA
 pIl
-pLb
-oAc
+dTQ
+iUW
 lzQ
 dPu
 dsi
@@ -516206,8 +516269,8 @@ pyP
 fAA
 bcB
 kby
-bcB
-bcB
+wxu
+ncy
 bcB
 vxe
 vRR
@@ -517110,7 +517173,7 @@ pIl
 pIl
 oHt
 pIl
-lcZ
+kac
 lyG
 weS
 vxe
@@ -517554,7 +517617,7 @@ bGf
 uwf
 isS
 iqT
-mDc
+ykK
 ank
 vxe
 wzy
@@ -517564,7 +517627,7 @@ uQS
 rov
 lyG
 lyG
-vYL
+lAt
 dPu
 lLL
 riq
@@ -519381,7 +519444,7 @@ uQL
 uQL
 uQL
 uQL
-jAe
+uxY
 uQL
 uQL
 vmi
@@ -519833,7 +519896,7 @@ vmi
 vmi
 vmi
 vmi
-rhf
+ygd
 vmi
 vmi
 vmi
@@ -520279,14 +520342,14 @@ vmi
 vmi
 vmi
 vmi
-ijk
-sXL
-sXL
-sXL
-sXL
-sXL
-sXL
-laf
+gtR
+pCd
+pCd
+pCd
+pCd
+pCd
+pCd
+pJG
 uQL
 vmi
 vmi
@@ -520731,14 +520794,14 @@ vmi
 vmi
 vmi
 vmi
-blj
-syb
-eja
-pIl
-xUY
-myt
 tqO
-ygd
+gPF
+lnu
+pIl
+dha
+myt
+eDw
+pel
 uQL
 vmi
 vmi
@@ -521183,12 +521246,12 @@ vmi
 vmi
 vmi
 vmi
-blj
-pLb
-jPl
+tqO
+dyx
+fPZ
 pIl
-jCA
-bJB
+hkj
+kAv
 lyG
 oZk
 uQL
@@ -521635,14 +521698,14 @@ vmi
 vmi
 vmi
 vmi
-blj
-lmP
-jPl
+tqO
+wTi
+fPZ
 pIl
-uZN
-vnO
-cRi
-ygd
+ipx
+oWO
+kMx
+pel
 uQL
 vmi
 vmi
@@ -522087,10 +522150,10 @@ vmi
 vmi
 vmi
 vmi
-uMM
+ekz
 uWp
-gFm
-qdH
+jxC
+jKf
 lyG
 lyG
 lyG
@@ -522539,14 +522602,14 @@ vmi
 vmi
 vmi
 vmi
-blj
+tqO
 fmU
 uWp
 pIl
-fBn
+xUY
 fAA
-fFz
-ygd
+jAV
+pel
 uQL
 vmi
 vmi
@@ -522991,14 +523054,14 @@ vmi
 vmi
 vmi
 vmi
-blj
+tqO
 pIl
 pIl
 pIl
 pIl
-xXW
+oPf
 pIl
-ygd
+pel
 uQL
 vmi
 vmi
@@ -523443,14 +523506,14 @@ vmi
 vmi
 vmi
 vmi
-blj
-aVE
+tqO
+bJB
 fAA
-fSB
-dTQ
+qbr
+sKU
 lyG
-dTQ
-ygd
+sKU
+pel
 uQL
 vmi
 vmi
@@ -523895,12 +523958,12 @@ vmi
 vmi
 vmi
 vmi
-uMM
-oic
+ekz
+qdH
 fAA
-ida
+dOz
 lyG
-eMi
+aVE
 lyG
 oZk
 uQL
@@ -524347,14 +524410,14 @@ vmi
 vmi
 vmi
 vmi
-blj
+tqO
 lyG
 lyG
 lyG
 lyG
 lyG
 lyG
-ygd
+pel
 uQL
 vmi
 vmi
@@ -524799,13 +524862,13 @@ vmi
 vmi
 vmi
 vmi
-blj
-iFA
+tqO
+tyL
 hox
 hox
 hox
 lyG
-hmx
+iLV
 oZk
 uQL
 vmi
@@ -525251,14 +525314,14 @@ vmi
 vmi
 vmi
 vmi
-blj
+tqO
+fvC
+cVo
 cUj
-oPf
-eeK
-mIU
-hfn
-bgr
-ygd
+hzN
+ilr
+uMM
+pel
 uQL
 vmi
 vmi
@@ -525703,14 +525766,14 @@ vmi
 vmi
 vmi
 vmi
-rtL
-igz
-igz
-igz
-igz
-igz
-igz
-eTw
+wQL
+sRD
+sRD
+sRD
+sRD
+sRD
+sRD
+dsL
 uQL
 vmi
 vmi
@@ -527943,9 +528006,9 @@ jWw
 wux
 jWw
 jWw
-nUS
-nUS
-nUS
+bGf
+bGf
+bGf
 iVE
 iWa
 iWa
@@ -528400,7 +528463,7 @@ aBB
 aBB
 jWw
 jWw
-iWa
+afp
 jWw
 jWw
 vmi

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -11,9 +11,11 @@
 	},
 /area/rogue/under/town/basement/keep)
 "aat" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "aaB" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
@@ -23,24 +25,7 @@
 	},
 /area/rogue/indoors/town/magician)
 "aaE" = (
-/obj/structure/fluff/statue/knightalt,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep)
-"aaH" = (
-/obj/structure/stairs,
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
-/area/rogue/indoors/town/manor)
-"aaK" = (
-/obj/structure/table/wood,
-/obj/item/candle/gold/lit{
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "aaO" = (
 /obj/structure/fluff/statue/knight,
@@ -179,11 +164,19 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "adH" = (
-/obj/structure/fluff/statue/knight/r,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
+"adV" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "adW" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -268,10 +261,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "aft" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
-	},
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/outdoors/town/roofs/keep)
 "afv" = (
 /obj/structure/chair/wood/rogue/fancy,
 /obj/effect/landmark/start/guildmaster,
@@ -312,9 +304,13 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/woods)
 "agd" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/town)
 "agh" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -530,9 +526,14 @@
 	},
 /area/rogue/indoors/town)
 "ajc" = (
-/obj/structure/fluff/statue/knight/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "ajm" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -584,10 +585,15 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town)
 "akC" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
-/turf/open/floor/rogue/hexstone,
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "longtable"
+	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "akG" = (
 /obj/item/natural/stone{
@@ -613,9 +619,15 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "akS" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32;
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "alb" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/tile,
@@ -695,14 +707,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "amM" = (
-/obj/structure/closet/crate/chest,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "amN" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/herringbone,
@@ -721,24 +728,15 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/roofs)
 "ank" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "garrison";
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town/roofs/keep)
 "ans" = (
 /obj/effect/spawner/roguemap/hauntpile,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/mazedungeon)
 "ant" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/obj/item/candle/candlestick/silver/lit,
-/turf/open/floor/rogue/cobble,
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "anw" = (
 /obj/structure/bars,
@@ -909,22 +907,21 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "aoJ" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/natural/cloth,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/chair/bench/ultimacouch/r,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "aoM" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 8
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
+	dir = 1
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/manor)
 "aoO" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "aoW" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = -32
@@ -995,26 +992,26 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "aqr" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "walls"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/fabric_double,
+/turf/open/floor/carpet/stellar,
+/area/rogue/indoors/town/manor)
 "aqx" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/indoors)
 "aqz" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/wallclock,
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "aqA" = (
-/obj/item/roguecoin/gold/pile,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/vault)
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/obj/structure/fermentation_keg/water,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "aqC" = (
 /obj/structure/winch{
 	gid = "tertiarygate";
@@ -1125,11 +1122,6 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
-"asw" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
 "asJ" = (
 /obj/effect/decal/cleanable/debris/glassy,
 /turf/open/floor/rogue/naturalstone,
@@ -1183,12 +1175,14 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/beach)
 "atr" = (
-/obj/structure/bearpelt{
-	desc = "A hide of a slain bear. It looks rich and expensive.";
-	pixel_y = 20
-	},
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/drawer,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/natural/feather,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/outdoors/town/roofs)
 "atx" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mossback,
 /turf/open/water/ocean,
@@ -1199,7 +1193,16 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
 "atE" = (
-/turf/open/water/bath,
+/obj/structure/chair/wood/rogue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/obj/effect/landmark/start/lord,
+/turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
 "atF" = (
 /obj/structure/fluff/walldeco/church/line,
@@ -1377,9 +1380,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
 "awz" = (
-/obj/structure/chair/bench,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "awB" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -1552,22 +1557,8 @@
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "azd" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/roguegrass/herb/rosa{
-	pixel_x = 0;
-	pixel_y = 3
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	pixel_x = 32;
-	pixel_y = -24
-	},
-/turf/open/floor/rogue/grasscold,
+/obj/structure/chair/wood/rogue/fancy,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "azh" = (
 /obj/structure/noose/gallows{
@@ -1665,7 +1656,7 @@
 "aBq" = (
 /obj/structure/flora/roguegrass/herb/rosa,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/outdoors/town)
 "aBx" = (
 /obj/effect/decal/remains/mole,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
@@ -1704,11 +1695,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "aCu" = (
-/obj/machinery/light/rogue/torchholder/c{
+/turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 1
 	},
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/manor)
 "aCJ" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/rogue/AzureSand,
@@ -1748,28 +1738,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
-"aDb" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/cooking/platter/silver{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/cooking/platter/silver,
-/obj/item/kitchen/fork/silver{
-	pixel_x = 14;
-	pixel_y = 6
-	},
-/obj/item/kitchen/spoon/gold{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "aDh" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/dirt/road,
@@ -1823,14 +1791,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
 "aEj" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 4;
-	locked = 1;
-	lockid = "steward";
-	name = "Stewardry Office"
+/obj/structure/fluff/statue/astrata/gold{
+	pixel_x = -18;
+	pixel_y = 3
 	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "aEn" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 4
@@ -1850,13 +1816,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "aEu" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/effect/landmark/start/marshal{
-	dir = 8
+/obj/effect/decal/cobbleedge{
+	dir = 7;
+	pixel_x = 13
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "aEz" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
@@ -2010,9 +1975,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
 "aHM" = (
-/obj/structure/flora/roguegrass/bush/wall/tall,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/closed/wall/mineral/rogue/decostone,
+/area/rogue/indoors/town/manor)
 "aHN" = (
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchmarble,
@@ -2053,16 +2021,16 @@
 /turf/open/floor/rogue/concrete/bronze,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "aIi" = (
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
+/obj/structure/bed/rogue/inn/double{
+	dir = 4
 	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/obj/item/bedsheet/rogue/fabric_double,
+/obj/effect/landmark/start/apothecary,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/outdoors/town/roofs)
 "aIn" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grassyel,
@@ -2246,18 +2214,10 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "aLr" = (
-/obj/structure/stairs/fancy/l{
-	dir = 1
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/carpet/lord{
-	icon_state = "carpet_l"
-	},
-/area/rogue/indoors/town/manor)
-"aLs" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/hexstone,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "aLA" = (
 /obj/structure/chair/bench/church/smallbench{
@@ -2267,9 +2227,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "aLW" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "royal";
-	name = "Lord's Apartment"
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -2343,8 +2302,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "aNj" = (
-/obj/effect/landmark/start/knight,
-/turf/open/floor/rogue/carpet/lord/center,
+/obj/structure/mineral_door/wood{
+	name = "Service Halls";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "aNk" = (
 /obj/structure/table/wood{
@@ -2386,15 +2350,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "aOc" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 10
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	pixel_y = -3
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs/keep)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "aOg" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor5-old"
@@ -2415,9 +2376,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach)
 "aOM" = (
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/garrison)
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "aOO" = (
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/alt/pink,
 /turf/open/floor/rogue/churchbrick,
@@ -2527,17 +2492,12 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/mountains/decap)
 "aQt" = (
-/obj/item/rogueweapon/huntingknife/chefknife,
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
 	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "aQB" = (
 /obj/machinery/light/rogue/chand,
 /turf/open/transparent/openspace,
@@ -2627,12 +2587,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
 "aRC" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "steward"
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
-/turf/open/floor/rogue/tile/tilerg,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "aRF" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -2658,9 +2619,13 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "aSm" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/town/basement/keep)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "aSu" = (
 /obj/structure/closet/crate/chest/wicker{
 	opened = 1
@@ -2720,9 +2685,9 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cave/skeletoncrypt)
 "aUk" = (
-/obj/machinery/light/rogue/lanternpost,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs/keep)
 "aUl" = (
 /obj/effect/landmark/start/physician,
 /turf/open/floor/carpet/red,
@@ -2783,10 +2748,9 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/mazedungeon)
 "aVE" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town)
+/obj/structure/rogue/trophy/deer,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "aVL" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -2814,6 +2778,9 @@
 /obj/structure/fluff/railing/border,
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/mountains/decap)
+"aVY" = (
+/turf/closed/wall/mineral/rogue/decostone/end,
+/area/rogue/indoors/town/manor)
 "aWc" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
@@ -2979,22 +2946,11 @@
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/shelter)
 "aYU" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
 	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/item/paper,
-/obj/item/natural/feather{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/exposed/town/keep)
 "aZb" = (
 /obj/effect/wisp,
 /obj/effect/decal/remains/human,
@@ -3040,6 +2996,13 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"aZH" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	name = "Jester's Chambers";
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "aZJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -3169,21 +3132,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/magician)
 "bbz" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/fork/silver{
-	pixel_x = 14;
-	pixel_y = 6
-	},
-/obj/item/kitchen/spoon/silver{
-	pixel_x = -14;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/bowl/silver{
-	pixel_x = 2
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "bbC" = (
 /obj/effect/decal/cleanable/blood,
@@ -3328,13 +3277,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "bdw" = (
-/obj/structure/mineral_door/wood/violet{
-	locked = 1;
-	lockid = "steward";
-	name = "Clerk Bedroom"
+/obj/structure/chair/wood/rogue{
+	pixel_x = 1;
+	pixel_y = -6
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "bdx" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt/road,
@@ -3358,9 +3306,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/magician)
 "bdV" = (
-/obj/structure/chair/wood/rogue/fancy,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/town/roofs)
 "bdZ" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/mazedungeon)
@@ -3388,12 +3336,10 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/church/basement)
 "beu" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "manor";
-	name = "Servant's Entry"
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "bey" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -3427,12 +3373,6 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
-"bfR" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet/lord/right,
-/area/rogue/indoors/town/manor)
 "bfT" = (
 /obj/structure/bed/rogue/bedroll,
 /obj/effect/landmark/start/vagrant,
@@ -3470,9 +3410,18 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/cave)
 "bgr" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/obj/item/candle/skull/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = 11;
+	pixel_y = 1
+	},
+/obj/item/candle/yellow/lit{
+	pixel_x = -13;
+	pixel_y = 3
+	},
+/obj/machinery/light/rogue/wallfire/candle/floorcandle,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "bgG" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -3543,14 +3492,15 @@
 /turf/closed/wall/mineral/rogue/roofwall/middle,
 /area/rogue/indoors)
 "bhE" = (
-/obj/structure/bed/rogue/inn,
-/obj/item/bedsheet/rogue/fabric,
-/obj/effect/landmark/start/councillor,
-/obj/structure/fluff/walldeco/rpainting/crown{
-	pixel_y = 32
+/obj/structure/lever/wall{
+	dir = 5;
+	redstone_id = "stewardshutter";
+	pixel_x = 16;
+	pixel_y = 1
 	},
-/turf/open/floor/carpet/inn,
-/area/rogue/under/town/basement/keep)
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "bhJ" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cave)
@@ -3588,11 +3538,10 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
 "biT" = (
-/obj/structure/fluff/railing/border{
+/turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/town/roofs/keep)
 "biV" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -3600,6 +3549,14 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/skeletoncrypt)
+"biX" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
+/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
+/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
+/obj/item/clothing/suit/roguetown/armor/gambeson/lord,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "bjm" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /obj/structure/bars/passage/steel{
@@ -3667,13 +3624,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/physician)
 "bko" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "garrison";
-	name = "squireroom door"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/walldeco/steward,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "bkv" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -3697,12 +3650,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "blj" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wcr";
+/obj/structure/mineral_door/wood/donjon{
 	locked = 1;
-	lockid = "sheriff"
+	lockid = "garrison"
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "blp" = (
 /mob/living/carbon/human/species/dwarfskeleton/ambush,
@@ -3754,9 +3706,16 @@
 	},
 /area/rogue/outdoors/woods)
 "bmn" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bowl/silver,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/obj/structure/bed/rogue,
+/obj/effect/landmark/start/squire{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "bmv" = (
 /obj/structure/table/wood{
@@ -3900,13 +3859,19 @@
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"bpd" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/manor)
 "bpp" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "bpr" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -3922,17 +3887,25 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
 "bpF" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/rack/rogue,
-/obj/item/clothing/wrists/roguetown/bracers/leather/heavy,
-/obj/item/clothing/wrists/roguetown/bracers/leather/heavy,
-/turf/open/floor/rogue/tile,
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/rollie/nicotine{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/clothing/mask/cigarette/rollie/nicotine/cheroot{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/turf/open/floor/rogue/tile/bath,
 /area/rogue/under/town/basement/keep)
 "bpK" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 1
 	},
+/obj/item/millstone,
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/manor)
 "bpP" = (
 /obj/effect/decal/cobbleedge{
@@ -3957,9 +3930,10 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "bqk" = (
-/obj/structure/bookcase/random/archive,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/physician)
+/turf/closed/wall/mineral/rogue/roofwall/middle{
+	dir = 8
+	},
+/area/rogue/indoors/town/manor)
 "bqp" = (
 /obj/structure/fluff/walldeco/chains{
 	icon_state = "chains3"
@@ -3989,6 +3963,14 @@
 "bqP" = (
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/mountains)
+"bqW" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
+	},
+/area/rogue/indoors/town/manor)
 "bqZ" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/churchrough,
@@ -4043,13 +4025,10 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "brE" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/lanternpost,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "brN" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "nightmaiden"
@@ -4082,22 +4061,28 @@
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "bso" = (
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	pixel_x = -4;
-	pixel_y = 0
+/obj/structure/table/wood{
+	icon_state = "map6"
 	},
+/obj/item/reagent_containers/glass/cup/silver{
+	desc = "A pewter goblet, cheaper than silver, but with a similar shine!";
+	name = "pewter goblet";
+	pixel_x = -11
+	},
+/obj/item/candle/silver/lit,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "bsx" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/effect/decal/cobbleedge,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/floordoor/gatehatch/inner{
+	redstone_id = "wallbridge"
 	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
+/obj/structure/kybraxor{
+	pixel_x = -32;
+	pixel_y = -32;
+	redstone_id = "wallbridge"
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "bsz" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -4107,6 +4092,15 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"bsC" = (
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "bsE" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/wood,
@@ -4166,14 +4160,10 @@
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/outdoors/mountains)
 "btu" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/item/candle/gold/lit{
-	pixel_y = 6
-	},
-/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "btx" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
@@ -4325,15 +4315,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "bvB" = (
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/obj/effect/landmark/start/servant,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 5
 	},
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/town/roofs/keep)
 "bvH" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -4418,10 +4403,12 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "bwV" = (
 /obj/structure/fluff/railing/border{
-	dir = 8
+	dir = 10
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/town/roofs/keep)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "bwW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -4495,6 +4482,9 @@
 /area/rogue/indoors)
 "byl" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "byn" = (
@@ -4524,6 +4514,10 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
+"byI" = (
+/obj/effect/landmark/start/steward,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "byP" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/cobble,
@@ -4662,8 +4656,8 @@
 /area/rogue/under/cave/goblinfort)
 "bAU" = (
 /obj/structure/flora/roguegrass/bush,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
 "bAY" = (
 /obj/item/book/rogue/bibble,
 /turf/open/floor/rogue/hexstone,
@@ -4862,13 +4856,15 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"bEd" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
+"bEj" = (
+/obj/structure/bed/rogue/inn/double{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/item/bedsheet/rogue/double_pelt{
+	dir = 1
 	},
+/obj/effect/landmark/start/knight,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "bEq" = (
 /obj/structure/fluff/littlebanners/greenwhite{
@@ -5017,13 +5013,8 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
 "bHv" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/tile,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "bHE" = (
 /mob/living/simple_animal/hostile/rogue/mirespider_lurker,
@@ -5040,12 +5031,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/dukecourt)
 "bHU" = (
-/obj/structure/gate{
-	gid = "thronegate";
-	name = "The Throne";
-	redstone_id = "thronegate"
-	},
-/turf/open/floor/rogue/carpet/lord/left,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
 "bHV" = (
 /turf/open/floor/rogue/tile,
@@ -5185,17 +5171,9 @@
 /turf/open/water/swamp,
 /area/rogue/indoors/cave)
 "bJB" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/obj/structure/roguewindow/openclose/reinforced,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "bJH" = (
 /obj/structure/table/wood,
 /obj/item/paper/scroll,
@@ -5230,9 +5208,8 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "bKp" = (
-/obj/structure/fluff/walldeco/chains,
-/turf/open/floor/rogue/wood,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/outdoors/town/roofs)
 "bKv" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -5448,12 +5425,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "bOt" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 4
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "bOu" = (
 /obj/effect/landmark/mapGenerator/rogue/mountain{
@@ -5479,8 +5456,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/orcdungeon)
 "bPd" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/carpet,
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "bPl" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
@@ -5516,10 +5495,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "bPN" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/item/reagent_containers/glass/bucket/pot,
+/obj/effect/decal/cobbleedge{
+	dir = 6
 	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "bPS" = (
 /obj/structure/table/wood{
@@ -5573,10 +5554,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "bQX" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/mineral_door/wood/fancywood{
+	name = "Lord's Office";
+	lockid = "lord";
+	locked = 1
 	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "bQY" = (
 /obj/structure/mineral_door/wood{
@@ -5662,10 +5645,10 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
 "bSa" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "manor"
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "bSb" = (
 /obj/structure/stairs/stone{
@@ -5879,8 +5862,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "bVl" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile/masonic,
+/obj/structure/table/vtable,
+/obj/item/clothing/mask/cigarette/pipe/westman,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "bVo" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -5927,13 +5911,11 @@
 /area/rogue/under/town/sewer)
 "bVW" = (
 /obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
+	icon_state = "largetable";
+	dir = 5
 	},
-/obj/item/millstone{
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/cobble,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "bVY" = (
 /turf/closed/wall/mineral/rogue/tent{
@@ -6050,9 +6032,17 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
 "bYk" = (
-/obj/structure/chair/bench/ultimacouch/r,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "bYr" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt/road,
@@ -6140,8 +6130,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "bZC" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/wood,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/closed/wall/mineral/rogue/decostone/long{
+	dir = 1
+	},
 /area/rogue/indoors/town/manor)
 "bZI" = (
 /obj/structure/bars/pipe{
@@ -6151,10 +6143,12 @@
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/basement/keep)
 "bZJ" = (
-/obj/effect/landmark/start/knight,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 8
 	},
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "bZT" = (
 /obj/structure/stairs{
@@ -6297,6 +6291,13 @@
 /obj/item/book/rogue/cardgame,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
+"cdL" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "cdO" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 4;
@@ -6441,6 +6442,12 @@
 	icon_state = "plating2"
 	},
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"cgt" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "cgw" = (
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -6519,32 +6526,24 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "cik" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/bookcase,
+/obj/item/book/rogue/tales3,
+/obj/item/book/rogue/sword,
+/obj/item/book/rogue/tales1,
+/obj/item/book/rogue/law,
+/obj/item/book/rogue/nitebeast,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "ciy" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown/fallgown,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/random,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
-/obj/item/clothing/suit/roguetown/armor/silkcoat,
-/obj/item/clothing/suit/roguetown/shirt/tunic/random,
-/obj/item/clothing/suit/roguetown/shirt/tunic/black,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
-/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk,
-/obj/item/clothing/cloak/half/red,
-/obj/item/clothing/cloak/half,
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/storage/backpack/rogue/satchel,
-/turf/open/floor/rogue/carpet/lord/center,
+/obj/effect/landmark/start/prince,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "ciG" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/fluff/clock,
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = 2;
+	pixel_y = 16
+	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "ciQ" = (
 /obj/structure/table/wood{
@@ -6575,13 +6574,18 @@
 /area/rogue/indoors/shelter/mountains/decap)
 "cjs" = (
 /obj/structure/table/wood{
-	dir = 2;
-	icon_state = "longtable"
+	icon_state = "map1"
 	},
-/obj/item/roguestatue/glass{
-	pixel_y = 8
+/obj/item/cooking/platter/silver{
+	pixel_x = 6;
+	pixel_y = 10
 	},
-/turf/open/floor/rogue/carpet,
+/obj/item/cooking/platter/silver,
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "cjx" = (
 /obj/structure/bed/rogue/shit{
@@ -6610,10 +6614,13 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield/eora)
 "cke" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/obj/item/tablecloth/silk{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "ckm" = (
 /turf/open/water/ocean,
 /area/rogue/under/cavewet/bogcaves)
@@ -6893,11 +6900,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "cpa" = (
-/obj/structure/roguethrone,
-/obj/structure/roguemachine/titan{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/carpet/lord/center,
+/turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/manor)
 "cpb" = (
 /obj/item/natural/bone,
@@ -6913,12 +6916,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "cpI" = (
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = 12;
-	pixel_y = -9
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "cpM" = (
 /obj/structure/vine,
 /turf/closed/wall/mineral/rogue/pipe,
@@ -6935,19 +6937,11 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/cell)
 "cqj" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
 	},
-/obj/effect/decal/cobbleedge,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/pillory/reinforced{
-	lockid = list("garrison")
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "cqn" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 4
@@ -7001,12 +6995,19 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "crj" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = 5;
+	pixel_y = 0
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "crl" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/beach)
@@ -7021,9 +7022,8 @@
 	},
 /area/rogue/outdoors/rtfield)
 "cry" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/fabric_double,
-/turf/open/floor/rogue/carpet/lord/center,
+/obj/structure/roguewindow/openclose,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "crB" = (
 /obj/structure/rack/rogue,
@@ -7178,11 +7178,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
 "ctB" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
+/turf/open/floor/rogue/rooftop/green{
+	dir = 8
 	},
 /area/rogue/indoors/town/manor)
 "ctD" = (
@@ -7302,35 +7299,12 @@
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
 "cvU" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "steward"
-	},
-/obj/item/roguekey/manor,
-/obj/item/roguekey/walls,
-/obj/item/roguekey/steward,
-/obj/item/roguekey/church,
-/obj/item/roguekey/dungeon,
-/obj/item/roguekey/graveyard,
-/obj/item/roguekey/garrison,
-/obj/item/roguekey/mercenary,
-/obj/item/roguekey/tavern,
-/obj/item/roguekey/physician,
-/obj/item/roguekey/farm,
-/obj/item/roguekey/tailor,
-/obj/item/roguekey/shop,
-/obj/item/roguekey/nightmaiden,
-/obj/structure/lever/wall{
+/obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_x = 32;
-	redstone_id = "steward_shutter"
+	pixel_y = 0
 	},
-/obj/item/roguekey/archive,
-/obj/item/roguekey/apartments/stable1,
-/obj/item/roguekey/apartments/stable2,
-/obj/item/roguekey/tavernkeep,
-/obj/item/roguekey/tower,
-/turf/open/floor/rogue/tile/tilerg,
-/area/rogue/indoors/town)
+/turf/open/water/bath,
+/area/rogue/under/town/basement/keep)
 "cvV" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
@@ -7361,10 +7335,12 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
 "cwe" = (
-/obj/structure/chair/bench/church{
-	dir = 1
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "manor";
+	name = "Councilor's Chambers"
 	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "cwC" = (
 /obj/structure/fluff/statue/knight/r,
@@ -7497,8 +7473,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
 "cyA" = (
-/obj/structure/chair/bench/church/r,
-/turf/open/floor/rogue/cobble,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "cyM" = (
 /obj/structure/stationary_bell{
@@ -7736,18 +7714,19 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "cDw" = (
-/obj/structure/bed/rogue/inn/double{
-	dir = 1
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
 	},
-/obj/item/bedsheet/rogue/fabric_double{
-	dir = 1
+/obj/effect/decal/cobbleedge,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/effect/landmark/start/apothecary,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/structure/pillory/reinforced{
+	lockid = list("garrison")
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/physician)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "cDB" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/under/cave/dukecourt)
@@ -7795,9 +7774,17 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "cEN" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "cEP" = (
 /obj/structure/rack/rogue/shelf/big{
 	icon_state = "shelf_biggest";
@@ -7891,7 +7878,26 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "cGC" = (
-/obj/machinery/light/rogue/torchholder/c,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/effect/decal/cobbleedge{
+	icon_state = "borderfall";
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	pixel_x = 0;
+	pixel_y = -6
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
 "cGD" = (
@@ -7940,7 +7946,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/town/roofs/keep)
 "cHu" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/grass,
@@ -8035,12 +8041,6 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/dwarfin)
-"cJk" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "cJt" = (
 /obj/structure/rack/rogue,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -8208,11 +8208,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "cLX" = (
-/obj/structure/mirror{
-	pixel_y = 28
+/obj/structure/roguewindow/openclose{
+	dir = 4
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/town/roofs)
 "cMc" = (
 /obj/structure/stairs{
 	dir = 1
@@ -8247,7 +8247,7 @@
 	},
 /area/rogue/indoors/town)
 "cMu" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "cMw" = (
@@ -8335,14 +8335,13 @@
 	},
 /area/rogue/indoors/town)
 "cNi" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 9
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/garrison)
 "cNn" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -8374,13 +8373,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "cOh" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/obj/structure/flora/roguegrass,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk"
 	},
-/turf/open/floor/rogue/grassyel,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
 "cOi" = (
 /obj/structure/rack/rogue,
@@ -8740,15 +8736,14 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach)
 "cUj" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/buckler,
-/turf/open/floor/rogue/tile,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/water/bath,
 /area/rogue/under/town/basement/keep)
 "cUk" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/shoes/roguetown/boots/armor/iron,
-/obj/item/clothing/shoes/roguetown/boots/armor/iron,
-/turf/open/floor/rogue/tile,
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "cUm" = (
 /obj/structure/fluff/walldeco/chains{
@@ -8794,6 +8789,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
+"cVe" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "cVk" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/tunic/white,
@@ -8810,16 +8814,14 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "cVo" = (
-/obj/structure/bed/rogue/inn/double{
-	dir = 4
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cobbleedge,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/effect/landmark/start/apothecary,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/physician)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "cVp" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -8837,19 +8839,12 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"cVU" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
 "cVX" = (
 /obj/structure/chair/wood/rogue/fancy{
-	dir = 1
+	dir = 4
 	},
-/obj/effect/landmark/start/guard_captain,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/manor)
 "cWe" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/cobble,
@@ -8894,6 +8889,16 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach/forest)
+"cWR" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/structure/mirror,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement/keep)
 "cWT" = (
 /obj/structure/fluff/walldeco/chains{
 	icon_state = "chains7"
@@ -9096,20 +9101,19 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
 "dat" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/stairs/fancy/l{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood,
+/turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/manor)
 "dau" = (
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 9
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "daw" = (
 /obj/structure/fluff/railing/border{
 	dir = 5;
@@ -9249,8 +9253,12 @@
 	dir = 1;
 	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "ddu" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/church,
@@ -9308,15 +9316,20 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "deO" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
-"deQ" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/cobble,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
+"deQ" = (
+/obj/structure/fluff/clock,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "deZ" = (
 /obj/effect/decal/cobbleedge{
@@ -9396,11 +9409,8 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "dgz" = (
-/obj/structure/chair/wood/rogue/throne,
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/wood,
+/obj/structure/stairs/stone/d,
+/turf/closed,
 /area/rogue/indoors/town/manor)
 "dgC" = (
 /obj/structure/plasticflaps,
@@ -9429,11 +9439,12 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/mountains/decap)
 "dha" = (
-/obj/structure/fluff/walldeco/bigpainting/lake{
-	pixel_x = 0
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = 8;
+	pixel_y = 0
 	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/basement)
 "dhf" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/greenstone,
@@ -9477,9 +9488,11 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "dir" = (
-/turf/open/floor/rogue/tile/masonic{
+/obj/structure/table/wood{
+	icon_state = "longtable_mid";
 	dir = 1
 	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "diy" = (
 /turf/open/floor/rogue/cobblerock,
@@ -9527,13 +9540,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "djh" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "knight";
-	name = "Knight's Chamber"
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "djl" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder,
 /turf/open/floor/rogue/dirt,
@@ -9584,10 +9597,8 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/shelter/mountains/decap)
 "dkt" = (
-/obj/structure/table/wood,
-/obj/item/book/rogue/law,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/blocks/bluestone,
+/area/rogue/outdoors/exposed/town/keep)
 "dky" = (
 /obj/item/natural/rock/salt,
 /turf/open/floor/rogue/hexstone,
@@ -9611,10 +9622,6 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/physician)
-"dkT" = (
-/obj/structure/fluff/wallclock,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/manor)
 "dls" = (
 /obj/structure/stairs{
 	dir = 8
@@ -9715,12 +9722,9 @@
 /turf/open/floor/rogue/volcanic,
 /area/rogue/under/cave/dragonden)
 "dnk" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "longtable"
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 6
 	},
-/obj/item/clothing/ring/gold,
-/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "dnl" = (
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
@@ -9739,7 +9743,7 @@
 /area/rogue/under/cave/skeletoncrypt)
 "dnA" = (
 /obj/structure/fluff/walldeco/painting/queen,
-/turf/closed/wall/mineral/rogue/decostone/cand,
+/turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/manor)
 "dnE" = (
 /obj/structure/fluff/railing/border{
@@ -9893,8 +9897,8 @@
 	icon_state = "cobbleedge-e"
 	},
 /obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
 "dqn" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/chair/wood/rogue/chair3{
@@ -9929,10 +9933,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/woods)
 "dqz" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
 	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
 "dqB" = (
 /obj/structure/bars/pipe{
@@ -9947,9 +9951,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "dqE" = (
-/obj/structure/flora/roguegrass/herb/random,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/garrison)
 "dqS" = (
 /obj/item/reagent_containers/glass/cup/silver{
 	name = "pewter goblet";
@@ -9985,21 +9991,17 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
-"drt" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "drA" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "drE" = (
-/turf/open/floor/rogue/carpet/lord/left,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/wallfire/candle/blue{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/manor)
 "drN" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/magician)
@@ -10012,12 +10014,8 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "drS" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "manor";
-	name = "Storage Room"
-	},
 /turf/open/floor/rogue/tile/masonic{
-	dir = 1
+	dir = 4
 	},
 /area/rogue/indoors/town/manor)
 "drT" = (
@@ -10056,17 +10054,12 @@
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/magician)
 "dsi" = (
-/obj/structure/fluff/walldeco/stone{
+/obj/structure/fluff/statue/gargoyle,
+/obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
-"dsl" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/indoors/town)
 "dsm" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -10086,10 +10079,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "dsv" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "manor";
-	name = "Guest Room I"
+/obj/structure/bed/rogue,
+/obj/effect/landmark/start/squire{
+	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -10329,8 +10321,14 @@
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "dyx" = (
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/under/cave)
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/exposed/town/keep)
 "dyA" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
@@ -10349,14 +10347,10 @@
 	},
 /area/rogue/indoors/town)
 "dyQ" = (
-/obj/item/book/rogue/beardling,
-/obj/item/book/rogue/blackmountain,
-/obj/item/book/rogue/sword,
-/obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/turf/closed/wall/mineral/rogue/stone{
+	max_integrity = 50000
 	},
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/exposed/town/keep)
 "dyR" = (
 /obj/structure/table/church{
 	icon_state = "churchtable_end"
@@ -10587,9 +10581,10 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "dDx" = (
-/obj/item/book/rogue/law,
-/obj/item/book/rogue/necra,
-/obj/structure/bookcase,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -10648,19 +10643,23 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "dEP" = (
-/obj/structure/mannequin,
-/obj/item/clothing/suit/roguetown/armor/plate/half,
-/obj/item/clothing/head/roguetown/helmet/sallet,
-/turf/open/floor/rogue/tile,
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/silver/lit,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 10;
+	pixel_y = -70
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
 "dEQ" = (
-/obj/structure/flora/roguegrass/bush/wall/tall,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/flora/roguegrass/bush,
+/obj/structure/fluff/railing/fence{
+	dir = 1
 	},
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "dEU" = (
 /obj/structure/flora/roguetree/stump/log{
 	pixel_x = -10
@@ -10672,11 +10671,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "dFa" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "longtable"
 	},
-/turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/indoors/town)
+/obj/item/candle/silver/lit,
+/turf/open/floor/rogue/carpet/lord/left,
+/area/rogue/indoors/town/manor)
 "dFh" = (
 /obj/structure/stairs,
 /obj/machinery/light/rogue/torchholder/r,
@@ -10690,8 +10691,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "dFk" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle,
-/area/rogue/indoors/town/physician)
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/under/town/basement/keep)
 "dFp" = (
 /obj/structure/bars/pipe,
 /obj/structure/bars/pipe{
@@ -10914,14 +10920,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "dJv" = (
-/obj/item/rogue/instrument/lute,
-/obj/item/rogue/instrument/harp,
-/obj/item/rogue/instrument/guitar,
-/obj/item/rogue/instrument/flute,
-/obj/structure/closet/crate/chest,
-/obj/item/rogue/instrument/accord,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "dJx" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -10953,19 +10956,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/underdark)
 "dKe" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/item/roguekey/armory,
-/obj/item/roguekey/sheriff,
-/obj/item/roguekey/dungeon,
-/obj/item/roguekey/walls,
-/obj/item/roguekey/manor,
-/obj/item/storage/keyring,
-/obj/item/storage/belt/rogue/leather/steel/tasset,
-/obj/item/roguekey/warden,
-/obj/item/roguekey/sergeant,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "dKf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -11079,14 +11071,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/dwarfin)
 "dMi" = (
-/obj/structure/mineral_door/bars{
-	lockid = "manor"
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/garrison)
 "dMk" = (
-/obj/structure/fluff/statue/knight/r,
-/turf/open/floor/rogue/cobble,
+/turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/under/town/basement/keep)
 "dMl" = (
 /obj/machinery/light/rogue/torchholder/c,
@@ -11120,6 +11108,13 @@
 	},
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/mountains/decap)
+"dMM" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/garrison)
 "dMS" = (
 /obj/structure/table/church,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -11132,9 +11127,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "dNg" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "physician"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "dNl" = (
 /obj/item/natural/rock/salt,
 /turf/open/floor/rogue/dirt/road,
@@ -11184,14 +11182,22 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "dNO" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/double_pelt,
-/turf/open/floor/rogue/carpet/lord/center,
-/area/rogue/under/town/basement/keep)
+/obj/structure/chair/bench/church/mid,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/basement)
 "dOd" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
+"dOj" = (
+/obj/structure/mineral_door/wood{
+	name = "Council Office";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "dOo" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -11263,10 +11269,7 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap)
 "dPu" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/manor)
 "dPB" = (
 /obj/structure/fluff/railing/border{
@@ -11465,10 +11468,15 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
 "dTb" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/shirt/tunic,
+/obj/item/clothing/suit/roguetown/shirt/tunic,
+/obj/item/clothing/suit/roguetown/shirt/tunic,
+/obj/item/clothing/under/roguetown/skirt,
+/obj/item/clothing/under/roguetown/skirt,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "dTd" = (
 /obj/structure/fluff/psycross/zizocross,
@@ -11492,12 +11500,13 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cavewet/bogcaves)
 "dTu" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "steward"
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 32
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/obj/effect/particle_effect/smoke/transparent,
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "dTv" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
@@ -11531,11 +11540,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "dTQ" = (
-/obj/structure/fermentation_keg/random,
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
 	},
-/area/rogue/under/town/basement/keep)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs/keep)
 "dTS" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -11552,6 +11561,11 @@
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"dUr" = (
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 1
+	},
+/area/rogue/indoors/town/manor)
 "dUs" = (
 /obj/structure/spider/stickyweb,
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
@@ -11714,11 +11728,15 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "dWM" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/tile/masonic,
+/obj/item/reagent_containers/glass/bucket/pot/teapot/fancy{
+	pixel_x = -15;
+	pixel_y = 40
+	},
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "dWR" = (
 /obj/structure/fluff/pillow/purple,
@@ -11726,11 +11744,14 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "dWW" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/item/candle/yellow/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = 6;
+	pixel_y = 6
 	},
-/area/rogue/indoors/town/vault)
+/obj/machinery/light/rogue/wallfire/candle/floorcandle,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "dXi" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -11844,10 +11865,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/church/basement)
 "dZz" = (
-/obj/machinery/anvil,
-/obj/item/rogueweapon/hammer/iron,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "dZC" = (
 /obj/structure/table/church,
 /obj/item/reagent_containers/glass/cup/golden{
@@ -11966,7 +11985,15 @@
 	},
 /area/rogue/indoors)
 "ebP" = (
-/turf/open/floor/rogue/tile/masonic/inverted,
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/gold/lit{
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/under/town/basement/keep)
 "ebQ" = (
 /obj/structure/roguewindow/openclose{
@@ -12125,11 +12152,13 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
 "eeK" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 33
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "steward";
+	name = "Clerk's Bedroom"
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/manor)
 "eeL" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach)
@@ -12427,11 +12456,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "eja" = (
-/obj/structure/roguemachine/mail{
-	mailtag = "Streets (East)"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "ejb" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
@@ -12545,10 +12572,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "ekz" = (
-/obj/structure/closet/crate/roguecloset/dark,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/under/town/basement/keep)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "ekF" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -12584,11 +12612,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/goblinfort)
 "els" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "warehouse_shutter"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/vault)
 "elw" = (
 /obj/structure/table/wood{
 	icon_state = "longtable_mid"
@@ -12602,6 +12627,10 @@
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/forest)
+"elC" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/town/roofs)
 "elD" = (
 /obj/item/roguecoin/copper,
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
@@ -12617,31 +12646,10 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/woods)
-"elY" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
-	},
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	pixel_x = 3;
-	pixel_y = 5;
-	sellprice = 30
-	},
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "elZ" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/garrison)
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "emg" = (
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/cobble,
@@ -12700,17 +12708,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "enm" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
+/obj/structure/mineral_door/wood/deadbolt{
+	name = "Guest Room";
+	dir = 8
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "eno" = (
 /obj/item/natural/stone,
@@ -12831,10 +12833,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"eoH" = (
-/obj/effect/landmark/start/lady,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "eoJ" = (
 /obj/structure/flora/roguegrass,
 /mob/living/simple_animal/butterfly,
@@ -12886,8 +12884,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "ept" = (
-/obj/machinery/light/rogue/firebowl/standing,
-/turf/open/floor/rogue/tile,
+/obj/structure/chair/wood/rogue{
+	pixel_x = 2;
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
 "epy" = (
 /obj/structure/flora/roguetree,
@@ -13000,12 +13001,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
 "erO" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/quiver/javelin/steel{
-	pixel_y = 32
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/area/rogue/indoors/town/vault)
 "erP" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/mountains/decap)
@@ -13035,9 +13034,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "esm" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
+/obj/structure/bars{
+	color = "#755f48";
+	name = "rusted bars"
 	},
+/turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/basement/keep)
 "esn" = (
 /obj/structure/fluff/railing/wood{
@@ -13058,11 +13059,8 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/mountains/decap)
 "esG" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/turf/open/floor/rogue/carpet,
+/obj/structure/fluff/statue/knightalt,
+/turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
 "esJ" = (
 /obj/item/ingot/copper,
@@ -13115,11 +13113,9 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "etH" = (
-/obj/structure/table/wood,
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "etM" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/spider/stickyweb,
@@ -13319,13 +13315,18 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "ewz" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/effect/landmark/events/haunts,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "Lord"
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
+/obj/item/bomb,
+/obj/item/bomb,
+/obj/item/rogueweapon/huntingknife/idagger/silver/elvish{
+	name = "royal elvish dagger"
 	},
+/obj/item/flint,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "ewC" = (
 /obj/structure/bed/rogue{
@@ -13342,10 +13343,10 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "ewD" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/double_pelt,
+/obj/effect/landmark/start/knight,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "ewQ" = (
 /turf/open/floor/rogue/wood,
@@ -13435,15 +13436,15 @@
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/outdoors/exposed/bath/vault)
 "exS" = (
-/obj/structure/table/wood{
-	icon_state = "map5"
+/obj/effect/decal/cobbleedge{
+	dir = 6
 	},
-/obj/item/reagent_containers/glass/cup/silver{
-	pixel_x = 6;
-	pixel_y = 11
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "exT" = (
 /obj/structure/rack/rogue/shelf,
 /obj/structure/rack/rogue/shelf/big{
@@ -13474,8 +13475,14 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/underdark)
 "eyl" = (
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town)
+/obj/structure/mineral_door/wood{
+	name = "Bath";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "eyn" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -13539,14 +13546,8 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/basement)
 "ezs" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/structure/globe,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/outdoors/rtfield)
 "ezJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -13554,12 +13555,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
 "ezM" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_y = 32
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
 	},
-/obj/structure/closet/crate/roguecloset/dark,
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "ezQ" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -13884,12 +13884,11 @@
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/cave/dukecourt)
 "eFM" = (
-/obj/machinery/light/rogue/lanternpost{
-	dir = 1
+/obj/item/roguebin/water/gross,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/manor)
 "eFS" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -13944,12 +13943,11 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/forest)
 "eGS" = (
-/obj/structure/lever/wall{
-	dir = 8;
-	redstone_id = "stewardshutter"
+/obj/structure/roguemachine/scomm{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/outdoors/town/roofs)
 "eHa" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
@@ -13974,9 +13972,18 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/shelter/woods)
 "eHY" = (
-/obj/structure/toilet,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/cobble,
+/obj/item/candle/candlestick/silver/single/lit{
+	pixel_x = 9;
+	pixel_y = 10
+	},
+/obj/item/tablecloth/silk{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/under/town/basement/keep)
 "eIa" = (
 /obj/machinery/light/rogue/oven{
@@ -14092,13 +14099,17 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "eKq" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "manor"
+/obj/structure/stairs/fancy/c,
+/obj/structure/stairs/fancy/c{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/stairs/fancy/c,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"eKr" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "eKx" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/wood,
@@ -14193,11 +14204,17 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/physician)
 "eMi" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/closet/crate/roguecloset{
+	name = "Ropes and Chains"
 	},
-/obj/item/candle/silver/lit,
-/turf/open/floor/rogue/carpet,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rogueweapon/whip,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "eMl" = (
 /obj/structure/fermentation_keg/random/beer,
@@ -14270,6 +14287,13 @@
 /obj/structure/flora/rock/pile,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/orcdungeon)
+"eNM" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/turf/open/floor/rogue/carpet/lord/right,
+/area/rogue/indoors/town/manor)
 "eNN" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/rogue/hay,
@@ -14448,22 +14472,25 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
-"eRm" = (
-/obj/structure/chair/bench/couchablack,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/manor)
 "eRq" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
 /obj/machinery/light/rogue/oven/east,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
+"eRr" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "eRG" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/goden/steel,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "eRS" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -14486,14 +14513,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "eSn" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/millstone{
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town)
+/obj/structure/fluff/statue/knight/r,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "eSo" = (
 /obj/structure/table/wood,
 /obj/structure/lever{
@@ -14521,18 +14543,18 @@
 /turf/open/water/bloody,
 /area/rogue/under/cave/orcdungeon)
 "eSD" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/cup/silver{
-	desc = "A pewter goblet, cheaper than silver, but with a similar shine!";
-	name = "pewter goblet";
-	pixel_x = 9;
-	pixel_y = 10
+/obj/effect/decal/cobbleedge{
+	icon_state = "borderfall";
+	dir = 1
 	},
-/obj/item/candle/silver/lit{
-	pixel_x = -10;
-	pixel_y = 5
+/obj/structure/roguemachine/musicbox{
+	pixel_y = 16
 	},
-/turf/open/floor/rogue/tile/masonic/inverted,
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "eSI" = (
 /mob/living/simple_animal/hostile/rogue/mirespider_paralytic/angry,
@@ -14623,13 +14645,8 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves)
 "eVb" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/shirt/vampire,
-/obj/item/clothing/suit/roguetown/shirt/tunic/silktunic,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/steward,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "eVi" = (
 /obj/item/natural/stone,
@@ -14782,14 +14799,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/goblindungeon)
 "eXA" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/obj/structure/flora/roguegrass,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/turf/closed/wall/mineral/rogue/stonebrick{
+	density = 0
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/under/town/basement/keep)
 "eXE" = (
 /obj/structure/table/cooling,
 /obj/structure/bars{
@@ -14901,12 +14914,6 @@
 /mob/living/carbon/human/species/human/northern/highwayman,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/mountains/decap)
-"eZu" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
 "eZy" = (
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/cobblerock,
@@ -14958,10 +14965,16 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach)
 "fat" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/hexstone,
+/obj/structure/closet/crate/roguecloset/lord,
+/obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
+/obj/item/rogueweapon/sword/long/judgement,
+/obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
+/obj/item/clothing/gloves/roguetown/plate,
+/obj/item/clothing/wrists/roguetown/bracers,
+/obj/item/clothing/shoes/roguetown/boots/armor,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/storage/belt/rogue/leather/steel/tasset,
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "faB" = (
 /obj/structure/chair/wood/rogue{
@@ -15034,19 +15047,14 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
 "fbW" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/flail,
+/obj/item/rogueweapon/flail{
+	pixel_x = 0;
+	pixel_y = -5
 	},
-/obj/item/rogueweapon/huntingknife/chefknife,
-/obj/item/book/rogue/yeoldecookingmanual{
-	pixel_x = 10
-	},
-/obj/item/candle/gold/lit{
-	pixel_x = -10;
-	pixel_y = 10
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "fbZ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -15148,14 +15156,9 @@
 	},
 /area/rogue/outdoors/mountains)
 "fdb" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/closet/crate/roguecloset,
-/obj/item/flashlight/flare/torch/metal,
-/obj/item/flashlight/flare/torch/metal,
-/obj/item/flashlight/flare/torch/metal,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/obj/machinery/light/rogue/hearth,
+/obj/effect/decal/cobbleedge,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "fdc" = (
 /obj/structure/stairs{
@@ -15250,14 +15253,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "fdR" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/turf/open/floor/rogue/rooftop{
+	dir = 1
 	},
-/obj/effect/landmark/events/testportal{
-	aportalloc = "manor"
-	},
-/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "fdZ" = (
 /obj/structure/table/wood{
@@ -15268,14 +15266,6 @@
 	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/physician)
-"feo" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "manor"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
-/area/rogue/indoors/town/manor)
 "fep" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -15382,11 +15372,19 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/woods)
 "ffL" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
+/obj/structure/table/wood{
+	icon_state = "longtable"
 	},
-/turf/open/floor/rogue/carpet/lord/left,
-/area/rogue/under/town/basement/keep)
+/obj/item/reagent_containers/glass/cup/golden{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/beer/stonebeardreserve{
+	pixel_x = 13;
+	pixel_y = 11
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "ffN" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -15432,11 +15430,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "fgq" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/bed/rogue,
+/obj/effect/landmark/start/hostage,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
 "fgw" = (
 /obj/structure/bed/rogue/shit,
@@ -15453,27 +15451,6 @@
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"fgP" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bucket/pot/teapot/fancy,
-/obj/item/reagent_containers/glass/cup/ceramic/fancy{
-	pixel_x = -10;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/glass/cup/ceramic/fancy{
-	pixel_x = -10;
-	pixel_y = -2
-	},
-/obj/item/reagent_containers/glass/cup/ceramic/fancy{
-	pixel_x = 11;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/glass/cup/ceramic/fancy{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "fha" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -15555,10 +15532,13 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "fiP" = (
-/obj/structure/closet/crate/drawer/random,
-/obj/structure/fluff/railing/border,
-/turf/open/floor/carpet/inn,
-/area/rogue/under/town/basement/keep)
+/obj/structure/mineral_door/wood/donjon{
+	locked = 1;
+	lockid = "steward";
+	name = "Stewardry Office"
+	},
+/turf/closed/wall/mineral/rogue/decowood,
+/area/rogue/indoors/town/manor)
 "fiU" = (
 /obj/structure/chair/bench/coucha{
 	can_buckle = 0
@@ -15641,12 +15621,12 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "fjY" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "dungeon"
+/obj/effect/decal/cobbleedge{
+	dir = 7;
+	pixel_x = 13
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "fkc" = (
 /obj/structure/bars,
 /obj/structure/roguewindow,
@@ -15818,31 +15798,19 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
 "fmO" = (
-/obj/structure/table/wood{
-	icon_state = "map1"
-	},
-/obj/item/cooking/platter/silver{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/cooking/platter/silver,
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/needle,
+/obj/item/needle,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "fmU" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bottle/rogue/whitewine{
-	pixel_x = -12;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "fnd" = (
 /turf/closed/mineral/random/rogue/med,
@@ -15889,8 +15857,12 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "foa" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	pixel_x = 11;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "foi" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/troll/bog,
@@ -15921,14 +15893,11 @@
 	},
 /area/rogue/indoors)
 "foK" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/obj/structure/stairs/stone/d{
+	dir = 8
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "foN" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -16152,15 +16121,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
 "frA" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "steward";
-	name = "Bathroom"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/effect/decal/carpet/square,
+/turf/open/floor/rogue/tile/masonic/inverted,
+/area/rogue/indoors/town/manor)
 "frN" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16231,7 +16195,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/carpet/purple,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/outdoors/town)
 "fti" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -16268,18 +16232,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "ftV" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/fluff/walldeco/rpainting/crown{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 9
-	},
-/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "fue" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
@@ -16321,13 +16277,16 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
 "fvf" = (
-/obj/item/book/rogue/bookofpriests,
-/obj/item/book/rogue/cardgame,
-/obj/item/book/rogue/tales1,
-/obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 0
 	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "fvr" = (
 /obj/structure/stairs,
@@ -16366,16 +16325,17 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "fvA" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/machinery/light/rogue/torchholder/c{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
-"fvC" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/tower/metal,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
+"fvC" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
+	},
+/area/rogue/indoors/town/vault)
 "fvE" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /obj/item/clothing/head/roguetown/articap,
@@ -16559,13 +16519,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblindungeon)
 "fyA" = (
-/obj/structure/closet/crate/roguecloset/crafted,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
-/obj/item/clothing/suit/roguetown/armor/silkcoat,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/structure/bed/rogue/inn/double,
+/obj/structure/fluff/wallclock/r,
+/obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/carpet/red,
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/manor)
 "fyQ" = (
 /obj/item/bedsheet/rogue/double_pelt,
 /obj/structure/bed/rogue/inn/wooldouble,
@@ -16580,14 +16538,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/roofs)
 "fyX" = (
-/obj/structure/table/wood{
-	icon_state = "longtable_mid"
-	},
-/obj/item/candle/candlestick/gold/lit{
-	pixel_x = -10;
-	pixel_y = 12
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/manor)
 "fzm" = (
 /obj/structure/fluff/railing/border{
@@ -16644,6 +16595,14 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"fAi" = (
+/obj/structure/mineral_door/wood/window{
+	locked = 1;
+	lockid = "sheriff";
+	name = "captains room door"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "fAm" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/basement)
@@ -16713,25 +16672,20 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/cave)
 "fBd" = (
-/obj/machinery/light/rogue/lanternpost,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "fBm" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/mazedungeon)
 "fBn" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 32
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "fBq" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/potion_vitals,
@@ -16743,8 +16697,12 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "fBC" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile/bath,
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "fBJ" = (
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
@@ -16766,9 +16724,9 @@
 	},
 /area/rogue/indoors/town/magician)
 "fCk" = (
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "fCr" = (
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/blocks,
@@ -16948,11 +16906,13 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "fFz" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/long,
-/obj/item/rogueweapon/sword/long,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/mannequin/male/female,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "fFF" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -16986,11 +16946,9 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/physician)
 "fGt" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 4
+/turf/open/floor/rogue/rooftop/green{
+	dir = 1
 	},
-/turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "fGv" = (
 /obj/structure/flora/roguegrass,
@@ -17029,9 +16987,12 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/underdark)
 "fHg" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/basement)
 "fHh" = (
 /obj/structure/stairs{
 	dir = 8
@@ -17118,12 +17079,8 @@
 	},
 /area/rogue/indoors/shelter/mountains/decap)
 "fIG" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
+/obj/structure/fluff/walldeco/customflag,
+/turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
 "fIL" = (
 /obj/structure/mineral_door/wood{
@@ -17188,11 +17145,8 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "fJL" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/turf/open/floor/rogue/wood,
+/obj/structure/ladder,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
 "fKa" = (
 /obj/structure/winch{
@@ -17314,10 +17268,16 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "fLP" = (
-/obj/structure/bed/rogue,
-/obj/effect/landmark/start/hostage,
-/turf/open/floor/rogue/wood,
-/area/rogue/under/town/basement/keep)
+/obj/structure/closet/crate/chest,
+/obj/item/quiver,
+/obj/item/quiver,
+/obj/item/quiver,
+/obj/item/quiver/sling/iron,
+/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fLQ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17354,6 +17314,62 @@
 /mob/living/carbon/human/species/elf/dark/drowraider,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"fMx" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver{
+	name = "pewter goblet";
+	pixel_x = -11
+	},
+/obj/item/reagent_containers/glass/cup/silver{
+	name = "pewter goblet";
+	pixel_x = -11
+	},
+/obj/item/reagent_containers/glass/cup,
+/obj/item/reagent_containers/glass/cup,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl/iron{
+	name = "pewter bowl"
+	},
+/obj/item/reagent_containers/glass/bowl/iron{
+	name = "pewter bowl"
+	},
+/obj/item/reagent_containers/glass/bowl/iron{
+	name = "pewter bowl"
+	},
+/obj/item/reagent_containers/glass/bowl/iron{
+	name = "pewter bowl"
+	},
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter/pewter,
+/obj/item/cooking/platter/pewter,
+/obj/item/reagent_containers/glass/bowl/silver{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bowl/silver{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bowl/silver{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bowl/gold,
+/obj/item/reagent_containers/glass/bowl/silver{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bowl/silver{
+	pixel_x = 2
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "fMy" = (
 /obj/effect/landmark/events/deadite_animal_migration_point{
 	order = 14
@@ -17401,11 +17417,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "fNC" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/effect/landmark/start/guard_captain,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/obj/item/roguemachine/mastermail,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "fNH" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/dirt/road,
@@ -17517,17 +17531,21 @@
 	},
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "fPZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 1
 	},
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/item/cooking/platter/silver,
+/obj/item/kitchen/fork/silver{
+	pixel_x = 12;
+	pixel_y = 6
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 4
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = -13;
+	pixel_y = 8
 	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "fQb" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -17564,10 +17582,12 @@
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/dwarfin)
 "fQw" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
+/obj/item/book/rogue/tales3,
+/obj/structure/closet/crate/drawer/random{
+	pixel_x = 1;
+	pixel_y = 3
 	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "fQE" = (
 /turf/open/floor/rogue/cobble,
@@ -17636,14 +17656,9 @@
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
 "fRL" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 9
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "fRM" = (
 /mob/living/simple_animal/pet/cat/rogue/black,
 /turf/open/floor/rogue/blocks,
@@ -17696,10 +17711,12 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "fSB" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
+/obj/structure/chair/wood/rogue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 12
 	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
 "fSD" = (
 /obj/structure/table/wood{
@@ -17712,14 +17729,8 @@
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/physician)
 "fSG" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/fluff/statue/knightalt,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
 "fSJ" = (
 /obj/structure/table/wood{
@@ -17806,9 +17817,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
 "fUm" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
+/obj/structure/closet/crate/drawer,
+/obj/item/natural/feather,
+/obj/item/candle/yellow,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "fUn" = (
@@ -17895,7 +17906,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "fVF" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/closet/crate/chest/neu,
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/storage/belt/rogue/pouch,
+/obj/item/storage/belt/rogue/pouch,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "fVR" = (
@@ -18007,6 +18023,12 @@
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"fXd" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
+	},
+/area/rogue/indoors/town/manor)
 "fXf" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -18116,10 +18138,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter)
 "fZc" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/tile/masonic/inverted,
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
 "fZe" = (
 /obj/structure/stairs{
@@ -18144,11 +18165,18 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "fZu" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 9
 	},
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/indoors/town)
+/obj/item/natural/feather{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "fZJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -18373,12 +18401,17 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
 "gei" = (
-/obj/structure/mannequin,
-/obj/item/clothing/suit/roguetown/armor/leather/studded,
-/obj/item/clothing/head/roguetown/helmet/kettle,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "gem" = (
 /obj/structure/mineral_door/bars{
 	lockid = "manor"
@@ -18463,10 +18496,9 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "ggg" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/turf/closed/wall/mineral/rogue/decostone/end{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "ggq" = (
 /obj/machinery/light/rogue/hearth,
@@ -18508,9 +18540,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "ghh" = (
-/obj/structure/fluff/statue/knight,
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/twig{
+	dir = 4
+	},
+/area/rogue/outdoors/town/roofs/keep)
 "ghj" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/dirt,
@@ -18558,8 +18591,11 @@
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
 "gij" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner,
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/wood,
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/manor)
 "gik" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 1
@@ -18608,16 +18644,16 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield/eora)
 "gjo" = (
-/obj/structure/fluff/statue/knight,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 8
 	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "gjv" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/turf/closed/wall/mineral/rogue/decostone/end{
+	dir = 8
 	},
-/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "gjC" = (
 /obj/structure/chair/wood/rogue/chair3,
@@ -18785,8 +18821,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
 "gmR" = (
-/turf/open/floor/carpet/inn,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/bluestone,
+/area/rogue/outdoors/exposed/town/keep)
 "gmZ" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
@@ -18798,10 +18835,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "gno" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/pelt,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
 	},
 /area/rogue/indoors/town/manor)
 "gnv" = (
@@ -18870,13 +18908,6 @@
 /obj/item/clothing/suit/roguetown/shirt/robe/astrata,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/orcdungeon)
-"gpi" = (
-/obj/structure/table/wood,
-/obj/item/candle/candlestick/gold/lit{
-	pixel_y = 12
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "gpj" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -18919,45 +18950,11 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/garrison)
 "gpw" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/candle/yellow{
-	pixel_x = 2;
-	pixel_y = 41
-	},
-/obj/item/candle/yellow{
-	pixel_x = -3;
-	pixel_y = 41
-	},
-/obj/item/candle/yellow{
-	pixel_x = -8;
-	pixel_y = 41
-	},
-/obj/item/candle/yellow{
-	pixel_x = 7;
-	pixel_y = 41
-	},
-/obj/structure/rack/rogue/shelf,
-/obj/item/broom{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/broom{
-	pixel_x = 2;
+/obj/structure/chair/wood/rogue/fancy{
+	pixel_x = 0;
 	pixel_y = 1
 	},
-/obj/item/soap{
-	pixel_x = 4;
-	pixel_y = -5
-	},
-/obj/item/soap{
-	pixel_x = -1;
-	pixel_y = -5
-	},
-/obj/item/soap{
-	pixel_x = -6;
-	pixel_y = -5
-	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "gpG" = (
 /obj/structure/chair/stool/rogue,
@@ -19089,16 +19086,19 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/shelter)
 "grk" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
 	},
-/obj/machinery/light/rogue/oven/south,
-/obj/item/cooking/pan{
+/obj/item/candle/candlestick/silver/single/lit{
+	pixel_x = 18;
+	pixel_y = -7
+	},
+/obj/item/reagent_containers/glass/cup/ceramic/fancy{
 	pixel_x = 2;
-	pixel_y = -1
+	pixel_y = -22
 	},
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "grs" = (
 /obj/machinery/light/rogue/wallfire/candle/off,
@@ -19224,14 +19224,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "gtR" = (
-/obj/structure/bed/rogue/inn,
-/obj/item/bedsheet/rogue/fabric,
-/obj/effect/landmark/start/councillor,
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_y = 32
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/turf/open/floor/carpet/inn,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "gtY" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/effect/decal/cleanable/blood,
@@ -19474,10 +19473,13 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave)
 "gxw" = (
-/obj/structure/roguemachine/mail{
-	mailtag = "Throne Room"
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood,
+/obj/structure/stairs/fancy/c{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "gxy" = (
 /obj/structure/table/wood{
@@ -19501,9 +19503,6 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"gxR" = (
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "gxS" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -19592,22 +19591,31 @@
 	},
 /area/rogue/indoors/shelter/woods)
 "gyY" = (
-/obj/structure/roguemachine/scomm/l,
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "hand";
+	name = "Hand's Chambers"
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
 "gzi" = (
 /obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+	icon_state = "map2"
 	},
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 9
+/obj/item/paper/scroll{
+	pixel_x = -2;
+	pixel_y = 14
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/turf/open/floor/rogue/carpet/lord/center,
+/area/rogue/indoors/town/manor)
+"gzr" = (
+/obj/structure/bed/rogue/inn/double,
+/obj/structure/fluff/walldeco/med5{
+	pixel_x = 32
 	},
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "gzs" = (
 /obj/structure/bars/cemetery,
@@ -19705,16 +19713,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "gAn" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/book/rogue/blackmountain,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/chair/stool/rogue,
+/obj/effect/landmark/start/physician,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "gAp" = (
 /obj/structure/fluff/statue/knightalt/r,
@@ -19730,9 +19731,12 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "gAH" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/physician)
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread"
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "gAL" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/dirt,
@@ -19745,8 +19749,16 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/magician)
 "gAQ" = (
-/obj/structure/fluff/walldeco/wantedposter/l,
-/turf/open/floor/rogue/cobblerock,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = 1
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "gAZ" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
@@ -19791,10 +19803,11 @@
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/beach/forest)
 "gCd" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 6
 	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "gCA" = (
 /obj/effect/decal/cobbleedge{
@@ -19837,9 +19850,11 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "gDG" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "gDJ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -19855,6 +19870,11 @@
 /obj/structure/flora/hotspring_rocks/small/two,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/beach/forest)
+"gDT" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "gDW" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -19941,15 +19961,23 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/sewer)
 "gFm" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/double_pelt,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/carpet/lord/center,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "gFt" = (
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
+"gFC" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/book/rogue/law,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "gFF" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -20056,6 +20084,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
+"gHd" = (
+/obj/structure/fluff/statue/knight/interior,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "gHe" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/naturalstone,
@@ -20153,12 +20185,10 @@
 	},
 /area/rogue/indoors/town/garrison)
 "gIs" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Keep Sideroom"
+/obj/structure/chair/wood/rogue{
+	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "gIy" = (
 /obj/structure/closet/crate/chest/wicker{
@@ -20168,6 +20198,13 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
+"gIz" = (
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/needle,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "gIF" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -20231,13 +20268,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"gJJ" = (
-/obj/item/book/rogue/cooking,
-/obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "gJM" = (
 /obj/structure/rack/rogue,
 /obj/item/natural/wood/plank,
@@ -20253,7 +20283,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "gJY" = (
-/obj/structure/bookcase/random/archive,
+/obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "gKa" = (
@@ -20271,14 +20301,7 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/magician)
 "gKk" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/natural/feather,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "gKv" = (
 /obj/structure/fluff/railing/fence{
@@ -20390,11 +20413,8 @@
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors/town/shop)
 "gMg" = (
-/obj/effect/decal/cobbleedge,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "gMl" = (
 /obj/structure/fluff/railing/border{
@@ -20402,15 +20422,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
-"gMr" = (
-/obj/structure/fluff/railing/wood{
-	layer = 4.51
-	},
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/town/roofs/keep)
 "gMy" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -20439,20 +20450,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "gMS" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/rogue/meat/sausage,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town)
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/exposed/town/keep)
 "gMT" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/roguemachine/mail{
@@ -20500,18 +20502,6 @@
 /obj/structure/roguerock,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"gOQ" = (
-/obj/structure/closet/crate/roguecloset/lord,
-/obj/item/rogueweapon/sword/long/judgement,
-/obj/item/clothing/wrists/roguetown/bracers,
-/obj/item/storage/belt/rogue/leather/steel/tasset,
-/obj/item/clothing/gloves/roguetown/blacksteel/modern/plategloves,
-/obj/item/clothing/head/roguetown/helmet/blacksteel/modern/armet,
-/obj/item/clothing/shoes/roguetown/boots/blacksteel/modern/plateboots,
-/obj/item/clothing/suit/roguetown/armor/plate/modern/blacksteel_full_plate,
-/obj/item/clothing/under/roguetown/platelegs/blacksteel/modern,
-/turf/open/floor/rogue/carpet/lord/left,
-/area/rogue/indoors/town/manor)
 "gOR" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 1
@@ -20658,14 +20648,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"gSi" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "royal";
-	name = "Lord's Apartment"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
 "gSm" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/grass,
@@ -20784,10 +20766,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
 "gTK" = (
-/obj/structure/stairs/fancy/l{
-	dir = 1
-	},
-/turf/open/floor/rogue/woodturned,
+/turf/open/floor/rogue/rooftop/green/corner1,
 /area/rogue/indoors/town/manor)
 "gTN" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -20838,12 +20817,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"gUZ" = (
-/obj/machinery/light/rogue/lanternpost{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep)
 "gVb" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -20910,14 +20883,11 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "gWb" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/structure/table/vtable/v2,
+/obj/item/clothing/cloak/apron/cook{
+	name = "barber's apron"
 	},
-/obj/structure/closet/crate/drawer/random{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
 "gWh" = (
 /obj/machinery/light/rogue/firebowl/standing,
@@ -21101,6 +21071,15 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"gZn" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "gZo" = (
 /obj/structure/fluff/pillow/magenta,
 /turf/open/floor/rogue/tile/brownbrick,
@@ -21147,19 +21126,15 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/orcdungeon)
 "hao" = (
-/obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/chair/wood/rogue{
+	dir = 1
 	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "haq" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/candle/candlestick/gold/lit,
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/obj/structure/feedinghole,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "has" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -21218,10 +21193,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"hbc" = (
-/obj/structure/fluff/statue/knight,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
 "hbd" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -21260,24 +21231,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
 "hbx" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/effect/decal/cobbleedge,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/closet/crate/drawer/random,
+/obj/structure/fluff/railing/border,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "hbA" = (
 /obj/structure/far_travel,
@@ -21456,6 +21413,15 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter)
+"hee" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/manor)
 "heh" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -21496,13 +21462,11 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
 "heB" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/obj/structure/flora/roguegrass/herb/rosa,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/tile/masonic/inverted,
+/area/rogue/indoors/town/manor)
 "heG" = (
 /mob/living/carbon/human/species/goblin/npc/ambush,
 /turf/open/floor/rogue/dirt/road,
@@ -21542,14 +21506,15 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement)
 "hfn" = (
-/obj/structure/stairs,
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
+/obj/effect/decal/cobbleedge{
+	dir = 6
 	},
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "hft" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/beach)
@@ -21646,11 +21611,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
 "hhv" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "hhG" = (
 /obj/item/roguestatue/iron,
 /obj/structure/table/wood,
@@ -21730,8 +21695,13 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
 "hii" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/closet/crate/chest,
+/obj/item/paper/scroll,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "hio" = (
 /obj/structure/table/wood,
@@ -21849,9 +21819,14 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "hkj" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/water/bath,
-/area/rogue/indoors/town)
+/obj/structure/mineral_door/wood{
+	name = "Throne Room";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "hkm" = (
 /obj/structure/fluff/statue/gargoyle{
 	pixel_y = 10
@@ -21941,7 +21916,7 @@
 /area/rogue/indoors/shelter/woods)
 "hlN" = (
 /turf/open/floor/carpet/purple,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/outdoors/town)
 "hlP" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/dirt,
@@ -21973,13 +21948,17 @@
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "hmp" = (
-/obj/structure/closet/crate/drawer,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = 1
 	},
-/obj/item/scomstone/bad/garrison,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "hmt" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/concrete,
@@ -21991,9 +21970,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "hmx" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "manor";
+	name = "Chapel"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "hmE" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -22051,10 +22034,6 @@
 /obj/effect/spawner/lootdrop/steel_weapon_spawner,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/orcdungeon)
-"hny" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
 "hnz" = (
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/church,
@@ -22078,15 +22057,13 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/dwarfin)
 "hof" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/table/church,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "hog" = (
-/obj/structure/rack/rogue,
-/obj/item/clothing/gloves/roguetown/chain,
-/obj/item/clothing/gloves/roguetown/chain,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "hoo" = (
 /obj/structure/flora/rogueshroom{
 	pixel_y = -5
@@ -22094,8 +22071,7 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "hox" = (
-/obj/machinery/light/rogue/chand,
-/turf/open/transparent/openspace,
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "hoC" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
@@ -22146,15 +22122,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "hqc" = (
-/obj/structure/closet/crate/drawer/random{
-	pixel_y = 0
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/tile/tilerg,
+/area/rogue/outdoors/exposed/town/keep)
 "hqd" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -22395,11 +22364,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
 "hsS" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
+/turf/closed/wall/mineral/rogue/roofwall/innercorner,
+/area/rogue/outdoors/town/roofs)
 "hsX" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -22462,31 +22428,22 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/church/chapel)
 "htK" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/roguegrass/herb/rosa{
-	pixel_x = 0;
-	pixel_y = 3
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	pixel_x = -32;
-	pixel_y = -24
-	},
-/turf/open/floor/rogue/grasscold,
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/fabric_double,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "htN" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "htV" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/closet/crate/chest/neu,
+/obj/item/clothing/shoes/roguetown/boots/armor/iron,
+/obj/item/clothing/shoes/roguetown/boots/armor/iron,
+/obj/item/clothing/gloves/roguetown/angle,
+/obj/item/clothing/gloves/roguetown/angle,
+/obj/item/clothing/shoes/roguetown/boots/leather/atgervi,
+/obj/item/clothing/shoes/roguetown/boots/leather/atgervi,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "htY" = (
 /obj/structure/fluff/railing/border{
@@ -22531,14 +22488,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement)
 "huL" = (
-/obj/structure/flora/roguegrass/bush,
-/obj/structure/flora/roguegrass,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "huQ" = (
 /obj/structure/fluff/walldeco/bigpainting{
 	pixel_x = 2;
@@ -22547,10 +22501,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
 "huV" = (
-/obj/structure/fluff/statue/knight/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "huX" = (
 /obj/structure/fluff/railing/border{
@@ -22643,14 +22595,17 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "hvN" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/item/candle/candlestick/silver/lit{
+	pixel_y = 9
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs/keep)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "hvS" = (
 /obj/structure/bed/rogue/shit{
 	name = "makeshift bed"
@@ -22658,21 +22613,18 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/fishmandungeon)
 "hvV" = (
-/obj/structure/closet/crate/drawer,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/natural/feather,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/physician)
-"hvW" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = -16;
-	pixel_y = 33
+/obj/structure/stairs{
+	dir = 8
 	},
-/obj/structure/fluff/wallclock/r,
-/turf/open/floor/rogue/carpet/lord/center,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/garrison)
+"hvW" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "hwa" = (
 /obj/structure/chair/wood/rogue{
@@ -22795,15 +22747,8 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave/goblinfort)
 "hxZ" = (
-/obj/structure/bookcase,
-/obj/item/book/rogue/tales3,
-/obj/item/book/rogue/sword,
-/obj/item/book/rogue/tales1,
-/obj/item/book/rogue/law,
-/obj/item/book/rogue/nitebeast,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/closet/crate/roguecloset/dark,
+/turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "hyh" = (
 /obj/structure/stairs{
@@ -22955,9 +22900,13 @@
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/sewer)
 "hAe" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/rooftop/green{
+	dir = 1
+	},
+/area/rogue/outdoors/town/roofs/keep)
 "hAg" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 8;
@@ -23142,15 +23091,14 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
 "hDh" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/structure/stairs{
+	dir = 8
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-n"
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/tile/bfloorz,
+/area/rogue/under/town/basement/keep)
 "hDr" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -23294,28 +23242,18 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "hFO" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-sread"
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
-	},
+/obj/item/armor_brush,
+/obj/item/polishing_cream,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
 "hFP" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_x = 10;
-	pixel_y = 6
-	},
-/obj/item/candle/silver/lit{
-	pixel_x = -10;
-	pixel_y = 10
-	},
-/turf/open/floor/rogue/tile/masonic/inverted,
+/obj/structure/roguemachine/mail,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "hFR" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -23336,6 +23274,16 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"hGk" = (
+/obj/structure/table/wood{
+	icon_state = "longtable_mid";
+	dir = 1
+	},
+/obj/item/candle/candlestick/silver/lit{
+	pixel_y = 9
+	},
+/turf/open/floor/rogue/carpet/lord/center,
+/area/rogue/indoors/town/manor)
 "hGm" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cave/fishmandungeon)
@@ -23603,8 +23551,8 @@
 /area/rogue/indoors/cave)
 "hLN" = (
 /obj/structure/far_travel,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/town)
 "hMk" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/underdark)
@@ -23651,9 +23599,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "hMB" = (
-/obj/effect/landmark/start/steward,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
+/turf/open/lava/acid,
+/area/rogue/under/town/basement/keep)
 "hMD" = (
 /obj/item/natural/bone,
 /turf/open/floor/rogue/hexstone,
@@ -23768,11 +23715,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "hOT" = (
-/obj/structure/mannequin,
-/obj/item/clothing/suit/roguetown/armor/leather/studded,
-/obj/item/clothing/head/roguetown/helmet/kettle,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/closet/crate/chest/neu_fancy,
+/obj/item/roguecoin/silver/pile,
+/turf/open/floor/rogue/tile/masonic,
+/area/rogue/indoors/town/vault)
 "hOX" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -23790,8 +23736,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "hPp" = (
-/obj/structure/chair/bench/couch,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/chair/bench/couchablack,
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
 "hPA" = (
 /obj/structure/chair/stool/rogue,
@@ -23803,10 +23752,10 @@
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "hPG" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	name = "Dressing Room"
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/carpet,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "hPK" = (
 /obj/structure/chair/stool/rogue,
@@ -23826,13 +23775,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "hQj" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/lever/wall{
+	pixel_x = 32;
+	redstone_id = "warehouse_shutter"
 	},
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "hQq" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -23868,10 +23816,14 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "hQM" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/table/wood{
+	icon_state = "map3"
 	},
-/turf/open/floor/rogue/hexstone,
+/obj/item/natural/feather{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "hQT" = (
 /obj/structure/table/wood{
@@ -23896,8 +23848,15 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/basement)
 "hRe" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = -16;
+	pixel_y = 33
+	},
+/obj/structure/chair/bench/coucha/r,
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "hRh" = (
 /obj/structure/flora/roguegrass/water/reeds,
@@ -23951,16 +23910,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"hRU" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/candle/silver/lit,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
-/area/rogue/indoors/town/manor)
 "hRZ" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
@@ -23969,6 +23918,16 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet/bogcaves)
+"hSA" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "hSE" = (
 /obj/item/natural/bowstring,
 /turf/open/floor/rogue/concrete,
@@ -24047,11 +24006,13 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
 "hUf" = (
-/obj/item/roguemachine/mastermail,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	pixel_x = 7;
+	pixel_y = 2
 	},
-/area/rogue/indoors/town)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "hUM" = (
 /mob/living/simple_animal/pet/cat/inn{
 	name = "Bintu"
@@ -24177,14 +24138,16 @@
 	},
 /area/rogue/indoors/town/garrison)
 "hWA" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/obj/item/kitchen/spoon/gold{
-	pixel_y = 4
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "hWN" = (
 /obj/structure/roguewindow/openclose/reinforced{
@@ -24200,9 +24163,7 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "hWW" = (
-/obj/structure/chair/bench/couch,
-/obj/structure/fireaxecabinet/south,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/rooftop/green,
 /area/rogue/indoors/town/manor)
 "hXa" = (
 /obj/structure/table/wood{
@@ -24251,7 +24212,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cobbleedge{
-	dir = 9;
+	dir = 7;
 	pixel_x = 13
 	},
 /turf/open/floor/rogue/blocks,
@@ -24262,6 +24223,12 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
+"hXX" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "hYg" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
@@ -24365,8 +24332,9 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/town/basement/keep)
 "iag" = (
-/obj/structure/table/wood,
-/obj/structure/mineral_door/wood/deadbolt/shutter,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -24389,9 +24357,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "iaB" = (
-/obj/structure/fluff/walldeco/wantedposter/r,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/metal/barograte,
+/area/rogue/outdoors/exposed/town/keep)
 "iaL" = (
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
@@ -24456,17 +24424,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "ibZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/decal/cobbleedge{
+/obj/structure/chair/wood/rogue/fancy{
 	dir = 4
 	},
-/obj/structure/fluff/littlebanners{
-	pixel_y = -6
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "ica" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
@@ -24548,9 +24510,8 @@
 	},
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ida" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
+	dir = 7
 	},
 /area/rogue/indoors/town/manor)
 "idh" = (
@@ -24609,8 +24570,9 @@
 "idI" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/outdoors/town)
 "idS" = (
 /mob/living/simple_animal/hostile/rogue/deepone/wiz,
 /turf/open/floor/rogue/naturalstone,
@@ -24785,11 +24747,17 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "igz" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/obj/structure/flora/roguegrass/bush/wall/tall,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "igJ" = (
 /obj/structure/mineral_door/wood/window{
 	locked = 1;
@@ -24798,12 +24766,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/magician)
 "igK" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "igN" = (
 /obj/structure/chair/wood/rogue,
@@ -24841,9 +24805,9 @@
 	},
 /area/rogue/indoors/town/garrison)
 "ihP" = (
-/obj/structure/fluff/wallclock,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/obj/structure/bars/cemetery,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
 "ihW" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/cell)
@@ -24925,9 +24889,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "ijk" = (
-/obj/structure/fluff/clock,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/wood{
+	icon_state = "map6"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "ijo" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -24973,10 +24939,7 @@
 	},
 /area/rogue/indoors/town)
 "ijI" = (
-/obj/structure/fermentation_keg/random/water,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/under/town/basement/keep)
 "ijQ" = (
 /obj/structure/closet/crate/chest/old_crate,
@@ -25070,12 +25033,8 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
 "iln" = (
-/obj/structure/toilet{
-	color = "#ffee00";
-	name = "The Royal Shitter"
-	},
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/fireaxecabinet/south,
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "ilx" = (
 /obj/structure/closet/crate/chest,
@@ -25144,10 +25103,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/physician)
 "imB" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/manor)
 "imF" = (
 /turf/open/lava/acid,
@@ -25187,6 +25149,16 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"ine" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "ini" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/scarymaze)
@@ -25236,13 +25208,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "iol" = (
-/obj/structure/stairs/fancy/r{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/woodturned,
+/obj/structure/stairs/fancy/l,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "ion" = (
 /obj/structure/stairs{
@@ -25400,17 +25367,15 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains/decap)
 "iqA" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/natural/feather{
+	pixel_x = 33;
+	pixel_y = -122
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	pixel_x = -4;
-	pixel_y = 0
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "iqF" = (
 /obj/structure/bars/passage{
@@ -25438,7 +25403,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/town/roofs/keep)
 "iqU" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/tunic/white,
@@ -25447,9 +25412,18 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/town/basement/keep)
 "iqX" = (
-/obj/structure/fluff/statue/knight,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/mineral_door/wood/donjon{
+	dir = 2;
+	locked = 1;
+	lockid = "vault";
+	name = "Vault Door"
+	},
+/obj/structure/fluff/walldeco/alarm{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/vault)
 "iqY" = (
 /obj/structure/vine,
 /turf/open/water/swamp/deep,
@@ -25499,16 +25473,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "iry" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/closet/crate/drawer,
+/obj/item/rogueweapon/huntingknife/idagger/silver,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
-/area/rogue/outdoors/town/roofs/keep)
+/area/rogue/indoors/town/manor)
 "irz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/silver{
@@ -25583,12 +25553,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "isS" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "manor";
-	name = "Meeting Room"
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/rooftop/green{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/town/roofs/keep)
 "isU" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/hexstone,
@@ -25661,10 +25630,12 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/bath)
 "iuM" = (
-/obj/effect/landmark/start/knight,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 4
 	},
+/obj/item/candle/yellow/lit,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "ivg" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
@@ -25688,12 +25659,8 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "ivq" = (
-/obj/structure/fluff/walldeco/bigpainting{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/tile/masonic,
+/area/rogue/indoors/town/vault)
 "ivC" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/herringbone,
@@ -25801,8 +25768,23 @@
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/indoors/town/garrison)
 "ixs" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "ixx" = (
 /turf/open/water/river{
@@ -25907,9 +25889,9 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors)
 "izp" = (
-/obj/structure/flora/roguegrass/herb/random,
+/obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/outdoors/town)
 "izU" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 8;
@@ -25943,27 +25925,24 @@
 /area/rogue/outdoors/mountains/decap)
 "iAH" = (
 /obj/structure/table/wood{
-	dir = 8;
 	icon_state = "largetable";
-	pixel_x = -5
+	dir = 8
 	},
-/obj/item/roguestatue/steel,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
-"iAM" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/item/paper/scroll{
+	pixel_x = 4;
+	pixel_y = 2
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
-"iAO" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
+/area/rogue/indoors/town/manor)
+"iAO" = (
+/obj/structure/closet/crate/drawer,
+/obj/item/candle/candlestick/silver/lit{
+	pixel_y = 14;
+	pixel_x = 0
+	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "iAR" = (
 /obj/structure/chair/bench/church/smallbench,
@@ -26069,9 +26048,13 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "iCz" = (
-/obj/machinery/light/rogue/firebowl/standing,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = 1
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/town)
 "iCA" = (
 /obj/machinery/light/small{
 	color = "#b51d12";
@@ -26097,29 +26080,27 @@
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/outdoors/rtfield)
 "iCY" = (
-/obj/structure/closet/crate/chest,
-/obj/item/natural/bundle/cloth{
-	amount = 8
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/firebowl/standing,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "iCZ" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
+/obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "iDj" = (
@@ -26215,8 +26196,17 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
 "iFa" = (
-/obj/structure/stairs,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/natural/feather,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "iFe" = (
 /turf/open/floor/rogue/hexstone,
@@ -26234,11 +26224,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "iFA" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "iFF" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/snow,
@@ -26299,12 +26287,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "iGT" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "manor";
-	name = "toilets"
+/obj/structure/table/wood{
+	icon_state = "map5"
 	},
-/turf/open/floor/rogue/cobble,
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
 "iHa" = (
 /obj/machinery/light/rogue/smelter/great{
@@ -26441,31 +26429,29 @@
 /area/rogue/indoors/town)
 "iJi" = (
 /obj/structure/rack/rogue/shelf,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot{
-	pixel_x = -6;
-	pixel_y = 32
+/obj/item/gwstrap{
+	pixel_x = -12;
+	pixel_y = 13
 	},
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot{
-	pixel_y = 32
+/obj/item/gwstrap{
+	pixel_x = -19;
+	pixel_y = 16
 	},
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot{
-	pixel_x = 6;
-	pixel_y = 32
+/obj/item/gwstrap{
+	pixel_x = -15;
+	pixel_y = 16
 	},
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/tile,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "iJp" = (
-/obj/structure/mannequin,
-/obj/item/clothing/suit/roguetown/armor/plate/half,
-/obj/item/clothing/head/roguetown/helmet/sallet,
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/item/roguekey/vault,
+/obj/structure/closet/crate/roguecloset/lord{
+	lockid = "steward"
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/item/roguekey/armory,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/manor)
 "iJx" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
 /turf/open/floor/rogue/churchmarble,
@@ -26545,15 +26531,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblindungeon)
 "iKH" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 9
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/spider/stickyweb,
+/turf/open/water/sewer,
+/area/rogue/under/town/sewer)
 "iKK" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -26648,8 +26628,11 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "iLV" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle,
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "warehouse_shutter"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "iLW" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -26726,10 +26709,10 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/woods)
 "iMQ" = (
-/obj/structure/roguemachine/scomm{
+/obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/carpet/lord/right,
+/turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/manor)
 "iMR" = (
 /obj/structure/table/wood{
@@ -26787,10 +26770,8 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/basement)
 "iND" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/woodturned,
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "iNG" = (
 /obj/structure/flora/roguegrass,
@@ -27032,8 +27013,11 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "iRq" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/cobble,
+/obj/structure/stairs{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/under/town/basement/keep)
 "iRt" = (
 /obj/structure/mineral_door/wood{
@@ -27093,9 +27077,13 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
 "iSQ" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/garrison)
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "iSR" = (
 /obj/structure/stairs{
 	dir = 1
@@ -27204,15 +27192,15 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
 "iUW" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = 16;
-	pixel_y = 32
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/item/natural/feather{
+	pixel_x = -2;
+	pixel_y = 6
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/carpet,
+/area/rogue/under/town/basement/keep)
 "iVn" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -27237,8 +27225,14 @@
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/church/basement)
 "iVM" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "iVP" = (
 /obj/structure/fluff/railing/border{
@@ -27391,9 +27385,8 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "iXI" = (
-/obj/machinery/gear_painter,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/outdoors/town/roofs)
 "iXJ" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -27408,8 +27401,11 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/cave)
 "iXX" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/tile,
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "manor"
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "iYc" = (
 /turf/open/floor/rogue/cobblerock,
@@ -27491,7 +27487,7 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/basement)
 "iZi" = (
-/obj/item/roguebin/water,
+/obj/item/roguebin/water/gross,
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = 11;
 	pixel_y = -2
@@ -27736,11 +27732,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach)
 "jcT" = (
-/obj/structure/roguemachine/mail/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass,
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "jcV" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor6-old"
@@ -27800,19 +27795,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "jdv" = (
-/obj/structure/fluff/clock,
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/wooddark/vertical,
+/area/rogue/outdoors/town/roofs)
 "jdx" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/beach)
 "jdB" = (
-/obj/structure/table/wood,
-/obj/item/candle/candlestick/gold/lit{
-	pixel_y = 12
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/turf/closed/wall/mineral/rogue/roofwall/outercorner,
+/area/rogue/outdoors/town/roofs)
 "jdF" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -27835,13 +27825,12 @@
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "jdT" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32;
+	pixel_x = 32
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
-/area/rogue/outdoors/town/roofs/keep)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "jef" = (
 /obj/structure/bars/pipe{
 	dir = 4
@@ -27912,12 +27901,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/cave/dukecourt)
 "jfm" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_y = 32
+/obj/structure/chair/wood/rogue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11
 	},
-/obj/structure/closet/crate/drawer,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/carpet/lord/center,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
 "jfu" = (
 /obj/structure/fluff/railing/border{
@@ -27940,6 +27929,16 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/orcdungeon)
+"jfF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "jfI" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -28125,6 +28124,12 @@
 "jiA" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
+"jiD" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "jiQ" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -28138,22 +28143,16 @@
 /area/rogue/indoors/cave)
 "jiV" = (
 /obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
+	icon_state = "map3"
 	},
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "jiZ" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cobbleedge,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/garrison)
 "jja" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /obj/item/clothing/ring/silver,
@@ -28199,9 +28198,11 @@
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/mountains)
 "jjT" = (
-/obj/structure/well,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "jjU" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/water/sewer,
@@ -28215,10 +28216,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "jkr" = (
-/obj/structure/roguemachine/steward,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town)
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/exposed/town/keep)
 "jkC" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -28268,10 +28267,10 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
 "jlB" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/manor)
 "jlI" = (
 /obj/effect/spawner/roguemap/stump,
 /obj/structure/fluff/railing/fence{
@@ -28405,12 +28404,10 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "joB" = (
-/obj/structure/table/wood,
-/obj/item/book/rogue/abyssor,
-/obj/item/candle/gold/lit{
-	pixel_y = 5
+/obj/structure/table/wood{
+	icon_state = "map6"
 	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "joM" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -28432,12 +28429,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
 "jph" = (
-/obj/structure/roguemachine/mail{
-	mailtag = "Steward"
-	},
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/handcart,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "jpn" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/carpet/lord/center/no_teleport,
@@ -28563,11 +28558,14 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
 "jrn" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "jrv" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -28641,11 +28639,10 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "jsG" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-sread"
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 8
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/manor)
 "jsI" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -28655,14 +28652,21 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "jsJ" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "manor";
-	name = "Guest Room II"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/fallgown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/random,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
+/obj/item/clothing/suit/roguetown/armor/silkcoat,
+/obj/item/clothing/suit/roguetown/shirt/tunic/random,
+/obj/item/clothing/suit/roguetown/shirt/tunic/black,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
+/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk,
+/obj/item/clothing/cloak/half/red,
+/obj/item/clothing/cloak/half,
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/storage/backpack/rogue/satchel,
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "jsZ" = (
 /obj/structure/closet/crate/roguecloset,
@@ -28767,14 +28771,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "jvx" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/cup/silver{
-	desc = "A pewter goblet, cheaper than silver, but with a similar shine!";
-	name = "pewter goblet";
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/tile/masonic/single,
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "jvy" = (
 /obj/structure/table/wood{
@@ -28794,10 +28792,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
 "jvF" = (
-/obj/structure/chair/bench/couch{
-	icon_state = "redcouch2"
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/obj/structure/rogue/trophy/deer,
+/obj/item/paper,
+/obj/item/natural/feather{
+	pixel_x = 8;
+	pixel_y = -3
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -28814,12 +28817,10 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "jwe" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Keep Front Gate"
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "jwl" = (
 /obj/effect/decal/cobbleedge,
@@ -28870,10 +28871,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
 "jxs" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/closet/crate/roguecloset/dark,
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "jxv" = (
 /obj/structure/fluff/walldeco/chains{
@@ -28890,24 +28889,19 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "jxB" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/roguekey/manor,
-/obj/item/roguekey/manor,
-/obj/item/roguekey/manor,
-/obj/item/clothing/ring/silver,
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "longtable"
+	},
+/turf/open/floor/rogue/carpet/lord/left,
+/area/rogue/indoors/town/manor)
+"jxC" = (
+/obj/structure/fluff/railing/border,
+/obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/manor)
-"jxC" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/area/rogue/indoors/town/garrison)
 "jxK" = (
 /obj/structure/chair/wood/rogue/chair4,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -28924,13 +28918,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "jyb" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
+/obj/structure/bars/steel,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/garrison)
 "jyo" = (
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt/road,
@@ -28977,10 +28967,18 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "jyZ" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/tile/masonic,
+/obj/structure/fluff/walldeco/med6{
+	pixel_y = 32
+	},
+/obj/item/book/rogue/necra{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "jzk" = (
 /obj/machinery/light/rogue/hearth,
@@ -29036,16 +29034,17 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "jAe" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/flashlight/flare/torch/metal,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/closet/crate/chest/wicker,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "jAo" = (
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/naturalstone,
@@ -29069,13 +29068,8 @@
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/under/cave/skeletoncrypt)
 "jAV" = (
-/obj/structure/fluff/wallclock{
-	dir = 3
-	},
-/obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-sread"
-	},
-/turf/open/floor/rogue/wood,
+/obj/structure/fluff/walldeco/customflag,
+/turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/garrison)
 "jBj" = (
 /obj/structure/bookcase/random/adult,
@@ -29136,6 +29130,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"jCv" = (
+/obj/machinery/light/rogue/chand{
+	bulb_power = 3
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/manor)
 "jCx" = (
 /obj/item/natural/rock/salt,
 /turf/open/floor/rogue/dirt,
@@ -29434,12 +29434,6 @@
 /obj/structure/fluff/walldeco/artificerflag,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"jHQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
 "jHR" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -29548,11 +29542,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "jKf" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/obj/structure/chair/bench/church,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/basement)
 "jKh" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 4
@@ -29577,6 +29569,12 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
+"jKx" = (
+/obj/structure/closet/crate/drawer,
+/obj/item/natural/feather,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/tile/masonic/inverted,
+/area/rogue/indoors/town/manor)
 "jKH" = (
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/shop)
@@ -29614,10 +29612,8 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
 "jKV" = (
-/obj/structure/bookcase,
-/obj/item/book/rogue/robber,
-/obj/item/book/rogue/sword,
-/turf/open/floor/rogue/carpet,
+/obj/structure/flora/roguegrass/herb/rosa,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "jLl" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -29781,17 +29777,9 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "jOP" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/structure/fluff/railing/border,
-/obj/item/rogueweapon/huntingknife/chefknife,
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = -7
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town)
+/obj/structure/fluff/statue/knight,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "jPe" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -29808,13 +29796,17 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "jPl" = (
-/obj/structure/closet/crate/roguecloset/crafted,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
-/obj/item/clothing/under/roguetown/skirt,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town)
+/obj/structure/closet/crate/chest/neu,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/quiver/sling/iron,
+/obj/item/quiver/sling/iron,
+/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
+/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "jPs" = (
 /obj/machinery/light/roguestreet{
 	dir = 1
@@ -29865,15 +29857,13 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "jQC" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/table/wood{
+	icon_state = "map2"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/item/candle/candlestick/gold/lit{
+	pixel_y = 12
 	},
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/roguegrass/herb/rosa,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "jQE" = (
 /obj/effect/decal/cobbleedge{
@@ -29890,12 +29880,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "jQJ" = (
-/obj/structure/lever/wall{
-	dir = 8;
-	redstone_id = "steward_shutter"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/obj/effect/decal/carpet,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "jQO" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/hexstone,
@@ -30019,6 +30006,17 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"jTb" = (
+/obj/structure/mineral_door/wood{
+	name = "Service Halls";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "jTc" = (
 /obj/structure/hotspring/border/three,
 /turf/open/floor/rogue/grass,
@@ -30121,6 +30119,15 @@
 	},
 /turf/open/floor/rogue/concrete/bronze,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"jUL" = (
+/obj/structure/mineral_door/wood{
+	name = "Service Halls";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "jUR" = (
 /obj/structure/roguemachine/vendor,
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -30161,18 +30168,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblindungeon)
 "jWl" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/structure/fluff/wallclock,
-/obj/item/candle/gold/lit{
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/closet/crate/roguecloset/dark,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "jWn" = (
 /obj/structure/flora/roguegrass/bush/wall,
@@ -30308,17 +30305,19 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"jZa" = (
+/obj/structure/closet/crate/chest,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/item/flint,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/basement)
 "jZe" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
-"jZq" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/town/roofs/keep)
 "jZs" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 8
@@ -30368,12 +30367,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave)
-"jZO" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
 "jZR" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1
@@ -30403,15 +30396,11 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains/decap)
 "kac" = (
-/obj/structure/stairs{
-	dir = 4
+/turf/closed/wall/mineral/rogue/pipe{
+	dir = 8;
+	icon_state = "iron_joint"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/manor)
 "kan" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -30489,13 +30478,11 @@
 /area/rogue/outdoors/town)
 "kby" = (
 /obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "royal";
-	name = "Lord's Dining Room"
+	lockid = "manor";
+	name = "Meeting Room";
+	locked = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "kbG" = (
 /obj/machinery/light/rogue/campfire,
@@ -30514,19 +30501,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kbS" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/item/roguecoin/gold/pile,
+/obj/structure/fluff/walldeco/painting{
+	pixel_y = 32
 	},
-/obj/structure/flora/roguegrass/bush{
-	pixel_x = -5;
-	pixel_y = 0
+/turf/open/floor/rogue/tile/masonic{
+	dir = 8
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/indoors/town/vault)
 "kbV" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/herb/salvia,
@@ -30576,6 +30558,20 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors)
+"kcz" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "kcD" = (
 /obj/structure/fluff/walldeco/bigpainting/lake{
 	pixel_x = 0
@@ -30678,10 +30674,11 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "key" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
 	},
-/turf/open/floor/rogue/tile/masonic,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "kez" = (
 /obj/structure/mineral_door/wood/fancywood{
@@ -30755,12 +30752,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
 "kgb" = (
-/obj/structure/closet/crate/drawer/random{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/obj/item/roguekey/manor,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "kgg" = (
 /obj/structure/flora/roguegrass/bush/wall,
@@ -30845,30 +30838,15 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "khf" = (
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
 	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine{
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "khy" = (
 /obj/structure/table/wood{
@@ -30937,10 +30915,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kiz" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/vault)
+/turf/closed/wall/mineral/rogue/decostone/cand,
+/area/rogue/under/town/basement/keep)
 "kiD" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/dirt,
@@ -31262,9 +31238,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/underdark)
 "kpa" = (
-/obj/structure/mirror,
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/carpet,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/broom,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "kpb" = (
 /obj/effect/decal/cobbleedge{
@@ -31305,8 +31284,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "kpN" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/blocks,
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Hand's Chambers"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "kpX" = (
 /obj/structure/fluff/railing/border,
@@ -31339,14 +31324,16 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
 "kqG" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/machinery/light/rogue/lanternpost{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/item/roguegem/blue,
+/obj/item/roguegem/green,
+/obj/item/roguegem/yellow,
+/obj/item/roguegem/violet,
+/obj/item/roguegem/ruby,
+/obj/item/roguegem/ruby,
+/obj/structure/closet/crate/chest/neu_fancy,
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/tile/masonic,
+/area/rogue/indoors/town/vault)
 "kqL" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -31475,10 +31462,11 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/cell)
 "ktO" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/flail/sflail,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ktV" = (
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/outdoors/beach/forest)
@@ -31582,9 +31570,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter)
 "kve" = (
-/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/roguegrass/bush,
+/obj/structure/fluff/railing/fence{
+	dir = 4
+	},
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/outdoors/town)
 "kvh" = (
 /obj/structure/table/wood,
 /obj/structure/fluff/walldeco/painting/queen{
@@ -31688,11 +31679,10 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter)
 "kwQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/tile/bath,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "kwT" = (
 /obj/structure/rack/rogue/shelf/biggest,
@@ -31866,10 +31856,11 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "kzy" = (
-/obj/machinery/light/rogue/lanternpost,
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "kzG" = (
 /obj/machinery/light/roguestreet/midlamp{
 	pixel_y = 10
@@ -31904,12 +31895,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
 "kAv" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "kAx" = (
 /obj/structure/flora/roguegrass,
@@ -31925,21 +31914,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/shelter/mountains/decap)
 "kAF" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "garrison"
-	},
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/tabard/knight/guard,
-/obj/item/clothing/cloak/tabard/knight/guard,
-/obj/item/clothing/cloak/tabard/knight/guard,
-/obj/item/clothing/cloak/tabard/knight/guard,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/turf/closed,
+/area/rogue/indoors/town/physician)
 "kAI" = (
 /obj/structure/rack/rogue/shelf,
 /obj/item/reagent_containers/glass/cup/wooden{
@@ -31967,14 +31943,18 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/dwarfin)
 "kBl" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/closet/crate/roguecloset,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/roguekey/manor,
+/obj/item/roguekey/manor,
+/obj/item/roguekey/manor,
+/obj/item/clothing/ring/silver,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs/keep)
+/area/rogue/indoors/town/manor)
 "kBo" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -32043,12 +32023,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/orcdungeon)
 "kBZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
 	},
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "kCa" = (
 /mob/living/simple_animal/hostile/rogue/mirespider_lurker,
@@ -32084,12 +32062,10 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/shop)
 "kCs" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/obj/structure/globe,
-/obj/structure/roguemachine/mail/r,
-/turf/open/floor/rogue/cobble,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/half,
+/obj/item/clothing/shoes/roguetown/shortboots,
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "kCt" = (
 /obj/structure/closet/crate/chest,
@@ -32301,10 +32277,10 @@
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/under/cave/dukecourt)
 "kFL" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
 	},
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "kFR" = (
 /obj/machinery/light/small{
@@ -32512,15 +32488,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "kJS" = (
-/obj/structure/winch{
-	dir = 4;
-	gid = "thronegate";
-	pixel_x = -7;
-	redstone_id = "thronegate"
+/obj/structure/chair/wood/rogue{
+	dir = 8
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "kJU" = (
 /obj/structure/closet/crate/chest/old_crate,
@@ -32622,8 +32593,17 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "kMx" = (
-/turf/open/floor/rogue/tile/masonic/single,
-/area/rogue/indoors/town/manor)
+/obj/structure/mannequin,
+/obj/item/clothing/suit/roguetown/armor/leather/studded{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/roguetown/helmet/kettle{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "kMF" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
@@ -32692,9 +32672,20 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
 "kNL" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/whitewine{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/cup/silver{
+	desc = "A pewter goblet, cheaper than silver, but with a similar shine!";
+	name = "pewter goblet";
+	pixel_x = -11
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town/roofs/keep)
 "kNO" = (
 /obj/structure/fluff/alch,
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -32800,9 +32791,8 @@
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "kQf" = (
-/obj/structure/chair/bench/couch{
-	icon_state = "redcouch2"
-	},
+/obj/structure/closet/crate/drawer,
+/obj/item/scomstone/bad/garrison,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "kQh" = (
@@ -32859,6 +32849,23 @@
 /obj/item/natural/rock/gem,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/beach)
+"kRp" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/tile/masonic{
+	dir = 1
+	},
+/area/rogue/indoors/town/manor)
 "kRq" = (
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/blocks/platform,
@@ -32875,9 +32882,9 @@
 /area/rogue/indoors/cave)
 "kRA" = (
 /obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+	dir = 4
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "kRG" = (
 /obj/structure/flora/roguegrass/water/reeds,
@@ -32891,9 +32898,13 @@
 	},
 /area/rogue/indoors/town/dwarfin)
 "kRO" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/carpet/red,
-/area/rogue/under/town/basement/keep)
+/obj/structure/mineral_door/wood/donjon{
+	dir = 8;
+	locked = 1;
+	lockid = "steward"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "kRY" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -32901,8 +32912,8 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
 "kSj" = (
-/obj/structure/fluff/walldeco/painting/seraphina,
-/turf/closed/wall/mineral/rogue/decostone/cand,
+/obj/structure/stairs/stone/d,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "kSt" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -33055,10 +33066,9 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
 "kUH" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
-	},
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "kUI" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -33069,14 +33079,15 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement/keep)
-"kVf" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "manor";
-	name = "Council Office"
+"kUO" = (
+/turf/open/floor/rogue/rooftop/green{
+	dir = 4
 	},
-/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"kVf" = (
+/obj/structure/flora/roguegrass/bush/wall/tall,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
 "kVm" = (
 /obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/woodturned,
@@ -33341,9 +33352,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains/decap)
 "laf" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
+/obj/structure/chair/wood/rogue/chair3,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "lal" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -33386,14 +33397,14 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
 "laF" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n";
+	pixel_x = 2;
+	pixel_y = 8
 	},
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "laK" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/remains/human,
@@ -33501,13 +33512,9 @@
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
 "lcZ" = (
-/obj/structure/fluff/walldeco/painting{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "glyph6"
-	},
-/area/rogue/indoors/town/vault)
+/obj/structure/toilet,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "ldf" = (
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/dirt/road,
@@ -33606,8 +33613,7 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/sewer)
 "lfb" = (
-/obj/effect/landmark/start/guard_captain,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "lfc" = (
 /obj/structure/closet/crate/roguecloset,
@@ -33642,12 +33648,10 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
 "lfz" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/fabric_double,
+/obj/effect/landmark/start/hand,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "lfG" = (
 /turf/closed/wall/mineral/rogue/pipe{
@@ -33655,23 +33659,10 @@
 	},
 /area/rogue/under/town/sewer)
 "lfI" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/fluff/walldeco/rpainting/crown{
+	pixel_y = 32
 	},
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/cooking/platter/pewter,
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	pixel_x = 3;
-	pixel_y = 5;
-	sellprice = 30
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "lfO" = (
 /turf/open/floor/rogue/naturalstone,
@@ -33855,16 +33846,28 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
 "ljl" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/carpet,
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
 "lju" = (
-/obj/structure/mineral_door/wood/window{
-	locked = 1;
-	lockid = "sheriff";
-	name = "captains room door"
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/concrete,
+/obj/item/cooking/platter,
+/obj/item/reagent_containers/food/snacks/rogue/meat/salami{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/rogueweapon/huntingknife/chefknife{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "ljB" = (
 /obj/structure/fermentation_keg/water,
@@ -33913,13 +33916,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "lkJ" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "vault"
-	},
-/obj/structure/fluff/walldeco/alarm,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/church,
+/area/rogue/outdoors/exposed/town/keep)
 "lkT" = (
 /obj/structure/closet/crate/drawer,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -33951,6 +33949,36 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
+"lll" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "llp" = (
 /obj/structure/stairs{
 	dir = 8
@@ -33996,11 +34024,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "llF" = (
-/obj/structure/table/wood{
-	icon_state = "map4"
+/obj/item/roguecoin/gold/pile,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/vault)
 "llI" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
@@ -34066,22 +34095,40 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "lmP" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "steward"
 	},
-/obj/item/reagent_containers/glass/cup/golden{
-	pixel_x = -8;
-	pixel_y = 6
+/obj/item/roguekey/manor,
+/obj/item/roguekey/walls,
+/obj/item/roguekey/crafterguild,
+/obj/item/roguekey/steward,
+/obj/item/roguekey/church,
+/obj/item/roguekey/dungeon,
+/obj/item/roguekey/graveyard,
+/obj/item/roguekey/garrison{
+	name = "garrison key"
 	},
-/obj/item/reagent_containers/glass/bottle/rogue/redwine{
-	pixel_x = 6;
-	pixel_y = -6
+/obj/item/roguekey/mercenary,
+/obj/item/roguekey/nightmaiden,
+/obj/item/roguekey/tavern,
+/obj/item/roguekey/physician,
+/obj/item/roguekey/knight,
+/obj/item/roguekey/armory,
+/obj/item/roguekey/tower,
+/obj/item/roguekey/apartments/stable1,
+/obj/item/roguekey/apartments/stable2,
+/obj/item/roguekey/tailor,
+/obj/item/roguekey/shop,
+/obj/item/roguekey/archive,
+/obj/item/paper{
+	info = "Hand Key, Lord's Key, Knight Captain's Key, Marshall Key, Sergeant Key, Royal Key kept in Vault."
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "lmV" = (
 /obj/effect/decal/cobbleedge{
-	dir = 9;
+	dir = 7;
 	pixel_x = 13
 	},
 /obj/effect/decal/cobbleedge{
@@ -34105,13 +34152,15 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "lnu" = (
-/obj/structure/flora/roguegrass/bush,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "lnx" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -34152,14 +34201,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
-"lnQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/roguegrass/herb/rosa,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "lnT" = (
 /obj/structure/table/vtable,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -34216,10 +34257,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/skeletoncrypt)
 "loz" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/stoneaxe/battle,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/roofwall/middle,
+/area/rogue/indoors/town/manor)
 "loC" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -34297,16 +34336,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
 "lpr" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/chair/wood/rogue,
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
 	},
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "lpu" = (
 /turf/closed/wall/mineral/rogue/stone,
@@ -34371,14 +34405,12 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
 "lqJ" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "hand";
+	name = "Hand's Chambers"
 	},
-/obj/item/candle/candlestick/silver/lit,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "lqP" = (
 /turf/open/floor/rogue/hay,
@@ -34394,6 +34426,14 @@
 "lrc" = (
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/indoors/shelter)
+"lrk" = (
+/obj/structure/table/wood{
+	icon_state = "longtable_mid";
+	dir = 1
+	},
+/obj/item/book/rogue/yeoldecookingmanual,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "lrn" = (
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
@@ -34590,14 +34630,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"ltS" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "ltX" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/herringbone,
@@ -34685,12 +34717,14 @@
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/dwarfin)
 "lvE" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/manor)
+"lvT" = (
+/obj/structure/stairs/d,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "lwb" = (
 /obj/structure/fluff/walldeco/chains,
@@ -34823,9 +34857,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/mountains/decap)
 "lyq" = (
-/obj/effect/landmark/start/butler,
-/turf/open/floor/carpet/stellar,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/rooftop/green/corner1,
+/area/rogue/outdoors/town/roofs/keep)
 "lyr" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/AzureSand,
@@ -34849,10 +34882,7 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "lyG" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "lyI" = (
 /obj/item/roguebin/water/gross,
@@ -34973,14 +35003,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/shop)
 "lAt" = (
-/obj/item/roguekey/vault,
-/obj/structure/closet/crate/roguecloset/lord{
-	lockid = "steward"
+/obj/effect/decal/cobbleedge{
+	dir = 5
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/item/roguekey/armory,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/obj/structure/fluff/canopy/booth/booth02,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "lAw" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/ocean/deep,
@@ -34992,9 +35020,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
 "lAF" = (
-/obj/structure/toilet,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile/masonic/inverted,
+/obj/structure/chair/bench/couchablack,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/under/town/basement/keep)
 "lAO" = (
 /obj/structure/roguemachine/bounty,
@@ -35154,19 +35182,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
 "lDn" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/flashlight/flare/torch/lantern{
-	pixel_x = 4;
-	pixel_y = 32
-	},
-/obj/item/flashlight/flare/torch/lantern{
-	pixel_x = -4;
-	pixel_y = 32
-	},
-/obj/item/flashlight/flare/torch/lantern{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/tile,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/town/basement/keep)
 "lDp" = (
 /obj/structure/rack/rogue,
@@ -35185,13 +35201,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
 "lDK" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "walls";
-	dir = 8
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/manor)
 "lDL" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/fabric,
@@ -35318,14 +35332,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "lGl" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_x = 32
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "lGp" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -35558,7 +35568,7 @@
 "lKw" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/outdoors/town)
 "lKH" = (
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/blocks,
@@ -35621,18 +35631,24 @@
 	},
 /area/rogue/indoors/town)
 "lLL" = (
-/obj/item/book/rogue/nitebeast,
-/obj/item/book/rogue/noc,
-/obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
+/obj/item/candle/candlestick/silver/lit{
+	pixel_y = 136;
+	pixel_x = 33
+	},
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "lLP" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/item/rogue/instrument/lute,
+/obj/item/rogue/instrument/harp,
+/obj/item/rogue/instrument/guitar,
+/obj/item/rogue/instrument/flute,
+/obj/structure/closet/crate/chest,
+/obj/item/rogue/instrument/accord,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "lLT" = (
 /obj/structure/flora/roguegrass,
@@ -35640,11 +35656,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "lLV" = (
-/obj/structure/table/wood{
-	icon_state = "map3"
+/obj/structure/bars/passage/shutter/open{
+	redstone_id = "stewardshutter"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "lLY" = (
 /obj/structure/table/vtable/v2,
 /obj/item/candle/skull,
@@ -35755,10 +35771,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "lNt" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/tile/bath,
+/obj/item/candle/candlestick/gold/lit{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "lND" = (
 /obj/structure/mineral_door/wood/donjon/stone{
@@ -35795,10 +35816,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "lOy" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "glyph3"
-	},
-/area/rogue/indoors/town/vault)
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "lOB" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
@@ -35834,13 +35854,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter)
 "lPk" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/under/town/basement/keep)
+/obj/structure/flora/ausbushes,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "lPm" = (
 /obj/structure/stairs{
 	dir = 1
@@ -35984,19 +36000,19 @@
 /area/rogue/outdoors/mountains/decap)
 "lSh" = (
 /obj/structure/rack/rogue,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs,
-/turf/open/floor/rogue/tile,
+/obj/item/rogueweapon/stoneaxe/woodcut/steel,
+/obj/item/rogueweapon/stoneaxe/woodcut/steel{
+	pixel_x = -1;
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "lSo" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "manor";
-	name = "Kitchen"
+/obj/structure/floordoor/gatehatch/inner{
+	redstone_id = "wallbridge"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "lSt" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -36004,6 +36020,21 @@
 /obj/machinery/light/rogue/wallfire/candle/off/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"lSR" = (
+/obj/structure/flora/roguegrass/bush/wall/tall{
+	pixel_x = -11;
+	pixel_y = 0
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "lTn" = (
 /obj/structure/bars/pipe{
 	dir = 4
@@ -36045,12 +36076,6 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town)
-"lUs" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/manor)
 "lUx" = (
 /obj/structure/fluff/walldeco/psybanner/red,
 /turf/closed/wall/mineral/rogue/stone{
@@ -36066,17 +36091,21 @@
 /obj/structure/bars/steel,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"lUO" = (
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/fabric_double,
+/obj/effect/landmark/start/guard_captain,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "lUQ" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
 "lUZ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 9
+/obj/structure/fluff/walldeco/rpainting/crown{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "lVh" = (
 /obj/structure/flora/hotspring_rocks/small/five,
@@ -36096,11 +36125,21 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "lVB" = (
-/obj/structure/mirror,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/effect/decal/cobbleedge{
+	dir = 5
 	},
-/area/rogue/indoors/town)
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve{
+	pixel_x = -14;
+	pixel_y = -13
+	},
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve{
+	pixel_x = -21;
+	pixel_y = -18
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "lVE" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/ambush,
@@ -36221,12 +36260,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/woods)
-"lXR" = (
-/obj/structure/chair/bench/coucha/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "lXW" = (
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/cobble,
@@ -36288,9 +36321,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/magician)
 "lZz" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town/vault)
 "lZA" = (
 /obj/structure/meathook,
 /obj/effect/decal/cleanable/blood,
@@ -36369,10 +36404,10 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
 "maL" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32
-	},
-/turf/open/floor/rogue/tile/masonic,
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "mbc" = (
 /obj/structure/table/wood{
@@ -36404,20 +36439,17 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/outdoors/town)
 "mby" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "mbG" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wcv";
-	locked = 1;
-	lockid = "knight";
-	name = "royal guard quarters"
+/obj/structure/fluff/walldeco/steward{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "mbI" = (
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /obj/structure/closet/crate/roguecloset,
@@ -36444,11 +36476,15 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "mca" = (
-/obj/structure/stairs/stone{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/bundle/stick,
+/obj/item/natural/bundle/stick,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "mcl" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/blocks/green,
@@ -36491,11 +36527,14 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet/bogcaves)
 "mcU" = (
-/obj/structure/bed/rogue/inn,
-/obj/item/bedsheet/rogue/fabric,
-/obj/effect/landmark/start/councillor,
-/turf/open/floor/carpet/inn,
-/area/rogue/under/town/basement/keep)
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = "manor";
+	name = "Service Halls"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/manor)
 "mcY" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -36518,14 +36557,12 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "mdm" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/soap/bath,
-/obj/item/soap/bath,
-/obj/item/rogueweapon/huntingknife/scissors/steel{
-	pixel_y = -5;
-	sellprice = 8
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/fabric,
+/obj/effect/landmark/start/jester{
+	dir = 8
 	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "mdv" = (
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -36804,9 +36841,15 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "mhx" = (
-/obj/structure/roguemachine/lottery_roguetown,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/table/wood{
+	icon_state = "map3"
+	},
+/obj/item/candle/silver/lit{
+	pixel_x = -2;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "mhy" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road,
@@ -36894,11 +36937,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "mjw" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/obj/structure/chair/bench/ultimacouch,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "mjz" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -36942,11 +36984,11 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
 "mkj" = (
-/obj/structure/fluff/wallclock{
-	dir = 3
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "mkn" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt/road,
@@ -37065,11 +37107,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/goblinfort)
 "mmb" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/vault)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "mmd" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -37089,16 +37128,6 @@
 "mmr" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
-"mmy" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/masonic,
-/area/rogue/indoors/town/manor)
 "mmB" = (
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/town/basement/keep)
@@ -37137,13 +37166,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/orcdungeon)
 "mno" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "manor"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/half,
+/obj/item/clothing/shoes/roguetown/shortboots,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "mnw" = (
 /obj/effect/decal/mossy{
@@ -37164,7 +37190,7 @@
 	dir = 1;
 	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/tile/masonic/single,
+/turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/manor)
 "mnC" = (
 /obj/machinery/light/rogue/torchholder/c,
@@ -37205,11 +37231,14 @@
 	},
 /area/rogue/outdoors/beach)
 "mow" = (
-/obj/structure/bars/passage/shutter/open{
-	redstone_id = "stewardshutter"
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "moJ" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp,
@@ -37314,8 +37343,20 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/skeletoncrypt)
 "mqT" = (
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/roguecloset{
+	name = "Chainmail"
+	},
+/obj/item/clothing/gloves/roguetown/chain/iron,
+/obj/item/clothing/gloves/roguetown/chain/iron,
+/obj/item/clothing/neck/roguetown/chaincoif/iron,
+/obj/item/clothing/neck/roguetown/chaincoif/iron,
+/obj/item/clothing/under/roguetown/chainlegs/iron,
+/obj/item/clothing/under/roguetown/chainlegs/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "mqV" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/manorguardsman,
@@ -37329,10 +37370,7 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/mountains/decap)
 "mqZ" = (
-/obj/effect/landmark/start/servant{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/manor)
 "mre" = (
 /obj/structure/fluff/railing/border{
@@ -37565,12 +37603,11 @@
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
 "mvH" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/cup/golden{
-	pixel_x = -8;
-	pixel_y = 6
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = 2;
+	pixel_y = 0
 	},
-/turf/open/floor/rogue/carpet/lord/left,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "mvN" = (
 /obj/machinery/light/rogue/torchholder/c,
@@ -37649,7 +37686,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "mxj" = (
-/turf/open/floor/carpet/stellar,
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 5
+	},
 /area/rogue/indoors/town/manor)
 "mxp" = (
 /obj/structure/fluff/littlebanners{
@@ -37661,12 +37700,6 @@
 /obj/structure/fermentation_keg/zagul,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"mxu" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "mxw" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
@@ -37683,15 +37716,7 @@
 /turf/closed/wall/mineral/rogue/stone/red_moss,
 /area/rogue/indoors/shelter/mountains/decap)
 "mxO" = (
-/obj/structure/table/wood{
-	icon_state = "longtable_mid"
-	},
-/obj/structure/mirror{
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/obj/item/clothing/ring/signet,
-/turf/open/floor/rogue/carpet/lord/center,
+/turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/manor)
 "mxP" = (
 /obj/structure/glowshroom,
@@ -37952,14 +37977,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/magician)
 "mCr" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/quiver/bolts,
-/obj/item/flashlight/flare/torch/lantern,
-/obj/item/rope/chain,
-/obj/item/gwstrap,
-/obj/item/rogueweapon/mace/cudgel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "mCs" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt,
@@ -37993,9 +38014,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
 "mDc" = (
-/obj/structure/mirror,
-/turf/open/floor/carpet/inn,
-/area/rogue/under/town/basement/keep)
+/obj/structure/kybraxor{
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "mDm" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
@@ -38089,14 +38113,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
 "mFr" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/flashlight/flare/torch/lantern,
-/obj/item/storage/belt/rogue/leather/steel/tasset,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/obj/item/clothing/shoes/roguetown/boots/nobleboot,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
-/turf/open/floor/rogue/carpet/lord/center,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/lanternpost,
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "mFt" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -38221,9 +38243,9 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "mHf" = (
-/obj/machinery/light/rogue/oven/west,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "mHg" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -38287,6 +38309,15 @@
 /obj/item/roguecoin/silver,
 /turf/open/water/sewer,
 /area/rogue/indoors/cave)
+"mIj" = (
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_x = -32
+	},
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/manor)
 "mIt" = (
 /obj/machinery/light/rogue/cauldron,
 /turf/open/floor/rogue/hexstone,
@@ -38318,12 +38349,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "mIU" = (
-/obj/structure/closet/crate/chest/neu_fancy,
-/obj/item/roguecoin/gold/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace,
+/obj/item/rogueweapon/mace{
+	pixel_x = 2;
+	pixel_y = -4
 	},
-/area/rogue/indoors/town/vault)
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "mJc" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/floor/rogue/dirt,
@@ -38412,11 +38445,17 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/goblindungeon)
 "mKP" = (
-/obj/structure/table/wood,
-/obj/item/cooking/platter/gold{
-	sellprice = 50
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
 	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/rogue/meat/salami{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "mKQ" = (
 /obj/structure/stairs{
@@ -38662,21 +38701,41 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "mOz" = (
-/obj/structure/chair/bench/couchablack,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/rack/rogue/shelf,
+/obj/item/flashlight/flare/torch/lantern{
+	pixel_y = 32;
+	pixel_x = 4
+	},
+/obj/item/flashlight/flare/torch/lantern{
+	pixel_y = 32;
+	pixel_x = -4
+	},
+/obj/item/flashlight/flare/torch/lantern{
+	pixel_y = 32
+	},
+/obj/item/flint{
+	pixel_x = 10;
+	pixel_y = 36
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "mOD" = (
-/obj/structure/stairs{
-	dir = 8
+/obj/structure/closet/crate/drawer/random{
+	pixel_y = 0
 	},
-/turf/open/floor/rogue/tile/bath,
+/obj/item/roguegem/diamond,
+/obj/item/clothing/ring/active/nomag,
+/obj/item/roguekey/lord{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "mON" = (
-/obj/structure/roguemachine/mail{
-	mailtag = "Warehouse"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "mOX" = (
 /obj/structure/table/church,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -38709,20 +38768,10 @@
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave/mazedungeon)
 "mPo" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/tablecloth/silk{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/obj/structure/closet/crate/drawer,
+/obj/item/natural/feather,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "mPv" = (
 /obj/structure/rack/rogue/shelf/biggest,
@@ -38743,10 +38792,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
 "mPH" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks,
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement/keep)
 "mPL" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -38762,26 +38809,6 @@
 	},
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/cave)
-"mQb" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/item/clothing/head/roguetown/chef,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
 "mQg" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/grassred,
@@ -38792,8 +38819,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "mQw" = (
-/obj/structure/fluff/statue/knight/r,
-/turf/open/floor/rogue/hexstone,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "mQB" = (
 /obj/structure/fluff/railing/fence{
@@ -38858,10 +38887,6 @@
 /obj/item/rogueweapon/stoneaxe,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
-"mSd" = (
-/obj/effect/landmark/start/lord,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "mSg" = (
 /obj/structure/winch{
 	gid = "lichdoor";
@@ -39095,13 +39120,6 @@
 /obj/item/flashlight/flare/torch/lantern/bronzelamptern/malums_lamptern,
 /turf/open/floor/rogue/concrete/bronze,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"mWk" = (
-/obj/structure/chair/bench/couchablack,
-/obj/structure/fluff/walldeco/bigpainting{
-	pixel_x = 0
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "mWp" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/under/cave/licharena)
@@ -39140,6 +39158,18 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"mWX" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "mWY" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -39150,19 +39180,32 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "mXe" = (
-/obj/structure/fluff/railing/border{
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/roguekey/armory,
+/obj/item/roguekey/sheriff,
+/obj/item/roguekey/dungeon,
+/obj/item/roguekey/walls,
+/obj/item/roguekey/manor,
+/obj/item/storage/keyring,
+/obj/item/storage/belt/rogue/leather/steel/tasset,
+/obj/item/roguekey/warden,
+/obj/item/roguekey/sergeant,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/manor)
+"mXi" = (
+/obj/structure/table/wood{
+	icon_state = "longtable_mid";
 	dir = 1
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/kitchen/rollingpin{
+	pixel_x = 13
 	},
-/area/rogue/outdoors/town/roofs/keep)
-"mXi" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/cobble,
+/obj/item/reagent_containers/peppermill,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "mXj" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -39221,8 +39264,10 @@
 	},
 /area/rogue/indoors/town/manor)
 "mXZ" = (
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/physician)
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_line"
+	},
+/area/rogue/indoors/town/manor)
 "mYm" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -39242,24 +39287,15 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "mYs" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "royal";
-	name = "Lord's Apartment"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/fluff/wallclock/r,
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "mYz" = (
-/obj/structure/table/wood,
-/obj/item/candle/candlestick/gold/lit{
-	pixel_y = 12
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/roofs/keep)
 "mYK" = (
 /obj/structure/fermentation_keg/random/water,
 /turf/open/floor/rogue/cobble,
@@ -39345,25 +39381,23 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "nan" = (
-/obj/structure/closet/crate/drawer,
-/obj/item/scomstone/bad/garrison,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
+	},
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "nar" = (
 /turf/open/water/swamp/deep,
 /area/rogue/indoors/cave)
 "nat" = (
-/obj/structure/fluff/walldeco/alarm{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/structure/stairs/stone{
+	dir = 8
 	},
-/obj/structure/mineral_door/wood/donjon{
-	dir = 1;
-	locked = 1;
-	lockid = "steward"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "nay" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -39477,11 +39511,11 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "ncy" = (
-/obj/structure/stairs/stone{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 9
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "ncA" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cave/orcdungeon)
@@ -39791,8 +39825,12 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement/keep)
 "ngD" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/hexstone,
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/fabric_double,
+/obj/structure/fluff/walldeco/painting{
+	pixel_x = 31
+	},
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "ngP" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
@@ -39878,19 +39916,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
 "nix" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = -5;
+	pixel_y = 0
 	},
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = -10;
-	pixel_y = 10
-	},
-/obj/item/kitchen/fork/gold{
-	pixel_x = 12;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/town)
 "niF" = (
 /obj/structure/closet/crate/chest/wicker,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -39925,19 +39957,35 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"niY" = (
+/obj/structure/gate{
+	name = "Throne Room Gate";
+	gid = "gatemanor2";
+	redstone_id = "gatemanor3"
+	},
+/turf/open/floor/rogue/carpet/lord/left,
+/area/rogue/indoors/town/manor)
 "njb" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/cup/silver{
-	name = "pewter goblet";
-	pixel_x = -11
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = 8
+	},
+/obj/item/kitchen/spoon/gold{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "njj" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	dir = 1
 	},
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "njv" = (
 /turf/open/floor/rogue/concrete,
@@ -39988,16 +40036,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/woods)
 "nkG" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
 /obj/structure/table/wood{
-	icon_state = "longtable"
+	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/item/reagent_containers/glass/bowl/gold,
+/obj/item/roguekey/manor,
+/obj/item/roguekey/manor,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "nkH" = (
@@ -40178,11 +40221,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "nnb" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = 8;
+	pixel_y = 2
 	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/physician)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/basement)
 "nni" = (
 /obj/effect/decal/mossy{
 	dir = 8
@@ -40222,13 +40266,15 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "nnJ" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/stone/moss,
+/area/rogue/outdoors/town)
 "nnL" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/physician)
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4;
+	icon_state = "wooddir"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "nnM" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -40259,13 +40305,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "noc" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/stairs{
+	dir = 8
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "noe" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
@@ -40325,14 +40368,6 @@
 "noW" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
-"noX" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/roguegrass/herb/rosa,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "noZ" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -40399,13 +40434,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "nqr" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/structure/fluff/walldeco/stone{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/carpet/stellar,
+/turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/manor)
 "nqs" = (
 /obj/machinery/light/rogue/firebowl/standing,
@@ -40458,10 +40487,8 @@
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/church/chapel)
 "nrO" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/roguemachine/withdraw,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "nrR" = (
 /obj/structure/bookcase,
@@ -40501,11 +40528,14 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
 "nsK" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
+/obj/structure/closet/crate/drawer/random{
+	pixel_x = 1;
+	pixel_y = 3
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/town/roofs/keep)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "nsM" = (
 /obj/structure/flora/newbranch/leafless{
 	dir = 8
@@ -40649,9 +40679,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "nvU" = (
-/obj/machinery/gear_painter,
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 32
+	},
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "nwa" = (
 /obj/effect/landmark/start/wapprentice,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -40806,14 +40839,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "nyU" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "longtable"
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "nzd" = (
 /obj/item/roguestatue/gold/loot,
@@ -40827,8 +40856,10 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "nzo" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "nzs" = (
 /obj/structure/fluff/traveltile/bandit{
@@ -40899,9 +40930,25 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "nAZ" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
+/obj/item/reagent_containers/glass/cup/ceramic/fancy{
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/cup/ceramic/fancy{
+	pixel_x = -1;
+	pixel_y = -24
+	},
+/obj/item/reagent_containers/glass/cup/ceramic/fancy{
+	pixel_x = -35;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "nBd" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/twig,
@@ -41001,8 +41048,12 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/shelter)
 "nCB" = (
-/obj/structure/fluff/statue/knight,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/rooftop/green{
+	dir = 8
+	},
 /area/rogue/indoors/town/manor)
 "nCL" = (
 /obj/effect/decal/cobbleedge{
@@ -41031,11 +41082,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "nDt" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/tile/bfloorz,
+/area/rogue/indoors/town/manor)
 "nDx" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -41053,21 +41102,8 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave/mazedungeon)
 "nDI" = (
-/obj/item/reagent_containers/glass/bottle/rogue/whitewine{
-	pixel_x = -10;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "longtable"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/ladder,
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
 "nDL" = (
 /obj/structure/closet/crate/chest{
@@ -41178,18 +41214,9 @@
 /area/rogue/under/town/basement/keep)
 "nFf" = (
 /obj/structure/fluff/railing/border{
-	dir = 8
+	dir = 10
 	},
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/obj/item/candle/candlestick/gold/lit{
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "nFq" = (
 /obj/machinery/light/rogue/lanternpost,
@@ -41446,6 +41473,19 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach/forest)
+"nJS" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/rope/chain,
+/obj/item/gwstrap,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile/masonic{
+	dir = 1
+	},
+/area/rogue/indoors/town/manor)
 "nJT" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -41494,10 +41534,20 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "nKF" = (
-/obj/structure/fermentation_keg/random/beer,
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows{
+	pixel_x = -2;
+	pixel_y = 1
 	},
+/obj/item/quiver/arrows{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/quiver/arrows{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "nKL" = (
 /obj/structure/table/wood{
@@ -41710,13 +41760,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "nOC" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "manor";
-	name = "Councilor's Chambers"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/clock,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "nOD" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grassyel,
@@ -41790,7 +41836,7 @@
 /obj/structure/roguemachine/atm{
 	location_tag = "Lampternball Court"
 	},
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "nPN" = (
 /obj/structure/flora/roguegrass/water/reeds,
@@ -42064,12 +42110,12 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "nTv" = (
-/obj/structure/rack/rogue,
-/obj/item/clothing/suit/roguetown/armor/gambeson/heavy,
-/obj/item/clothing/suit/roguetown/armor/gambeson/heavy,
-/obj/item/clothing/suit/roguetown/armor/gambeson/heavy,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nTw" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -42304,12 +42350,8 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "nXW" = (
-/obj/structure/bars/cemetery,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/grassyel,
+/obj/structure/fluff/statue/knight/r,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
 "nXY" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -42402,11 +42444,9 @@
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/town/roofs/keep)
 "nZB" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/garrison)
+/obj/effect/landmark/start/apothecary,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/outdoors/town/roofs)
 "nZD" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
@@ -42420,21 +42460,18 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
 "nZP" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/roguekey/armory,
-/obj/item/clothing/suit/roguetown/armor/brigandine,
-/obj/item/storage/keyring,
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/roguekey/manor,
-/obj/item/roguekey/walls,
-/obj/item/roguekey/dungeon,
-/obj/item/roguekey/sheriff,
-/obj/item/roguekey/garrison,
-/obj/item/storage/belt/rogue/leather/steel/tasset,
-/obj/item/roguekey/warden,
-/obj/item/roguekey/sergeant,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword,
+/obj/item/rogueweapon/sword{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/rogueweapon/sword{
+	pixel_x = 5;
+	pixel_y = -1
+	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/area/rogue/under/town/basement/keep)
 "nZS" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -42573,14 +42610,11 @@
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town)
 "ocm" = (
-/obj/structure/table/wood,
-/obj/item/cooking/platter/gold,
-/obj/item/kitchen/fork/silver{
-	pixel_x = 14;
-	pixel_y = 6
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "oco" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/blocks,
@@ -42598,8 +42632,12 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/skeletoncrypt)
 "ocA" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile/masonic/single,
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	dir = 1
+	},
+/obj/item/candle/yellow/lit,
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "ocH" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -42665,13 +42703,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "oee" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/gold/lit{
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/wood,
+/turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/town/basement/keep)
 "oef" = (
 /obj/structure/bed/rogue/inn,
@@ -42870,11 +42902,13 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
 "ogR" = (
-/obj/structure/fluff/clock,
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/structure/mineral_door/wood{
+	name = "Servant's Room";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "ogT" = (
 /obj/effect/decal/cobbleedge{
@@ -42920,36 +42954,15 @@
 /turf/open/floor/rogue/carpet/lord/center/no_teleport,
 /area/rogue/under/cave/licharena)
 "oic" = (
-/obj/structure/bed/rogue,
-/obj/effect/landmark/start/squire{
-	dir = 4
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
 	},
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "oih" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "longtable"
-	},
-/obj/item/reagent_containers/glass/cup/golden{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/cup/golden{
-	pixel_x = 8
-	},
-/obj/item/kitchen/spoon/gold{
-	pixel_x = -6;
-	pixel_y = -16
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "ois" = (
 /obj/effect/decal/wood/herringbone2{
@@ -43048,9 +43061,11 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/cave/orcdungeon)
 "ojQ" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "okc" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/rogue/dirt/road,
@@ -43169,12 +43184,13 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "oou" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot{
-	name = "cauldron"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/rooftop/green{
+	dir = 1
+	},
+/area/rogue/outdoors/town/roofs/keep)
 "ooz" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -43266,14 +43282,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
-"oqN" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "longtable"
-	},
-/obj/item/candle/silver/lit,
-/turf/open/floor/rogue/carpet/lord/center,
-/area/rogue/indoors/town/manor)
 "oqR" = (
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/rogue/blocks,
@@ -43327,13 +43335,8 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cavewet/bogcaves)
 "orR" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "steward";
-	name = "Steward Bedroom"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/outdoors/town/roofs)
 "orS" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -43429,10 +43432,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "osX" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
 	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "oth" = (
 /obj/structure/fluff/railing/border{
@@ -43526,15 +43530,12 @@
 /obj/structure/fluff/statue/gargoyle/candles,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
-"ovk" = (
-/obj/structure/fluff/railing/border,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/manor)
 "ovA" = (
-/obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
+/obj/structure/table/wood{
+	icon_state = "longtable"
 	},
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/manor)
 "ovM" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
@@ -43545,10 +43546,7 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ovY" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/masonic,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/manor)
 "ovZ" = (
 /obj/structure/roguerock,
@@ -43626,10 +43624,12 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave/mazedungeon)
 "oxU" = (
-/obj/structure/bookcase,
-/obj/item/book/rogue/bookofpriests,
-/obj/item/book/rogue/blackmountain,
-/turf/open/floor/rogue/carpet,
+/obj/structure/chair/hotspring_bench/right{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "oxW" = (
 /obj/structure/roguewindow/stained/silver,
@@ -43675,21 +43675,21 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "oyt" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "royal";
-	name = "Lord's Restroom"
+/obj/structure/table/wood{
+	icon_state = "map5"
 	},
-/turf/open/floor/rogue/herringbone,
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "oyw" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/beach)
 "oyx" = (
-/obj/structure/chair/bench/couch,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "oyz" = (
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -43723,12 +43723,9 @@
 /turf/open/water/swamp,
 /area/rogue/under/cave/goblindungeon)
 "oyV" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/obj/item/roguestatue/gold/loot,
+/turf/open/floor/rogue/tile/masonic,
+/area/rogue/indoors/town/vault)
 "oyW" = (
 /mob/living/carbon/human/species/dwarfskeleton/ambush,
 /turf/open/floor/rogue/hexstone,
@@ -43778,22 +43775,8 @@
 /turf/open/floor/rogue/volcanic,
 /area/rogue/outdoors/mountains/decap)
 "oAc" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = 12;
-	pixel_y = 6
-	},
-/obj/item/kitchen/spoon/silver{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/wood,
+/obj/structure/stairs/fancy/r,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "oAe" = (
 /obj/structure/fluff/railing/border{
@@ -43807,6 +43790,16 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
+"oAs" = (
+/obj/structure/chair/wood/rogue/fancy{
+	pixel_x = 0;
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "oAD" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -43874,11 +43867,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "oBL" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/roguemachine/scomm{
+	pixel_y = -32
 	},
-/obj/item/natural/feather,
-/turf/open/floor/rogue/carpet,
+/turf/open/floor/rogue/tile/bath,
 /area/rogue/under/town/basement/keep)
 "oBN" = (
 /obj/structure/floordoor/open{
@@ -43987,9 +43979,20 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "oDj" = (
-/obj/machinery/tanningrack,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/obj/item/candle/yellow/lit{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/candle/yellow/lit{
+	pixel_x = -4;
+	pixel_y = -8
+	},
+/obj/item/candle/yellow/lit{
+	pixel_x = -11;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "oDn" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -44203,10 +44206,7 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/cave/orcdungeon)
 "oHF" = (
-/obj/structure/stairs,
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
 "oHH" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -44218,14 +44218,8 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "oIo" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 33
-	},
-/obj/effect/decal/cobbleedge{
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/turf/closed/wall/mineral/rogue/decostone/end{
+	dir = 1
 	},
 /area/rogue/indoors/town/manor)
 "oIt" = (
@@ -44342,12 +44336,11 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "oJT" = (
-/obj/structure/lever/wall{
-	pixel_x = 32;
-	redstone_id = "warehouse_shutter"
+/obj/structure/roguewindow/openclose{
+	dir = 8
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/town/roofs)
 "oJW" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
@@ -44385,10 +44378,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "oKB" = (
-/obj/structure/table/wood{
-	icon_state = "map3"
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "oKI" = (
 /obj/structure/fluff/railing/border{
@@ -44429,15 +44420,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/shelter/woods)
 "oLl" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/obj/item/flint,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/turf/open/floor/rogue/cobble,
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 10
+	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "oLw" = (
 /obj/effect/decal/cobbleedge{
@@ -44633,18 +44620,22 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "oPf" = (
-/obj/item/roguecoin/silver/pile,
-/obj/structure/closet/crate/chest/neu_fancy,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/vault)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "oPj" = (
 /obj/structure/spider/stickyweb/mirespider,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
 "oPm" = (
 /obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/exposed/town/keep)
 "oPu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	locked = 1
@@ -44759,16 +44750,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "oRt" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "sheriff";
+	name = "Marshal's Quarters"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
 "oRu" = (
@@ -44788,21 +44776,11 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "oRZ" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "longtable"
+/obj/item/paper/scroll{
+	pixel_x = 63;
+	pixel_y = -123
 	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/elfred{
-	pixel_x = -12
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/carpet/lord/center,
+/turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
 "oSd" = (
 /obj/structure/closet/crate/chest/wicker,
@@ -44810,12 +44788,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet/bogcaves)
 "oSk" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/obj/item/candle/candlestick/silver/lit,
-/turf/open/floor/rogue/hexstone,
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
 "oSm" = (
 /obj/structure/table/wood,
@@ -44861,10 +44835,14 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/mountains/decap)
 "oSS" = (
-/obj/structure/fermentation_keg/random/water,
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "oSW" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -44956,6 +44934,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
+"oUL" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "oUR" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -44968,10 +44954,15 @@
 /area/rogue/outdoors/mountains/decap)
 "oVj" = (
 /obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/walldeco/wantedposter,
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town)
 "oVl" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/blocks/platform,
@@ -45025,9 +45016,8 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "oWi" = (
-/obj/structure/roguemachine/stockpile,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
+/area/rogue/indoors/town/manor)
 "oWr" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/wood,
@@ -45060,12 +45050,11 @@
 	},
 /area/rogue/under/cave/dukecourt)
 "oWO" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/stairs{
+	dir = 8
 	},
-/obj/item/kitchen/spoon/tin,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/tile/bfloorz,
+/area/rogue/under/town/basement/keep)
 "oXa" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -45088,10 +45077,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/orcdungeon)
 "oXg" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 9
 	},
-/turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "oXl" = (
 /obj/structure/closet/crate/roguecloset/inn,
@@ -45159,24 +45147,25 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "oYb" = (
-/obj/structure/table/wood,
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 9
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = -5;
+	pixel_y = 0
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = -5;
+	pixel_y = 0
 	},
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/town)
 "oYo" = (
-/obj/item/roguegem/ruby,
-/obj/item/roguegem/ruby,
-/obj/item/roguegem/violet,
-/obj/item/roguegem/yellow,
-/obj/item/roguegem/green,
-/obj/item/roguegem/blue,
-/obj/structure/closet/crate/chest/neu_fancy,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/vault)
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/food/snacks/smallrat,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "oYq" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/fluff/railing/border,
@@ -45234,9 +45223,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "oZk" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 1
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "oZs" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -45330,8 +45321,8 @@
 "paw" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
 "pax" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -45400,8 +45391,10 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "pbK" = (
-/obj/structure/chair/wood/rogue/throne,
-/turf/open/floor/rogue/wood,
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "pbL" = (
 /obj/structure/fluff/railing/border{
@@ -45431,12 +45424,9 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/dwarfin)
 "pcI" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bucket/pot/teapot/fancy,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "pcQ" = (
 /obj/structure/bars/passage{
@@ -45447,12 +45437,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "pda" = (
-/obj/structure/closet/crate/chest/neu_fancy,
-/obj/item/roguecoin/silver/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "glyph2"
-	},
-/area/rogue/indoors/town/vault)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "pdb" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -45516,13 +45503,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
 "pdO" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
-/area/rogue/outdoors/town/roofs/keep)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/manor)
 "pee" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/wood,
@@ -45536,11 +45519,14 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
 "pel" = (
-/obj/structure/table/wood{
-	icon_state = "map1"
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/halberd,
+/obj/item/rogueweapon/halberd{
+	pixel_x = -13;
+	pixel_y = -19
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "pem" = (
 /obj/structure/flora/newbranch/leafless{
 	dir = 1
@@ -45588,12 +45574,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"pfi" = (
-/obj/structure/roguemachine/mail/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "pfs" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -45701,10 +45681,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pgL" = (
-/obj/structure/bookcase,
-/obj/item/book/rogue/nitebeast,
-/obj/item/book/rogue/noc,
-/turf/open/floor/rogue/carpet,
+/obj/machinery/light/rogue/oven/south,
+/obj/effect/decal/cobbleedge,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "pgM" = (
 /obj/structure/stairs,
@@ -45739,12 +45718,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "phw" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 9
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
-	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "phx" = (
 /obj/structure/rack/rogue/shelf/biggest,
@@ -45821,16 +45799,10 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
 "piN" = (
-/obj/structure/fluff/statue/knight,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
+/obj/structure/roguewindow/harem2{
+	density = 0
 	},
-/area/rogue/indoors/town/manor)
-"piQ" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/manor)
 "piV" = (
 /obj/structure/chair/wood/rogue{
@@ -45998,14 +45970,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
 "pmh" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/roguegrass/bush/wall/tall{
-	pixel_x = -11;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/grass,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "pmo" = (
 /obj/structure/closet/crate/chest/old_crate,
@@ -46048,8 +46014,8 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "pnA" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/tile,
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "pnE" = (
 /obj/structure/composter/full,
@@ -46167,8 +46133,10 @@
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/shelter/woods)
 "pqi" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/carpet/royalblack,
+/obj/item/clothing/suit/roguetown/shirt/tunic/silktunic,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/steward,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "pql" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -46196,36 +46164,14 @@
 "pqC" = (
 /obj/structure/flora/roguegrass/bush,
 /obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
 "pqG" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "pqR" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/obj/item/paper{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/paper{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/paper{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/paper{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/obj/item/paper{
-	pixel_y = 7
-	},
-/obj/item/natural/feather,
-/turf/open/floor/carpet/royalblack,
+/turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/garrison)
 "prg" = (
 /mob/living/simple_animal/hostile/rogue/haunt,
@@ -46249,15 +46195,14 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
 "prx" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
 /obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "prC" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -46581,13 +46526,8 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
 "pxW" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_y = 9
-	},
-/turf/open/floor/rogue/cobble,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
 /area/rogue/under/town/basement/keep)
 "pxX" = (
 /obj/structure/table/wood{
@@ -46617,16 +46557,8 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cave/skeletoncrypt)
 "pyE" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/flora/roguegrass/bush,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/indoors/town/manor)
 "pyK" = (
 /obj/item/clothing/head/roguetown/helmet/kettle/minershelm,
 /turf/open/floor/rogue/naturalstone,
@@ -46637,14 +46569,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/magician)
 "pyP" = (
-/obj/item/book/rogue/festus,
-/obj/item/book/rogue/fishing,
-/obj/item/book/rogue/tales3,
-/obj/item/book/rogue/yeoldecookingmanual,
-/obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/chair/wood/rogue{
+	dir = 8
 	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "pzb" = (
 /obj/structure/closet/crate/chest/neu,
@@ -46700,10 +46628,12 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/physician)
 "pzw" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/mineral_door/wood/donjon{
+	dir = 8;
+	locked = 1;
+	lockid = "garrison"
 	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
 "pzA" = (
 /obj/structure/fluff/walldeco/painting/seraphina,
@@ -46882,18 +46812,14 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/goatmale,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
-"pBF" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
 "pBH" = (
-/obj/structure/bars/cemetery,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/machinery/light/rogue/torchholder/c{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/under/town/basement/keep)
 "pBL" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/blocks,
@@ -46924,22 +46850,19 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "pCd" = (
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/obj/structure/closet/crate/drawer,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "pCk" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/structure/stairs{
+	dir = 8
 	},
-/obj/item/rogueweapon/huntingknife/chefknife{
-	pixel_x = 5;
-	pixel_y = 1
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/item/reagent_containers/peppermill{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "pCl" = (
 /obj/structure/mineral_door/wood/donjon{
@@ -47074,10 +46997,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "pEB" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 4
-	},
-/area/rogue/indoors/town/garrison)
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
+/area/rogue/outdoors/exposed/town/keep)
 "pEO" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/outdoors/mountains)
@@ -47088,12 +47009,14 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/town)
 "pFh" = (
-/obj/structure/table/wood{
-	icon_state = "map6"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/beer/voddena,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/roguecloset/crafted,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
+/obj/item/clothing/under/roguetown/skirt,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/manor)
 "pFn" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/concrete,
@@ -47183,11 +47106,9 @@
 	},
 /area/rogue/indoors/town/dwarfin)
 "pGZ" = (
-/obj/structure/well/fountain{
-	pixel_x = -16
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/closet/crate/roguecloset/dark,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "pHe" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
@@ -47259,18 +47180,14 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "pIl" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
+/turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/manor)
 "pIv" = (
-/obj/structure/mirror{
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/garrison)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shield/tower/metal,
+/obj/item/rogueweapon/shield/buckler,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "pIB" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -47351,15 +47268,9 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
 "pJG" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/structure/closet/crate/roguecloset/dark,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/clothing/suit/roguetown/armor/gambeson/heavy,
-/obj/item/clothing/suit/roguetown/shirt/vampire,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "pJJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -47430,11 +47341,10 @@
 	},
 /area/rogue/indoors/shelter/woods)
 "pKH" = (
-/obj/structure/fluff/walldeco/bigpainting{
-	pixel_x = 0;
-	pixel_y = 32
+/obj/structure/roguewindow/openclose{
+	dir = 1
 	},
-/turf/open/floor/rogue/carpet/lord/left,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "pKL" = (
 /obj/structure/fluff/railing/border{
@@ -47450,24 +47360,26 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "pKR" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "manor"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
-	},
-/area/rogue/under/town/basement/keep)
+/obj/structure/roguemachine/noticeboard,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "pKZ" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "pLb" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = "steward"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/walldeco/alarm{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "pLc" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/hexstone,
@@ -47489,11 +47401,6 @@
 "pLs" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/exposed/bath/vault)
-"pLt" = (
-/obj/structure/chair/bench/couchablack/r,
-/obj/structure/mirror/fancy,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/manor)
 "pLu" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -47548,13 +47455,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/goblinfort)
 "pMW" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "sheriff";
-	name = "Marshal's Quarters"
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town/roofs/keep)
 "pNg" = (
 /mob/living/carbon/human/species/dwarfskeleton/ambush,
 /obj/effect/decal/cobbleedge{
@@ -47569,14 +47472,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
 "pNs" = (
-/obj/structure/fluff/railing/wood{
-	layer = 4.51
+/obj/structure/chair/wood/rogue{
+	dir = 4
 	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/town/roofs/keep)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "pNv" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/naturalstone,
@@ -47634,22 +47534,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "pOI" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/cup/golden{
-	pixel_x = -8;
-	pixel_y = 6
+/obj/structure/bed/rogue/inn/double,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/obj/item/kitchen/spoon/gold{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = 12;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "pOJ" = (
 /obj/structure/winch{
@@ -47666,12 +47556,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
-"pOU" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/manor)
 "pOX" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -47806,11 +47690,10 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "pRi" = (
-/obj/structure/closet/crate/roguecloset/dark,
-/obj/item/clothing/cloak/stabard/surcoat/councillor,
-/obj/item/clothing/cloak/stabard/surcoat/councillor,
-/obj/item/clothing/cloak/stabard/surcoat/councillor,
-/turf/open/floor/rogue/wood,
+/obj/structure/roguemachine/atm{
+	location_tag = "Keep Front Gate"
+	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "pRj" = (
 /obj/structure/mineral_door/wood{
@@ -47892,11 +47775,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
 "pSy" = (
-/obj/structure/fluff/railing/border{
+/turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 8
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/area/rogue/outdoors/town/roofs)
 "pSM" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grassred,
@@ -48072,10 +47954,13 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "pVP" = (
-/obj/structure/closet/crate/roguecloset/dark,
-/obj/item/soap/bath,
-/obj/item/soap/bath,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/structure/chair/bench/couch{
+	icon_state = "redcouch2"
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "pVW" = (
 /obj/effect/decal/remains/saiga,
@@ -48090,29 +47975,13 @@
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
 "pWB" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/structure/closet/crate/chest/neu{
-	locked = 1;
-	lockid = "garrison"
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt{
+	pixel_x = 0;
+	pixel_y = 8
 	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/natural/bundle/cloth{
-	amount = 8
-	},
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/structure/table/church/m,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "pWJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -48130,11 +47999,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pWX" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/turf/open/floor/rogue/cobble,
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/under/town/basement/keep)
 "pWZ" = (
 /obj/structure/fluff/railing/border{
@@ -48250,12 +48118,10 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
 "pYz" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/table/wood{
+	icon_state = "map5"
 	},
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
 "pYH" = (
 /obj/structure/fluff/railing/border{
@@ -48284,7 +48150,10 @@
 /obj/effect/decal/cobbleedge{
 	pixel_y = 1
 	},
-/turf/open/floor/rogue/cobble/mossy,
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
 "pZm" = (
 /obj/structure/fluff/railing/border,
@@ -48321,9 +48190,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
 "pZw" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope/chain,
-/turf/open/floor/rogue/carpet,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "pZS" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -48342,7 +48212,7 @@
 /area/rogue/outdoors/beach)
 "pZZ" = (
 /obj/effect/landmark/events/haunts,
-/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "qac" = (
@@ -48352,11 +48222,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "qad" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/effect/particle_effect/smoke/transparent,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "qaf" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/orcdungeon)
@@ -48365,19 +48233,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement)
-"qat" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/obj/item/reagent_containers/food/snacks/grown/berries/rogue,
-/obj/item/reagent_containers/food/snacks/grown/berries/rogue,
-/obj/item/reagent_containers/food/snacks/grown/berries/rogue,
-/obj/effect/decal/cobbleedge,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "qax" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/wood,
@@ -48426,11 +48281,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
 "qbr" = (
-/obj/structure/stairs{
-	dir = 4
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "qbz" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/item/roguecoin/gold,
@@ -48561,8 +48417,40 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
 "qdH" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/tile/masonic/inverted,
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/cloth{
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/obj/item/natural/cloth{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/natural/cloth{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/natural/cloth{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/natural/cloth{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/natural/cloth{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/soap/bath{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/soap/bath{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/turf/open/floor/rogue/tile/bath,
 /area/rogue/under/town/basement/keep)
 "qdI" = (
 /obj/structure/fluff/railing/border,
@@ -48579,14 +48467,21 @@
 	},
 /area/rogue/indoors/town)
 "qdL" = (
-/obj/structure/table/wood,
-/obj/item/cooking/platter/copper,
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_x = -8;
-	pixel_y = 16
-	},
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/roguekey/armory,
+/obj/item/clothing/suit/roguetown/armor/brigandine,
+/obj/item/storage/keyring,
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/roguekey/manor,
+/obj/item/roguekey/walls,
+/obj/item/roguekey/dungeon,
+/obj/item/roguekey/sheriff,
+/obj/item/roguekey/garrison,
+/obj/item/storage/belt/rogue/leather/steel/tasset,
+/obj/item/roguekey/warden,
+/obj/item/roguekey/sergeant,
 /turf/open/floor/rogue/tile/masonic{
-	dir = 1
+	dir = 4
 	},
 /area/rogue/indoors/town/manor)
 "qdR" = (
@@ -48610,10 +48505,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "qer" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/garrison)
 "qet" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -48672,6 +48565,18 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"qfy" = (
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/item/candle/yellow/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/item/candle/yellow/lit{
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "qfA" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
@@ -48748,12 +48653,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/orcdungeon)
 "qgS" = (
-/obj/structure/rack/rogue,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "qha" = (
 /obj/effect/decal/mossy{
 	dir = 1
@@ -48837,20 +48739,19 @@
 	},
 /area/rogue/outdoors/rtfield)
 "qjb" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
-	},
-/obj/item/candle/candlestick/gold/single/lit{
-	pixel_y = 9
-	},
 /obj/structure/table/wood{
-	dir = 4;
-	icon_state = "longtable"
+	icon_state = "longtable_mid";
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/item/reagent_containers/glass/bottle/rogue/whitewine{
+	pixel_x = -10;
+	pixel_y = 4
 	},
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "qjc" = (
 /obj/structure/table/wood{
@@ -48951,13 +48852,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
 "qkv" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/structure/fluff/walldeco/stone{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "qkF" = (
 /obj/effect/decal/cobbleedge{
@@ -49378,11 +49277,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
 "qrX" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/vault)
 "qrY" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/dirt,
@@ -49413,16 +49309,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblindungeon)
-"qsQ" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
-	},
-/obj/item/candle/gold/lit{
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
 "qsV" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/roguegear{
@@ -49586,11 +49472,19 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves)
 "qvp" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = -32
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/garrison)
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/effect/decal/cobbleedge{
+	icon_state = "borderfall";
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "qvr" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road,
@@ -49961,12 +49855,8 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/dwarfin)
 "qBO" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/basement)
 "qBP" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/cleanshallow,
@@ -50173,12 +50063,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
-"qFk" = (
-/obj/structure/rogue/trophy/deer,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "qFm" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -50190,25 +50074,13 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
 "qFy" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/structure/rack/rogue/shelf,
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = -6;
-	pixel_y = 42
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
 	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = -6;
-	pixel_y = 20
+/obj/structure/stairs{
+	dir = 1
 	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = 8;
-	pixel_y = 42
-	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = 8;
-	pixel_y = 20
-	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
 "qFI" = (
 /obj/structure/fluff/railing/border{
@@ -50283,11 +50155,14 @@
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/under/cave)
 "qHm" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 4
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "qHt" = (
 /obj/item/storage/bag/tray{
 	pixel_y = 32
@@ -50384,12 +50259,10 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "qIt" = (
-/obj/structure/chair/bench/couch{
-	icon_state = "redcouch2"
+/obj/structure/stairs{
+	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
 "qIx" = (
 /obj/structure/stairs/stone{
@@ -50478,9 +50351,19 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "qJz" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/structure/roguemachine/scomm,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = 32
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "drawbridge lever";
+	pixel_x = 6;
+	pixel_y = 9;
+	redstone_id = "wallbridge"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "qJA" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
@@ -50648,14 +50531,12 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "qML" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
+/obj/structure/bed/rogue{
+	dir = 8
 	},
-/area/rogue/indoors/town/manor)
-"qMS" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "qNd" = (
 /obj/effect/decal/cobbleedge{
@@ -50683,14 +50564,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "qNn" = (
-/obj/structure/table/wood{
-	icon_state = "map5"
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "qNv" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/herringbone,
@@ -50701,17 +50581,11 @@
 /area/rogue/indoors/town)
 "qNC" = (
 /obj/structure/table/wood{
+	dir = 1;
 	icon_state = "longtable"
 	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_y = 9
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/item/clothing/ring/gold,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "qND" = (
 /obj/structure/roguemachine/mail,
@@ -50831,6 +50705,12 @@
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/licharena)
+"qQj" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "qQm" = (
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
@@ -50978,9 +50858,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/shop)
 "qSC" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/manor)
 "qSD" = (
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/herringbone,
@@ -51082,15 +50964,8 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/shelter/mountains/decap)
 "qUQ" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/silver/lit{
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/manor)
 "qUS" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
@@ -51229,10 +51104,19 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "qXJ" = (
-/obj/structure/table/wood,
-/obj/item/book/rogue/tales1,
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/under/town/basement/keep)
+/obj/item/candle/yellow/lit{
+	pixel_x = -70;
+	pixel_y = 47
+	},
+/obj/item/candle/yellow/lit{
+	pixel_x = -14;
+	pixel_y = 41
+	},
+/obj/structure/table/church{
+	icon_state = "churchtable_end"
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "qXR" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -51387,11 +51271,9 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "qZN" = (
-/obj/structure/rack/rogue,
-/obj/item/clothing/under/roguetown/heavy_leather_pants,
-/obj/item/clothing/under/roguetown/heavy_leather_pants,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/effect/landmark/start/clerk,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "raa" = (
 /obj/item/natural/worms/leech{
 	pixel_x = 5
@@ -51495,12 +51377,8 @@
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/shelter/woods)
 "rbU" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
+/obj/structure/fluff/statue/small,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "rbX" = (
 /obj/structure/roguetent,
@@ -51666,15 +51544,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/fishmandungeon)
 "rfb" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/item/candle/candlestick/gold/single/lit{
-	pixel_y = 9
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/fluff/walldeco/customflag,
+/turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/manor)
 "rfc" = (
 /obj/item/natural/stone,
@@ -51732,6 +51603,16 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/underdark)
+"rfL" = (
+/obj/structure/chair/hotspring_bench{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/carpet/lord/center,
+/area/rogue/indoors/town/manor)
 "rfQ" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/cobble,
@@ -51838,8 +51719,8 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/basement)
 "riq" = (
-/obj/structure/fluff/statue/knight/r,
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "riv" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -51866,12 +51747,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "rji" = (
-/obj/structure/bookcase,
-/obj/item/book/rogue/necra,
-/obj/item/book/rogue/law,
-/obj/item/book/rogue/knowledge1,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
 "rjk" = (
 /obj/structure/bars,
 /turf/open/water/sewer,
@@ -51891,24 +51771,45 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
 "rjF" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/shirt/tunic,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
-/obj/item/clothing/suit/roguetown/armor/silkcoat,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/obj/item/clothing/suit/roguetown/shirt/dress/royal/princess,
-/obj/item/clothing/suit/roguetown/shirt/dress/royal/prince,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/roguewindow/openclose{
+	dir = 1
 	},
+/obj/machinery/light/rogue/torchholder/c,
+/obj/machinery/light/rogue/torchholder/c{
+	dir = 1
+	},
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "rjK" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+/obj/structure/closet/crate/chest,
+/obj/item/roguekey/manor,
+/obj/item/roguekey/walls,
+/obj/item/roguekey/crafterguild,
+/obj/item/roguekey/steward,
+/obj/item/roguekey/church,
+/obj/item/roguekey/dungeon,
+/obj/item/roguekey/graveyard,
+/obj/item/roguekey/garrison{
+	name = "garrison key"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/obj/item/roguekey/mercenary,
+/obj/item/roguekey/nightmaiden,
+/obj/item/roguekey/tavern,
+/obj/item/roguekey/physician,
+/obj/item/roguekey/knight,
+/obj/item/roguekey/armory,
+/obj/item/roguekey/tower,
+/obj/item/roguekey/sergeant,
+/obj/item/roguekey/sheriff,
+/obj/item/roguekey/royal,
+/obj/item/roguekey/lord,
+/obj/item/roguekey/merchant,
+/obj/item/roguekey/warden,
+/obj/item/roguekey/hand,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 1
+	},
+/area/rogue/indoors/town/vault)
 "rjO" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sickle/copper,
@@ -51945,10 +51846,9 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
 "rkS" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/exposed/town/keep)
 "rkT" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -51969,9 +51869,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "rlj" = (
-/obj/structure/roguemachine/noticeboard,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "rlk" = (
 /obj/machinery/light/rogue/wallfire/candle/off/r,
 /obj/effect/decal/cobbleedge{
@@ -52139,14 +52041,17 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
 "rnI" = (
-/turf/open/floor/carpet/red,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "rnN" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "hand";
+	name = "Hand's Chambers"
 	},
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "rnT" = (
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/twig,
@@ -52190,10 +52095,12 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/bog)
 "rov" = (
-/obj/structure/fluff/clock,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "heir";
+	name = "Heir's Apartment"
 	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "roJ" = (
 /obj/structure/table/wood{
@@ -52238,6 +52145,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
+"rpi" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/manor)
 "rpl" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/wood,
@@ -52344,14 +52257,13 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
 "rrN" = (
-/obj/structure/mineral_door/wood/fancywood{
+/obj/structure/mineral_door/wood{
+	name = "Storageroom";
+	icon_state = "wcv";
 	locked = 1;
-	lockid = "hand";
-	name = "Hand's Chambers"
+	lockid = "manor"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "rrZ" = (
 /obj/item/cooking/platter/silver{
@@ -52412,11 +52324,14 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/basement)
 "rtc" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Steward Desk"
+/obj/item/roguecoin/gold/pile,
+/obj/structure/fluff/walldeco/painting/queen{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
+	},
+/area/rogue/indoors/town/vault)
 "rth" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/carpet/red,
@@ -52473,15 +52388,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
 "rtL" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
 	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "rtM" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
@@ -52516,7 +52427,14 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/woods)
 "ruD" = (
-/turf/open/floor/rogue/tile/masonic,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "ruG" = (
 /obj/structure/closet/crate/drawer,
@@ -52625,15 +52543,11 @@
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/under/cave/dukecourt)
 "rwM" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/floordoor{
+	redstone_id = "thronegrille"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	pixel_x = 0;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/tile/bath,
+/obj/structure/chair/wood/rogue,
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "rwQ" = (
 /obj/structure/rack/rogue{
@@ -52884,10 +52798,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/basement)
 "rBB" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
+/obj/structure/roguemachine/mail/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/manor)
 "rBC" = (
 /obj/structure/fluff/railing/wood{
@@ -52933,6 +52847,13 @@
 "rBR" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter)
+"rBV" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	name = "Medical Ward";
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "rBY" = (
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
@@ -52943,28 +52864,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "rCi" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/pelt,
+/obj/structure/lever{
+	redstone_id = "thronegrille"
 	},
-/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
-/obj/item/reagent_containers/glass/cup/ceramic/fancy{
-	pixel_x = -3;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/glass/cup/ceramic/fancy{
-	pixel_x = -15;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/glass/cup/ceramic/fancy{
-	pixel_x = 6;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/glass/cup/ceramic/fancy{
-	pixel_x = -16;
-	pixel_y = 13
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "rCm" = (
 /turf/open/transparent/openspace,
@@ -52993,11 +52898,10 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/beach/forest)
 "rDc" = (
-/obj/structure/fluff/railing/border{
+/obj/structure/roguewindow/openclose{
 	dir = 4
 	},
-/obj/structure/fluff/railing/border,
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "rDh" = (
 /obj/structure/rack/rogue,
@@ -53034,18 +52938,21 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/mountains/decap)
 "rDx" = (
-/obj/item/candle/candlestick/gold/single/lit{
-	pixel_x = 10;
-	pixel_y = 10
+/obj/structure/closet/crate/roguecloset{
+	name = "Tabards and Jupons"
 	},
-/obj/item/tablecloth/silk{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/herringbone,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/cape/guard,
+/obj/item/clothing/cloak/cape/guard,
+/obj/item/clothing/cloak/stabard/surcoat/guard,
+/obj/item/clothing/cloak/stabard/surcoat/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "rDy" = (
 /turf/open/floor/rogue/wood/nosmooth,
@@ -53074,9 +52981,15 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "rDO" = (
-/obj/structure/table/wood,
+/obj/structure/table/wood{
+	icon_state = "map4"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/beer/voddena{
+	pixel_x = 10;
+	pixel_y = 10
+	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/area/rogue/under/town/basement/keep)
 "rEo" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -53167,13 +53080,18 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "rGe" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
+/obj/item/candle/silver/lit{
+	pixel_x = 3;
+	pixel_y = 7
 	},
-/area/rogue/outdoors/town/roofs/keep)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "rGg" = (
 /obj/structure/fluff/statue/gargoyle/moss{
 	pixel_y = 20
@@ -53196,10 +53114,12 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/beach)
 "rGx" = (
-/obj/structure/closet/crate/roguecloset/dark,
-/obj/item/clothing/suit/roguetown/shirt/tunic/white,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town)
+/obj/structure/chair/wood/rogue{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "rGA" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt/road,
@@ -53260,10 +53180,9 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "rHK" = (
-/obj/structure/bookcase,
-/obj/item/book/rogue/cardgame,
-/obj/item/book/rogue/festus,
-/obj/item/book/rogue/fishing,
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "rHO" = (
@@ -53365,13 +53284,9 @@
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/shelter)
 "rJA" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/turf/closed/wall/mineral/rogue/decostone{
+	name = "chimney"
 	},
-/obj/item/candle/candlestick/gold/lit{
-	pixel_y = 12
-	},
-/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "rJQ" = (
 /obj/item/grown/log/tree/stick,
@@ -53387,15 +53302,11 @@
 	},
 /area/rogue/indoors/town/tavern)
 "rKa" = (
-/obj/structure/table/wood{
-	icon_state = "longtable_mid"
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/structure/chair/bench/couch{
+	icon_state = "redcouch2"
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "rKo" = (
 /obj/structure/mineral_door/wood/window{
@@ -53459,9 +53370,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
 "rLn" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "rLp" = (
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/dirt,
@@ -53491,14 +53404,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/roofs)
 "rLB" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/obj/item/rogueweapon/huntingknife/idagger/silver/elvish{
-	name = "royal elvish dagger";
-	sellprice = 150
+/turf/closed/wall/mineral/rogue/stone{
+	max_integrity = 5000
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/exposed/town/keep)
 "rLE" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -53528,9 +53437,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
 "rLU" = (
-/obj/machinery/light/rogue/lanternpost,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "rLW" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -53701,8 +53612,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "rPN" = (
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/structure/mineral_door/wood/violet{
+	locked = 1;
+	lockid = "steward";
+	name = "Clerk Bedroom"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/manor)
 "rPT" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -53717,6 +53633,14 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"rQk" = (
+/obj/structure/chair/hotspring_bench/left{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet/lord/right,
+/area/rogue/indoors/town/manor)
 "rQn" = (
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/church,
@@ -53739,13 +53663,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter)
 "rQv" = (
-/obj/structure/fermentation_keg/water,
-/obj/effect/decal/cobbleedge{
-	dir = 1
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/pelt,
+/obj/structure/lever{
+	redstone_id = "thronegrille"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "rQD" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -53823,30 +53746,16 @@
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "rSH" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/cup/silver{
-	name = "pewter goblet";
-	pixel_x = -11
+/obj/machinery/light/rogue/wallfire/candle/blue{
+	pixel_y = -32
 	},
-/obj/item/kitchen/fork/gold{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = 12;
-	pixel_y = 6
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "rSJ" = (
-/obj/structure/bed/rogue,
-/obj/effect/landmark/start/squire{
-	dir = 4
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/under/town/basement/keep)
+/area/rogue/indoors/town/manor)
 "rSK" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/clothing/cloak/matron,
@@ -53905,12 +53814,10 @@
 	},
 /area/rogue/under/cave/dukecourt)
 "rTA" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32
+/obj/structure/fluff/walldeco/painting/queen{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "rTB" = (
 /obj/structure/spider/stickyweb,
@@ -53923,31 +53830,32 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
 "rTD" = (
-/obj/effect/landmark/start/suitor,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/closet/crate/chest/neu{
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/natural/bundle/cloth{
+	amount = 8
+	},
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/obj/item/needle/thorn,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "rTE" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
-	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = 8;
-	pixel_y = 20
-	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = -6;
-	pixel_y = 20
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "rTG" = (
 /obj/item/roguestatue/steel{
@@ -53966,17 +53874,23 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
 "rTT" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/pipe,
+/area/rogue/indoors/town/manor)
 "rTU" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/carpet,
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 8
+	},
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "rUb" = (
-/obj/structure/roguewindow/openclose/reinforced,
+/obj/structure/roguemachine/mail,
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
 /turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/manor)
 "rUd" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -54157,7 +54071,9 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "rXn" = (
-/obj/structure/chair/wood/rogue,
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "rXp" = (
@@ -54368,18 +54284,15 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "sbB" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
 	},
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 9
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "sbE" = (
 /obj/structure/fluff/railing/border{
@@ -54427,11 +54340,9 @@
 	},
 /area/rogue/indoors/town)
 "scw" = (
-/obj/item/roguecoin/gold/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/vault)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement/keep)
 "scE" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -54455,11 +54366,12 @@
 /area/rogue/indoors/cave)
 "scT" = (
 /obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-n"
+	dir = 5;
+	pixel_x = -10
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "scU" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grassyel,
@@ -54471,28 +54383,18 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/beach/forest)
 "scY" = (
-/obj/item/millstone{
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
-"sdc" = (
-/obj/effect/decal/cobbleedge{
+/obj/structure/fluff/railing/border{
 	dir = 6
 	},
-/obj/structure/closet/crate/drawer/random{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/obj/item/book/rogue/tales3,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
+/area/rogue/indoors/town/manor)
+"sdc" = (
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread"
+	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "sdh" = (
 /obj/structure/fluff/railing/border{
@@ -54592,9 +54494,19 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "sfH" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/undies/bikini,
+/obj/item/undies/bikini,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "sfM" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -54678,11 +54590,12 @@
 	},
 /area/rogue/indoors/town/dwarfin)
 "shc" = (
-/obj/structure/fluff/walldeco/steward{
-	dir = 1
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "shf" = (
 /obj/structure/stairs{
 	dir = 1
@@ -54690,11 +54603,13 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "shj" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Knight's Tower"
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/garrison)
 "shk" = (
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/dirt,
@@ -54770,10 +54685,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "siF" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/halberd/glaive,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "siI" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = -32
@@ -54924,11 +54841,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
 "skw" = (
-/obj/item/roguestatue/gold/loot,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/structure/stairs/stone{
+	dir = 8
 	},
-/area/rogue/indoors/town/vault)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "skz" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -55053,10 +54970,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/tavern)
 "slQ" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
 "slT" = (
 /obj/structure/table/vtable/v2,
@@ -55106,13 +55020,17 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/sewer)
 "smR" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/item/clothing/neck/roguetown/chaincoif,
-/obj/item/clothing/neck/roguetown/chaincoif,
-/obj/item/clothing/neck/roguetown/chaincoif,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "smS" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/dirt,
@@ -55127,29 +55045,20 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "smZ" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/garrison)
 "sna" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "snb" = (
-/obj/structure/fluff/railing/border{
+/obj/structure/stairs{
 	dir = 8
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "snc" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -55236,12 +55145,6 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/orcdungeon)
-"snS" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "snZ" = (
 /obj/structure/chair/bench{
 	dir = 1
@@ -55324,9 +55227,8 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/magician)
 "spe" = (
-/obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/stone/moss,
+/area/rogue/outdoors/rtfield)
 "spf" = (
 /obj/structure/spider/cocoon,
 /turf/open/floor/rogue/naturalstone,
@@ -55477,16 +55379,9 @@
 	},
 /area/rogue/indoors/cave)
 "sqP" = (
-/obj/structure/table/wood{
-	icon_state = "map6"
-	},
-/obj/item/reagent_containers/glass/cup/silver{
-	desc = "A pewter goblet, cheaper than silver, but with a similar shine!";
-	name = "pewter goblet";
-	pixel_x = -11
-	},
-/obj/item/candle/silver/lit,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/fluff/railing/border,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "sqQ" = (
 /obj/structure/chair/wood/rogue/fancy,
@@ -55559,10 +55454,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
 "ssc" = (
-/obj/structure/fluff/walldeco/bigpainting{
-	pixel_x = 2;
-	pixel_y = 32
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 9
 	},
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "sse" = (
@@ -55648,13 +55544,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "stc" = (
-/obj/structure/roguemachine/withdraw{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/structure/mineral_door/wood{
+	name = "Council Office";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "sto" = (
 /turf/open/floor/rogue/grass,
@@ -55670,10 +55566,12 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "stR" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = -32
+/obj/structure/mineral_door/wood/fancywood{
+	name = "Lord's Office";
+	lockid = "lord";
+	locked = 1
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
 "sua" = (
 /obj/structure/mineral_door/bars,
@@ -55850,10 +55748,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/beach)
 "swS" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/manor)
 "sxh" = (
 /obj/structure/fluff/railing/border{
@@ -55905,13 +55800,16 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "syb" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 8;
-	locked = 1;
-	lockid = "steward"
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/torchholder/c{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "syc" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -55952,13 +55850,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "syz" = (
-/obj/structure/closet/crate/drawer,
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_y = 32
-	},
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/carpet/lord/center,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "syA" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -55997,9 +55890,11 @@
 /turf/closed,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "szy" = (
-/obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/obj/structure/stairs/stone{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "szF" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
@@ -56027,15 +55922,11 @@
 /area/rogue/under/town/basement/keep)
 "sAj" = (
 /obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
+	icon_state = "map4"
 	},
-/obj/item/roguestatue/gold{
-	pixel_x = 3;
-	pixel_y = -8
-	},
-/obj/item/reagent_containers/glass/cup/golden{
-	pixel_x = -8
+/obj/item/tablecloth/silk{
+	pixel_x = -6;
+	pixel_y = 6
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
@@ -56358,11 +56249,6 @@
 /obj/item/bedsheet/rogue/wool,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark)
-"sIJ" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/roguegrass/bush,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
 "sIK" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
@@ -56466,14 +56352,11 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "sKU" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 1;
-	locked = 1;
-	lockid = "vault";
-	name = "Vault Door"
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "sKW" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -56500,11 +56383,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "sLa" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/transparent/openspace,
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "sLe" = (
 /obj/structure/chair/stool/rogue,
@@ -56679,15 +56561,16 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "sOa" = (
-/obj/item/book/rogue/law,
 /obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable";
-	pixel_x = -5
+	icon_state = "longtable_mid";
+	dir = 1
 	},
-/obj/machinery/light/rogue/wallfire/candle/weak/l,
-/turf/open/floor/rogue/tile/bfloorz,
-/area/rogue/under/town/basement/keep)
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "sOc" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -56709,17 +56592,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "sOx" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/effect/temp_visual/small_smoke,
+/turf/closed/wall/mineral/rogue/decostone{
+	name = "chimney"
 	},
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 9
-	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/manor)
 "sOB" = (
 /obj/effect/decal/cobbleedge{
@@ -56857,18 +56733,15 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/dukecourt)
 "sQw" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
+/obj/structure/mineral_door/wood{
+	name = "Servant's Room";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
 	},
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = 10;
-	pixel_y = 10
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "sQC" = (
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -56922,11 +56795,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
 "sRn" = (
-/obj/effect/decal/cobbleedge{
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "sRv" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/hexstone,
@@ -56946,15 +56817,18 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "sRD" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Stewardry"
+/obj/structure/stairs/stone{
+	dir = 4
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/turf/closed,
+/area/rogue/indoors/town/manor)
 "sRJ" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/firebowl/standing/blue{
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "sRL" = (
 /mob/living/carbon/human/species/goblin/npc/ambush/sea,
 /turf/open/floor/rogue/dirt/road,
@@ -57086,12 +56960,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach/forest)
 "sUn" = (
-/obj/structure/table/wood,
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_x = 10;
-	pixel_y = 10
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
-/turf/open/floor/rogue/carpet/lord/right,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "sUp" = (
 /obj/item/bedsheet/rogue/fabric_double,
@@ -57209,13 +57082,17 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
+"sWI" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "sWL" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/mountains/decap)
 "sWV" = (
-/obj/structure/chair/bench/church/mid,
-/turf/open/floor/rogue/cobble,
+/obj/effect/landmark/start/butler,
+/turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/manor)
 "sXa" = (
 /obj/effect/decal/mossy,
@@ -57239,14 +57116,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "sXr" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/water/bath,
-/area/rogue/indoors/town)
+/obj/structure/roguemachine/steward,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "sXv" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobblerock,
@@ -57282,8 +57154,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/woods)
 "sXL" = (
-/turf/open/water/bath,
-/area/rogue/indoors/town)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "sXR" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/carpet/red,
@@ -57366,43 +57242,10 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
 "sZm" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/structure/rack/rogue/shelf,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine{
-	pixel_x = -6;
-	pixel_y = 45
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/redwine{
-	pixel_x = 8;
-	pixel_y = 45
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/redwine{
-	pixel_y = 45
-	},
-/obj/item/storage/bag/tray{
-	pixel_y = 12
-	},
-/obj/item/storage/bag/tray{
-	pixel_y = 12
-	},
-/obj/item/natural/bundle/stick{
-	pixel_y = 14
-	},
-/obj/item/natural/bundle/stick{
-	pixel_y = 14
-	},
-/obj/item/natural/bundle/stick{
-	pixel_y = 14
-	},
-/obj/item/natural/bundle/stick{
-	pixel_y = 14
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/machinery/tanningrack,
+/obj/item/storage/roguebag,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "sZq" = (
 /obj/structure/lever/wall{
@@ -57417,11 +57260,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "sZH" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
 	},
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/manor)
 "sZK" = (
 /obj/item/kitchen/spoon,
 /obj/item/kitchen/rollingpin,
@@ -57482,11 +57325,11 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/tavern)
 "taV" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 1
+/obj/effect/decal/cobbleedge{
+	pixel_y = 1
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "tbg" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/cave/goblindungeon)
@@ -57538,8 +57381,11 @@
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/mountains/decap)
 "tbZ" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/carpet/lord/left,
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 5
+	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "tca" = (
 /obj/structure/ladder,
@@ -57695,11 +57541,11 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
 "tex" = (
-/obj/structure/bookcase,
-/obj/item/book/rogue/abyssor,
-/obj/item/book/rogue/tales3,
-/obj/structure/bookcase,
-/turf/open/floor/rogue/carpet,
+/obj/structure/fluff/clock,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "teA" = (
 /obj/structure/flora/newbranch/leafless{
@@ -57803,31 +57649,13 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "tga" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Knight's Tower"
 	},
-/obj/item/tablecloth/silk{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/item/tablecloth/silk{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/tablecloth/silk{
-	pixel_x = -6;
-	pixel_y = -5
-	},
-/obj/item/tablecloth/silk{
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/exposed/town/keep)
 "tgn" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -57866,9 +57694,13 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
 "tgY" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
 "the" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -57956,13 +57788,12 @@
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
 "tjj" = (
-/obj/machinery/light/rogue/oven/south,
-/obj/item/reagent_containers/glass/bucket/pot{
-	pixel_x = 0;
-	pixel_y = -1
-	},
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/blocks,
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/item/soap,
+/obj/machinery/tanningrack,
+/obj/item/storage/roguebag,
+/obj/item/soap,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "tjq" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
@@ -57996,11 +57827,6 @@
 	},
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/outdoors/exposed/bath/vault)
-"tjY" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
-/area/rogue/indoors/town/manor)
 "tkf" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -58027,22 +57853,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "tkB" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 1
-	},
-/obj/structure/feedinghole{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "tkE" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
-"tkH" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/manor)
 "tkR" = (
 /obj/structure/fluff/littlebanners{
 	pixel_y = -6
@@ -58055,17 +57873,6 @@
 	icon_state = "iron_line"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"tkZ" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wcv";
-	locked = 1;
-	lockid = "manor";
-	name = "Seneschal's Quarters"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "tle" = (
 /obj/structure/vine{
 	opacity = 1
@@ -58079,14 +57886,9 @@
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/under/cave/dukecourt)
 "tlk" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/turf/open/floor/rogue/rooftop{
+	dir = 8
 	},
-/obj/item/candle/candlestick/gold/lit{
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "tlo" = (
 /obj/structure/fluff/railing/border{
@@ -58106,12 +57908,16 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "tlQ" = (
-/obj/structure/closet/crate/drawer,
-/obj/structure/fluff/walldeco/rpainting/crown{
-	pixel_y = 32
+/obj/structure/mannequin,
+/obj/item/clothing/suit/roguetown/armor/plate/half{
+	pixel_x = 0;
+	pixel_y = -4
 	},
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/carpet/lord/center,
+/obj/item/clothing/head/roguetown/helmet/sallet{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "tlS" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -58215,21 +58021,6 @@
 /obj/item/roguestatue/glass,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
-"tmV" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/whitewine{
-	pixel_x = -12;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/cup/silver{
-	desc = "A pewter goblet, cheaper than silver, but with a similar shine!";
-	name = "pewter goblet";
-	pixel_x = -11
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/manor)
 "tmW" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /turf/open/floor/rogue/hexstone,
@@ -58286,11 +58077,11 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/bog)
 "tod" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 4
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/outdoors/town/roofs/keep)
 "toh" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/flora/roguegrass/bush/wall,
@@ -58332,17 +58123,11 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "toG" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/garrison)
 "toI" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "toJ" = (
 /turf/open/floor/rogue/naturalstone,
@@ -58366,13 +58151,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "tpg" = (
-/obj/structure/closet/crate/drawer,
-/obj/machinery/light/rogue/wallfire/candle/blue{
-	pixel_y = -32
-	},
-/obj/item/soap,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town)
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "tpj" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/churchrough,
@@ -58431,19 +58212,9 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/woods)
 "tqO" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/cape/guard,
-/obj/item/clothing/cloak/cape/guard,
-/obj/item/clothing/cloak/stabard/surcoat/guard,
-/obj/item/clothing/cloak/stabard/surcoat/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/tabard/knight/guard,
-/obj/item/clothing/cloak/tabard/knight/guard,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/obj/structure/chair/bench/church/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/basement)
 "tqQ" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/blocks,
@@ -58464,10 +58235,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "trl" = (
-/obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "trq" = (
 /obj/structure/bars/passage{
@@ -58632,11 +58401,12 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave)
 "ttA" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
 	},
-/turf/open/transparent/openspace,
+/obj/item/candle/silver/lit,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "ttW" = (
 /obj/item/clothing/neck/roguetown/psicross/silver,
@@ -58826,21 +58596,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "txn" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/item/candle/candlestick/gold/single/lit{
-	pixel_x = -10;
-	pixel_y = 10
-	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = 12;
-	pixel_y = 6
-	},
-/obj/item/kitchen/spoon/gold{
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/wood,
+/obj/machinery/light/rogue/torchholder,
+/turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
 "txq" = (
 /obj/machinery/light/rogue/torchholder/c{
@@ -58946,12 +58703,8 @@
 	},
 /area/rogue/indoors/shelter)
 "tyL" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "manor"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town/vault)
 "tyR" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/water/swamp,
@@ -58990,15 +58743,12 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/beach)
 "tzI" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "tzL" = (
 /obj/structure/stairs{
@@ -59110,7 +58860,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin)
 "tCk" = (
-/obj/structure/fluff/walldeco/bigpainting/lake,
+/obj/structure/chair/bench/ultimacouch/r,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -59176,9 +58929,12 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "tCI" = (
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 8
 	},
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "tCU" = (
 /obj/structure/fluff/clock,
@@ -59196,11 +58952,9 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/woods)
 "tDn" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/effect/landmark/start/clerk,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "tDu" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 4
@@ -59295,6 +59049,10 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
+"tEW" = (
+/obj/structure/foxpelt,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "tFd" = (
 /obj/structure/rack/rogue/shelf,
 /obj/item/natural/bundle/stick{
@@ -59336,10 +59094,9 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
 "tGv" = (
-/obj/effect/landmark/start/hand{
+/turf/open/floor/rogue/tile/masonic{
 	dir = 1
 	},
-/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "tGy" = (
 /obj/structure/mineral_door/wood{
@@ -59362,11 +59119,15 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "tGR" = (
+/obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/wood{
 	layer = 4.51
 	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town)
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "tGU" = (
 /obj/structure/closet/crate/chest/gold{
 	locked = 1;
@@ -59379,15 +59140,6 @@
 /obj/item/ingot/blacksteel,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/licharena)
-"tGW" = (
-/obj/structure/fluff/walldeco/painting{
-	pixel_y = 32
-	},
-/obj/structure/chair/bench/couchablack,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "tGY" = (
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
@@ -59480,10 +59232,15 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
 "tJd" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/flora/roguegrass/bush,
+/obj/structure/fluff/railing/fence{
+	dir = 1
+	},
+/obj/structure/fluff/railing/fence{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "tJh" = (
 /obj/structure/flora/roguegrass/bush,
 /obj/structure/flora/roguegrass/bush/wall/tall,
@@ -59564,8 +59321,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "tKl" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/water/bath,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "tKn" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -59677,13 +59436,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/underdark)
 "tMd" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wcr";
-	locked = 1;
-	lockid = "sheriff"
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/garrison)
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "tMg" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/woodstaff,
@@ -59711,8 +59467,15 @@
 	},
 /area/rogue/indoors/town/garrison)
 "tMv" = (
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/wood{
+	icon_state = "map1"
+	},
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "tMN" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -60153,13 +59916,8 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "tUx" = (
-/obj/structure/table/wood{
-	icon_state = "map2"
-	},
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/turf/closed,
+/area/rogue/outdoors/town/roofs)
 "tUy" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
@@ -60302,11 +60060,15 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "tWO" = (
-/obj/structure/fermentation_keg/hagwoodbitter,
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
-	},
-/area/rogue/under/town/basement/keep)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "tWP" = (
 /obj/structure/flora/roguegrass,
 /obj/effect/decal/mossy{
@@ -60360,10 +60122,8 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "tXs" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "tXv" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
@@ -60487,9 +60247,11 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/tavern)
 "tYN" = (
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "tYO" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -60609,13 +60371,10 @@
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/outdoors/beach)
 "ubv" = (
-/obj/effect/decal/cobbleedge,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
+/obj/structure/roguewindow,
+/obj/structure/fluff/statue/knightalt,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/dwarfin)
 "ubH" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/grasscold,
@@ -60829,6 +60588,15 @@
 	dir = 4
 	},
 /area/rogue/under/cave/dukecourt)
+"ufl" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "ufv" = (
 /obj/structure/chair/bench/couchamagenta/r,
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
@@ -60848,10 +60616,15 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/shelter/mountains/decap)
 "ufK" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/flora/roguegrass/bush,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "ufQ" = (
 /obj/structure/mineral_door/wood{
@@ -60908,12 +60681,6 @@
 	},
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/outdoors/beach/forest)
-"ugB" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manor)
 "ugJ" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 33
@@ -61144,22 +60911,11 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "ukx" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/structure/table/wood{
+	icon_state = "map4"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
-"ukB" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/town/roofs/keep)
 "ukN" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -61258,14 +61014,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter)
 "ulU" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/roguegrass/bush/wall/tall{
-	pixel_x = -20;
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_x = -32;
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "uma" = (
 /obj/structure/fluff/railing/border{
@@ -61295,34 +61048,28 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/skeletoncrypt)
 "umt" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/obj/item/paper{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/machinery/light/rogue/wallfire/candle/blue{
+	pixel_y = -32
 	},
-/obj/item/paper{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/paper{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/paper{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/obj/item/paper{
-	pixel_y = 7
-	},
-/obj/item/natural/feather,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/under/town/basement/keep)
 "umv" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/obj/structure/rack/rogue/shelf,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = -5;
+	pixel_y = 39
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 7;
+	pixel_y = 39
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "umA" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -61431,12 +61178,10 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/basement)
 "uoI" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "manor"
+/turf/open/floor/rogue/tile/masonic{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/area/rogue/indoors/town/vault)
 "uoM" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/herringbone,
@@ -61665,13 +61410,14 @@
 /area/rogue/outdoors/mountains/decap)
 "usE" = (
 /obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
+	icon_state = "longtable_mid"
 	},
-/obj/item/candle/silver/lit,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
+/obj/structure/mirror{
+	pixel_x = -28;
+	pixel_y = 0
 	},
+/obj/item/clothing/ring/signet,
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "usK" = (
 /obj/machinery/light/rogue/torchholder/c,
@@ -61735,8 +61481,14 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/exposed/bath/vault)
 "utH" = (
-/obj/effect/landmark/start/servant,
-/turf/open/floor/rogue/cobble,
+/obj/structure/chair/wood/rogue/fancy{
+	pixel_x = -1;
+	pixel_y = -7
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "utL" = (
 /obj/structure/closet/crate/chest/crate,
@@ -61758,12 +61510,12 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/shop)
 "utY" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
+/obj/structure/closet/crate/drawer,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "uud" = (
 /obj/effect/decal/cleanable/blood,
@@ -61856,6 +61608,11 @@
 	},
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
+"uvq" = (
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 8
+	},
+/area/rogue/indoors/town/manor)
 "uvs" = (
 /mob/living/carbon/human/species/human/northern/searaider/ambush,
 /turf/open/floor/rogue/naturalstone,
@@ -61877,16 +61634,21 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "uvR" = (
-/obj/structure/closet/crate/chest/neu,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
-"uwf" = (
-/obj/structure/chair/bench/couch{
-	icon_state = "redcouch2"
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
-/obj/structure/rogue/trophy/deer,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread"
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
+"uwf" = (
+/turf/open/floor/rogue/rooftop/green{
+	dir = 1
+	},
+/area/rogue/outdoors/town/roofs/keep)
 "uwg" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/wood,
@@ -61904,10 +61666,14 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "uwJ" = (
-/obj/structure/fluff/statue/gargoyle,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
+/obj/structure/table/wood{
+	icon_state = "map1"
 	},
+/obj/item/candle/skull{
+	pixel_x = 2;
+	pixel_y = 11
+	},
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "uwU" = (
 /obj/effect/decal/cobbleedge{
@@ -62002,18 +61768,22 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "uxY" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner,
-/area/rogue/indoors/town/physician)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "uxZ" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/mountains)
 "uyd" = (
-/obj/machinery/light/rogue/torchholder/l,
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
+/obj/structure/chair/bench/ultimacouch,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "uyl" = (
 /obj/structure/fluff/pillow/magenta{
@@ -62120,24 +61890,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
-"uzO" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/kitchen/fork/gold{
-	pixel_x = 12;
-	pixel_y = 6
-	},
-/obj/item/kitchen/spoon/silver{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
 "uzP" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -62194,11 +61946,10 @@
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
 "uAL" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "steward_shutter"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "uBc" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
@@ -62207,7 +61958,13 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/shelter/woods)
 "uBe" = (
-/turf/open/floor/rogue/tile/masonic/inverted,
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = "lord";
+	max_integrity = 3000
+	},
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "uBD" = (
 /obj/structure/closet/crate/roguecloset/inn,
@@ -62346,10 +62103,19 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
 "uDa" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 1
 	},
+/obj/item/reagent_containers/glass/cup/golden{
+	pixel_x = 8;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/glass/cup/golden{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "uDh" = (
 /obj/structure/chair/bench/couch,
@@ -62435,12 +62201,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement)
 "uEo" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
 	},
-/obj/item/reagent_containers/glass/bowl/silver,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "uEp" = (
 /obj/structure/handcart,
@@ -62467,17 +62233,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "uEt" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "uEw" = (
-/obj/structure/stairs/stone{
-	dir = 4
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 8
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/town/roofs)
 "uEJ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt/road,
@@ -62495,22 +62258,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
 "uFc" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = 32
 	},
-/obj/item/reagent_containers/glass/cup/golden/small{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/whitewine{
-	pixel_x = -10;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "uFd" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/hexstone,
@@ -62693,9 +62445,13 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach/forest)
 "uIr" = (
-/obj/structure/roguemachine/stockpile,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "uIt" = (
 /obj/structure/fluff/littlebanners{
 	pixel_y = 15
@@ -62892,6 +62648,15 @@
 "uLV" = (
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/outdoors/woods)
+"uMf" = (
+/obj/structure/mineral_door/wood{
+	name = "Pantry";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "uMg" = (
 /obj/structure/fluff/statue/knight,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -62913,14 +62678,23 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/mountains)
 "uMM" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
+/obj/structure/flora/roguegrass/bush,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/exposed/town/keep)
 "uMN" = (
+/obj/structure/stairs/stone/d{
+	dir = 1
+	},
+/obj/structure/stairs/stone/d,
 /turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/vault)
+/area/rogue/under/town/basement/keep)
 "uMO" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -62960,14 +62734,24 @@
 /area/rogue/indoors/town)
 "uNj" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1"
+	dir = 2;
+	icon_state = "longtable"
 	},
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "uNt" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/outdoors/beach)
+"uNz" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "uNE" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -63032,17 +62816,18 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave/orcdungeon)
 "uPI" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
 	},
-/turf/open/water/bath,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/manor)
 "uPP" = (
-/obj/structure/fermentation_keg/zagul,
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
+/obj/effect/decal/cobbleedge{
+	dir = 8
 	},
-/area/rogue/under/town/basement/keep)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "uPS" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -63073,10 +62858,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "uQf" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 4
+/obj/effect/decal/cobbleedge{
+	icon_state = "borderfall";
+	dir = 1
 	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "uQp" = (
 /obj/structure/chair/wood/rogue/chair3,
@@ -63089,12 +62875,13 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "uQs" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wcv";
-	locked = 1;
-	lockid = "manor"
+/obj/structure/winch{
+	dir = 4;
+	pixel_x = -6;
+	gid = "gatemanor2";
+	redstone_id = "gatemanor3"
 	},
-/turf/open/floor/rogue/cobblerock,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
 "uQt" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -63130,12 +62917,7 @@
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/bog)
 "uQL" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/town/roofs/keep)
 "uQM" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -63237,11 +63019,15 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "uSi" = (
-/obj/structure/fluff/railing/wood{
-	layer = 4.51
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/rope/chain,
+/obj/item/gwstrap,
+/obj/item/clothing/suit/roguetown/shirt/vampire,
+/obj/item/rogueweapon/mace/goden/steel,
+/obj/item/rogueweapon/sword/long/exe,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/manor)
 "uSj" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 1
@@ -63274,7 +63060,7 @@
 	dir = 1
 	},
 /obj/item/roguebin/water/gross,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "uSC" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -63399,6 +63185,14 @@
 	},
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
+"uVb" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "physician";
+	name = "Physician's Chambers"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "uVm" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobble,
@@ -63430,9 +63224,13 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
 "uWd" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/torchholder/c{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "uWo" = (
 /obj/structure/chair/wood/rogue/throne,
 /turf/open/floor/rogue/blocks/platform,
@@ -63504,11 +63302,11 @@
 /turf/open/water/swamp,
 /area/rogue/under/town/sewer)
 "uWU" = (
-/obj/structure/stairs{
-	dir = 8
+/obj/structure/fluff/littlebanners{
+	pixel_y = -6
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/rooftop/green,
+/area/rogue/outdoors/town/roofs/keep)
 "uXf" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/sword,
@@ -63696,9 +63494,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "uZN" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+	dir = 4
+	},
+/area/rogue/indoors/town/manor)
 "uZQ" = (
 /obj/effect/decal/cobbleedge{
 	pixel_y = 1
@@ -63721,7 +63520,7 @@
 /area/rogue/outdoors/mountains)
 "vaq" = (
 /obj/item/natural/stone,
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "vav" = (
 /obj/structure/mineral_door/wood/deadbolt,
@@ -63758,14 +63557,15 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/cave)
 "vaN" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Knight's Tower"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs/keep)
+/area/rogue/indoors/town/manor)
 "vaU" = (
 /obj/effect/decal/wood/herringbone2{
 	dir = 4
@@ -63797,12 +63597,19 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
 "vbt" = (
-/obj/structure/fermentation_keg/random/water,
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/item/candle/yellow/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = -6;
+	pixel_y = 8
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/item/candle/yellow/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = 8;
+	pixel_y = 13
+	},
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/basement)
 "vbD" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -63826,13 +63633,13 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "vbR" = (
-/obj/structure/closet/crate/drawer/random{
-	pixel_x = 1;
-	pixel_y = 3
+/obj/machinery/light/rogue/chand{
+	bulb_power = 3
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/machinery/light/rogue/chand{
+	bulb_power = 3
 	},
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "vbV" = (
 /obj/structure/table/wood{
@@ -63882,9 +63689,15 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/orcdungeon)
 "vdf" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 16;
+	pixel_y = 32
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "vdj" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/water/ocean,
@@ -63967,18 +63780,9 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "vfl" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/reagent_containers/glass/cup/silver/small{
-	pixel_x = 8
-	},
-/obj/item/kitchen/spoon/gold{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/obj/structure/fluff/canopy/booth/booth02,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "vfz" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -64007,14 +63811,13 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "vfL" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/turf/open/floor/rogue/rooftop/green{
+	dir = 1
 	},
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/town/roofs/keep)
 "vfU" = (
 /obj/structure/bed/rogue/shit{
 	name = "makeshift bed"
@@ -64108,13 +63911,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"vhZ" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "manor";
-	name = "Library"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
 "vid" = (
 /obj/structure/bed/rogue/shit,
 /mob/living/carbon/human/species/human/northern/highwayman,
@@ -64163,13 +63959,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves)
 "viS" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/roguecloset/crafted,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
+/obj/item/clothing/suit/roguetown/armor/silkcoat,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/manor)
 "viW" = (
 /obj/structure/lever/wall{
 	redstone_id = "trader_stock_shutter"
@@ -64361,9 +64157,13 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
 "vlL" = (
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/rooftop/green{
+	dir = 1
+	},
+/area/rogue/outdoors/town/roofs/keep)
 "vlP" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/structure/flora/roguegrass/maneater/real,
@@ -64384,7 +64184,7 @@
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/herb/rosa,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/town/roofs/keep)
 "vmw" = (
 /obj/structure/fluff/walldeco/painting/seraphina{
 	pixel_y = 32
@@ -64402,12 +64202,10 @@
 	},
 /area/rogue/indoors/town)
 "vmI" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
+/turf/closed/wall/mineral/rogue/roofwall/middle{
+	dir = 4
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/manor)
 "vmL" = (
 /obj/item/bedsheet/rogue/double_pelt,
 /obj/structure/bed/rogue/inn/wooldouble,
@@ -64444,14 +64242,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "vnq" = (
-/obj/machinery/light/rogue/lanternpost{
-	dir = 1
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/bookcase/random/archive,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/town/roofs)
 "vnx" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -64490,9 +64283,14 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/mazedungeon)
 "voe" = (
-/obj/structure/chair/bench/couchablack,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/closed/wall/mineral/rogue/pipe{
+	dir = 4;
+	icon_state = "iron_line"
+	},
+/area/rogue/under/town/basement/keep)
 "vow" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassyel,
@@ -64605,6 +64403,15 @@
 	},
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
+"vqB" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/candlestick/silver/lit{
+	pixel_y = 9
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "vqD" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "nightmaiden"
@@ -64761,13 +64568,15 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/eora)
 "vsW" = (
-/obj/structure/flora/roguegrass,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/grass,
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "vta" = (
-/obj/machinery/light/rogue/oven/north,
-/turf/open/floor/rogue/cobble,
+/obj/structure/bearpelt,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "vti" = (
 /obj/structure/table/wood{
@@ -64976,17 +64785,19 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "vwo" = (
-/obj/structure/table/wood,
-/obj/item/candle/candlestick/silver/lit{
-	pixel_y = 9
-	},
-/turf/open/floor/rogue/tile/masonic/single,
-/area/rogue/indoors/town/manor)
-"vwp" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
+/obj/structure/table/wood{
+	icon_state = "largetable";
 	dir = 4
 	},
-/area/rogue/indoors/town/physician)
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/manor)
+"vwp" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/kitchen/spoon/tin,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "vwA" = (
 /obj/structure/table/wood,
 /obj/item/clothing/neck/roguetown/psicross/malum,
@@ -65159,12 +64970,11 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/physician)
 "vAg" = (
-/obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
-/obj/item/roguecoin/gold/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/structure/fluff/railing/border{
+	dir = 9
 	},
-/area/rogue/indoors/town/vault)
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town/roofs)
 "vAn" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -65176,12 +64986,7 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
 "vAo" = (
-/obj/structure/stairs/fancy/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/carpet/lord{
-	icon_state = "carpet_r"
-	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "vAp" = (
 /obj/structure/bed/rogue/inn/hay,
@@ -65234,9 +65039,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "vAJ" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "vAM" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -65283,13 +65088,13 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "vBu" = (
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/structure/table/wood{
-	icon_state = "tablewood1"
+	icon_state = "largetable";
+	dir = 8
 	},
-/obj/item/armor_brush,
-/obj/item/polishing_cream,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "vBB" = (
 /obj/structure/fluff/railing/fence,
 /obj/effect/decal/cobbleedge{
@@ -65306,8 +65111,36 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "vBQ" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/rack/rogue/shelf/big,
+/obj/structure/rack/rogue/shelf,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_x = -6;
+	pixel_y = 45
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_x = 8;
+	pixel_y = 45
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_y = 45
+	},
+/obj/item/storage/bag/tray{
+	pixel_y = 12
+	},
+/obj/item/storage/bag/tray{
+	pixel_y = 12
+	},
+/obj/item/natural/bundle/stick{
+	pixel_y = 14
+	},
+/obj/item/natural/bundle/stick{
+	pixel_y = 14
+	},
+/obj/item/natural/bundle/stick{
+	pixel_y = 14
+	},
+/obj/item/natural/bundle/stick{
+	pixel_y = 14
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
@@ -65332,12 +65165,11 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "vCO" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/roguemachine/vaultbank,
-/turf/open/floor/rogue/tile{
-	icon_state = "glyph5"
-	},
-/area/rogue/indoors/town/vault)
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/fabric_double,
+/obj/effect/landmark/start/clerk,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/manor)
 "vCP" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -65400,6 +65232,23 @@
 "vDJ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/basement)
+"vDM" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/yellow/lit,
+/obj/item/candle/yellow/lit{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/candle/yellow/lit{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "vDR" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -65408,10 +65257,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
 "vDT" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "vDV" = (
 /turf/open/floor/rogue/woodturned,
@@ -65455,14 +65303,6 @@
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/eora)
-"vER" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "manor";
-	name = "Council Office"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
 "vET" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -65474,14 +65314,13 @@
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
 "vFd" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
+/obj/structure/roguewindow/openclose{
+	dir = 1
 	},
-/obj/item/candle/candlestick/gold/single/lit{
-	pixel_y = 9
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 1
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "vFg" = (
 /obj/effect/decal/mossy{
@@ -65490,9 +65329,15 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "vFh" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/bed/rogue/inn{
+	dir = 1
+	},
+/obj/item/bedsheet/rogue/fabric{
+	dir = 1
+	},
+/obj/effect/landmark/start/councillor,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/manor)
 "vFi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -65500,10 +65345,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
 "vFt" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "vFx" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/tile,
@@ -65526,10 +65374,10 @@
 	},
 /area/rogue/indoors/shelter)
 "vFY" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 1
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
+	dir = 4
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/manor)
 "vGa" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
@@ -65616,10 +65464,12 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
 "vHy" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
+/obj/structure/closet/crate/chest/neu_fancy,
+/obj/item/roguecoin/silver/pile,
+/turf/open/floor/rogue/tile/masonic{
 	dir = 1
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/vault)
 "vHB" = (
 /obj/item/seeds/cabbage,
 /obj/item/seeds/cabbage,
@@ -65672,9 +65522,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cave/orcdungeon)
 "vIv" = (
-/obj/structure/mirror,
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/under/town/basement/keep)
+/turf/closed,
+/area/rogue/under/cave)
 "vIw" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -65704,25 +65553,40 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/shelter/woods)
 "vII" = (
-/obj/structure/fluff/statue/astrata/gold,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement/keep)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/fishingrod/crafted,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/obj/item/bait/bloody,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/manor)
 "vIP" = (
-/obj/structure/chair/wood/rogue{
+/obj/effect/landmark/start/servant{
 	dir = 8
 	},
-/turf/open/floor/rogue/tile/masonic/inverted,
+/obj/structure/bed/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "vIR" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/item/candle/candlestick/gold/lit{
+	pixel_x = -32;
+	pixel_y = -117
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "vJa" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
+/turf/open/floor/rogue/tile/masonic{
+	dir = 1
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/town/roofs/keep)
+/area/rogue/indoors/town/vault)
 "vJj" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -65753,10 +65617,12 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "vJs" = (
-/obj/effect/landmark/start/prince{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 0
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "vJu" = (
 /obj/structure/fluff/railing/border{
@@ -65808,10 +65674,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "vKj" = (
-/obj/structure/stairs/fancy/c{
-	dir = 1
+/obj/structure/mineral_door/wood{
+	name = "Feast Hall";
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "manor"
 	},
-/turf/open/floor/rogue/carpet/lord,
+/turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
 "vKn" = (
 /obj/structure/table/wood{
@@ -66031,16 +65900,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "vOf" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 6
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-n"
+/obj/item/reagent_containers/glass/cup/skull{
+	pixel_x = -4;
+	pixel_y = 6
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "vOg" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -66065,7 +65933,7 @@
 	},
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/outdoors/town)
 "vOC" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -66148,13 +66016,11 @@
 	},
 /area/rogue/indoors/town/physician)
 "vPR" = (
-/obj/structure/fluff/walldeco/painting/queen{
-	pixel_y = 32
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "glyph4"
-	},
-/area/rogue/indoors/town/vault)
+/turf/open/water/bath,
+/area/rogue/under/town/basement/keep)
 "vPZ" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 1;
@@ -66227,10 +66093,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dukecourt)
 "vRR" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/structure/chair/bench/couch,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "vRU" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/spear2,
@@ -66258,14 +66123,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
 "vSw" = (
-/obj/structure/flora/roguegrass/bush,
-/obj/structure/flora/roguegrass,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/tile/bfloorz,
+/area/rogue/indoors/town/manor)
 "vSD" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -66284,16 +66143,18 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "vTb" = (
-/obj/structure/mirror,
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/garrison)
 "vTc" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/shirt/tunic,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
+/obj/item/clothing/suit/roguetown/armor/silkcoat,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/item/clothing/suit/roguetown/shirt/dress/royal/princess,
+/obj/item/clothing/suit/roguetown/shirt/dress/royal/prince,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "vTf" = (
 /turf/open/floor/rogue/cobble,
@@ -66327,12 +66188,14 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "vTJ" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/flashlight/flare/torch/lantern,
-/obj/item/rope/chain,
-/obj/item/gwstrap,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 5
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "vTN" = (
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/indoors/town/garrison)
@@ -66368,25 +66231,9 @@
 	},
 /area/rogue/indoors/town)
 "vUp" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/rogue/honey,
-/obj/item/reagent_containers/food/snacks/rogue/honey,
-/obj/item/reagent_containers/food/snacks/rogue/cheese,
-/obj/item/reagent_containers/food/snacks/rogue/cheese,
-/obj/item/reagent_containers/food/snacks/rogue/cheese,
-/obj/item/reagent_containers/food/snacks/rogue/cheese,
-/obj/item/reagent_containers/food/snacks/rogue/cheese,
-/obj/item/reagent_containers/food/snacks/rogue/cheese,
-/obj/item/reagent_containers/food/snacks/rogue/cheese,
-/obj/item/reagent_containers/food/snacks/rogue/cheese,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/effect/decal/carpet/square,
+/turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "vUw" = (
 /obj/structure/spider/stickyweb,
@@ -66415,9 +66262,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "vUZ" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/walldeco/stone,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/manor)
 "vVa" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/dirt,
@@ -66504,10 +66351,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/orcdungeon)
 "vWB" = (
-/obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 1
+/obj/structure/bookcase/random,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
 	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "vWC" = (
 /turf/closed/mineral/random/rogue/med,
@@ -66670,11 +66518,12 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "vYL" = (
-/obj/structure/closet/crate/drawer,
-/obj/item/book/rogue/law,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "vYO" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -66742,30 +66591,31 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
 "vZI" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
-	},
-/obj/item/candle/candlestick/gold/lit{
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town/roofs)
 "vZU" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/dukecourt)
 "waf" = (
-/obj/item/reagent_containers/food/snacks/crow{
-	dir = 8
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 1
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/manor)
 "wag" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/obj/effect/decal/cobbleedge{
+	dir = 7;
+	pixel_x = 13
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "wat" = (
 /obj/structure/fluff/railing/border{
 	dir = 5;
@@ -66799,10 +66649,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblinfort)
 "wbb" = (
-/obj/structure/roguemachine/mail{
-	mailtag = "Heir's Suite"
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
 "wbf" = (
 /obj/effect/decal/cobbleedge{
@@ -66814,6 +66664,25 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
+"wbt" = (
+/obj/structure/flora/roguegrass/bush,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/town)
+"wbA" = (
+/obj/structure/bed/rogue{
+	dir = 8
+	},
+/obj/effect/landmark/start/servant{
+	dir = 4
+	},
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "wbR" = (
 /obj/structure/table/wood,
 /obj/structure/lever/wall{
@@ -66929,26 +66798,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "wdr" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_x = 54;
+	pixel_y = -85
 	},
-/obj/item/cooking/pan{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/peppermill{
-	pixel_x = 14;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "wdB" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach)
-"wdE" = (
-/obj/structure/fluff/statue/gargoyle,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/manor)
 "wdI" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -67027,8 +66885,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
 "weS" = (
-/obj/machinery/light/rogue/firebowl/standing,
-/turf/open/floor/rogue/blocks,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/shirt/tunic,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
+/obj/item/clothing/suit/roguetown/armor/silkcoat,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/item/clothing/suit/roguetown/shirt/dress/royal/princess,
+/obj/item/clothing/suit/roguetown/shirt/dress/royal/prince,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "weX" = (
 /obj/structure/table/wood{
@@ -67065,7 +66930,13 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/shelter)
 "wfI" = (
-/obj/structure/fermentation_keg/beer,
+/obj/structure/bed/rogue/inn/double{
+	dir = 1
+	},
+/obj/item/bedsheet/rogue/fabric_double{
+	dir = 1
+	},
+/obj/effect/landmark/start/marshal,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -67087,11 +66958,14 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "wfS" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/structure/mineral_door/wood{
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "garrison";
+	name = "Seneschal's Quarters"
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
 "wfT" = (
@@ -67156,11 +67030,10 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "wha" = (
-/obj/item/book/rogue/abyssor,
-/obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/roguewindow/openclose{
+	dir = 8
 	},
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "whd" = (
 /obj/structure/bars/pipe{
@@ -67217,11 +67090,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "whK" = (
-/obj/structure/telescope,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/effect/decal/cobbleedge,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "whR" = (
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/hexstone,
@@ -67246,24 +67122,18 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "wic" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Throne Room"
+/obj/structure/stairs/fancy/r{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "wij" = (
-/obj/structure/rack/rogue,
-/obj/item/storage/roguebag{
-	pixel_x = -7;
-	pixel_y = 5
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-n"
 	},
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/obj/effect/decal/cobbleedge,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
 "wik" = (
 /obj/structure/rack/rogue,
 /obj/item/flashlight/flare/torch/metal,
@@ -67416,19 +67286,12 @@
 	},
 /area/rogue/indoors/town)
 "wkf" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
+/obj/structure/telescope{
+	pixel_x = 33;
+	pixel_y = -163
 	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/candlestick/silver/single/lit{
-	pixel_y = 9
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "wkg" = (
 /obj/structure/stairs,
@@ -67452,18 +67315,17 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
 "wkv" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/structure/mineral_door/wood/fancywood{
+	name = "Sauna"
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "wkx" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/under/town/basement/keep)
+/turf/open/floor/rogue/rooftop{
+	icon_state = "roof";
+	dir = 1
+	},
+/area/rogue/outdoors/town/roofs/keep)
 "wkz" = (
 /obj/structure/bars{
 	color = "#755f48";
@@ -67508,8 +67370,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach)
 "wli" = (
-/obj/structure/fluff/wallclock,
-/turf/open/floor/rogue/carpet,
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
 "wln" = (
 /obj/effect/decal/cobbleedge{
@@ -67559,10 +67424,11 @@
 /area/rogue/indoors/cave)
 "wlV" = (
 /obj/structure/fluff/railing/border{
-	dir = 4
+	dir = 9
 	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile/bath,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "wlX" = (
 /obj/structure/mineral_door/wood/bath/courtesan{
@@ -67593,6 +67459,14 @@
 /obj/item/clothing/neck/roguetown/psicross,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"wmt" = (
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "manor";
+	name = "Councilor's Chambers"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "wmx" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
@@ -67683,6 +67557,16 @@
 "wnA" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
+"wnD" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flint,
+/obj/item/candle/skull,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/obj/item/broom,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "wnE" = (
 /obj/structure/fluff/grindwheel,
 /obj/effect/decal/cleanable/debris/woody,
@@ -67695,10 +67579,6 @@
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"woi" = (
-/obj/structure/chair/wood/rogue/fancy,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "wom" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -67744,6 +67624,13 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"wpb" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_x = 32
+	},
+/obj/effect/particle_effect/smoke/transparent,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "wpd" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield/eora)
@@ -67786,14 +67673,12 @@
 /turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/under/cave/orcdungeon)
 "wpO" = (
-/obj/structure/fluff/railing/wood{
-	layer = 4.51
+/obj/structure/bearpelt{
+	desc = "A hide of a slain bear. It looks rich and expensive.";
+	pixel_y = 20
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/town/roofs/keep)
+/turf/open/floor/rogue/tile/masonic/inverted,
+/area/rogue/indoors/town/manor)
 "wpV" = (
 /obj/structure/chair/wood/rogue/fancy,
 /obj/effect/landmark/start/wapprentice,
@@ -67822,8 +67707,11 @@
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/outdoors/beach)
 "wqC" = (
-/obj/structure/fluff/statue/knight,
-/turf/open/floor/rogue/cobble,
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "dungeon"
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "wqP" = (
 /obj/structure/rack/rogue/shelf/biggest,
@@ -67918,8 +67806,12 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
 "wsu" = (
-/obj/structure/flora/roguegrass/bush/wall/tall,
-/turf/open/floor/rogue/grassyel,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "wsv" = (
 /mob/living/carbon/human/species/goblin/npc/ambush,
@@ -67976,10 +67868,16 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
 "wtb" = (
-/obj/structure/chair/bench/ultimacouch,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/candle/candlestick/silver/lit{
+	pixel_y = 14;
+	pixel_x = 0
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "wtd" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
@@ -68203,22 +68101,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "wxu" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "wxw" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"wxD" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-sread"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "wxQ" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/town/roofs)
@@ -68251,8 +68142,11 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/physician)
 "wyi" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/tile/masonic/inverted,
+/obj/structure/roguemachine/titan{
+	pixel_y = 32
+	},
+/obj/structure/roguethrone,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "wyo" = (
 /obj/structure/fluff/railing/border{
@@ -68331,16 +68225,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter)
 "wzF" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "knight"
-	},
-/obj/structure/fluff/walldeco/alarm{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/town/basement/keep)
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "wzO" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -68397,13 +68284,18 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
 "wAx" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "manor";
-	name = "jesters chambers"
+/obj/structure/bed/rogue/inn/double{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
+/obj/item/bedsheet/rogue/fabric_double{
+	dir = 1
+	},
+/obj/effect/landmark/start/apothecary,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/outdoors/town/roofs)
 "wAG" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 4
@@ -68451,10 +68343,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
-"wBT" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/manor)
 "wBU" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon1/gethsmane)
@@ -68565,6 +68453,12 @@
 	},
 /turf/open/floor/rogue/twig/platform,
 /area/rogue/indoors/shelter/woods)
+"wDV" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/manor)
 "wEc" = (
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32
@@ -68612,10 +68506,15 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/mountains/decap)
 "wEL" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "glyph1"
+/obj/structure/stairs/stone/d{
+	dir = 1
 	},
-/area/rogue/indoors/town/vault)
+/obj/structure/stairs/stone/d,
+/turf/closed/wall/mineral/rogue/pipe{
+	dir = 8;
+	icon_state = "iron_joint"
+	},
+/area/rogue/under/town/basement/keep)
 "wEQ" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -68627,6 +68526,13 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
+"wEV" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "wEX" = (
 /turf/closed/wall/mineral/rogue/stone/window/blue_moss,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
@@ -68686,29 +68592,21 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cave/orcdungeon)
 "wFH" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/shirt/tunic,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/puritan,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess,
-/obj/item/clothing/suit/roguetown/armor/silkcoat,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/obj/item/clothing/suit/roguetown/shirt/dress/royal/princess,
-/obj/item/clothing/suit/roguetown/shirt/dress/royal/prince,
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/item/storage/belt/rogue/surgery_bag/full{
+	pixel_y = 10
 	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "wFJ" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/item/candle/gold/lit{
-	pixel_y = 6
-	},
+/obj/structure/closet/crate/roguecloset/dark,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/clothing/suit/roguetown/armor/gambeson/heavy,
+/obj/item/clothing/suit/roguetown/shirt/tunic/silktunic,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "wFK" = (
@@ -68730,20 +68628,14 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/shelter/mountains/decap)
 "wFY" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/cup/silver{
-	name = "pewter goblet";
-	pixel_x = -11
+/obj/structure/bed/rogue,
+/obj/effect/landmark/start/squire{
+	dir = 4
 	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = 14;
-	pixel_y = 6
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/item/kitchen/fork/gold{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "wGh" = (
 /obj/structure/flora/roguegrass,
@@ -68849,13 +68741,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "wIl" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/manor)
+/obj/machinery/light/rogue/firebowl/standing,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "wIs" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -69042,15 +68930,11 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "wLC" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/tile/bath,
+/obj/structure/chair/bench/couch,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "wLE" = (
 /obj/structure/chair/stool/rogue,
@@ -69137,15 +69021,6 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"wNb" = (
-/obj/structure/table/wood{
-	icon_state = "map2"
-	},
-/obj/item/candle/candlestick/gold/lit{
-	pixel_y = 12
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "wNc" = (
 /obj/structure/flora/roguetree/evil,
 /turf/open/floor/rogue/dirt,
@@ -69171,16 +69046,13 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "wNM" = (
-/obj/effect/decal/cobbleedge{
-	pixel_y = 1
+/obj/structure/stairs{
+	dir = 1
 	},
-/obj/structure/roguemachine/scomm,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/structure/stairs/fancy/l{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "wNN" = (
 /obj/effect/decal/mossy{
@@ -69268,16 +69140,10 @@
 	},
 /area/rogue/indoors/town/physician)
 "wPp" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
+/turf/open/floor/rogue/twig{
+	dir = 8
 	},
-/obj/effect/decal/cobbleedge{
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/town/roofs/keep)
 "wPs" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/wood,
@@ -69333,11 +69199,9 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/shelter/mountains/decap)
 "wQL" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/structure/fluff/wallclock/r,
-/obj/item/bedsheet/rogue/fabric_double,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town)
+/obj/structure/roguemachine/stockpile,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/exposed/town/keep)
 "wQO" = (
 /obj/machinery/light/roguestreet/midlamp{
 	pixel_y = 10
@@ -69357,10 +69221,10 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/cave)
 "wQW" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
+/obj/structure/chair/wood/rogue{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
 "wRe" = (
 /obj/structure/table/wood{
@@ -69432,11 +69296,11 @@
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
 "wSh" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/structure/chair/wood/rogue{
+	dir = 1
 	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/town)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "wSk" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -69457,12 +69321,14 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/church/basement)
 "wSC" = (
-/obj/structure/mineral_door/wood{
+/obj/structure/mineral_door/wood/donjon{
 	locked = 1;
 	lockid = "manor";
-	name = "wine cellar"
+	name = "Bathroom";
+	dir = 8;
+	max_integrity = 3000
 	},
-/turf/open/floor/rogue/cobble,
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/town/basement/keep)
 "wSO" = (
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/pink,
@@ -69476,10 +69342,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "wTi" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/structure/closet/crate/roguecloset/dark,
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
+/area/rogue/indoors/town/manor)
 "wTp" = (
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
 /obj/machinery/light/rogue/wallfire/candle/floorcandle{
@@ -69595,6 +69459,7 @@
 	icon_state = "churchtable_end"
 	},
 /obj/item/candle/candlestick/gold/lit{
+	pixel_x = 3;
 	pixel_y = 23
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -69625,10 +69490,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
-"wWm" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
 "wWq" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/manor)
@@ -69648,6 +69509,14 @@
 /obj/item/reagent_containers/glass/bowl/gold,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains/decap)
+"wWL" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bottle/rogue/elfred{
+	pixel_x = -1;
+	pixel_y = 10
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "wWM" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -69710,11 +69579,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/orcdungeon)
 "wXL" = (
-/obj/structure/rack/rogue/shelf/biggest{
-	pixel_y = 24
+/turf/open/floor/rogue/rooftop/green{
+	dir = 8
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/town/roofs/keep)
 "wXO" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/ruinedwood,
@@ -69824,11 +69692,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "wZp" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/fluff/statue/gargoyle,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/carpet/lord/left,
+/area/rogue/indoors/town/manor)
 "wZq" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -69837,8 +69706,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
 "wZr" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/water/bath,
+/obj/structure/lever{
+	redstone_id = "thronegrille"
+	},
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "wZv" = (
 /obj/structure/chair/wood/rogue/fancy,
@@ -69963,8 +69834,11 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
 "xbs" = (
-/obj/structure/closet/crate/roguecloset/dark,
-/turf/open/floor/rogue/herringbone,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
 "xbw" = (
 /obj/structure/fluff/railing/border{
@@ -70090,13 +69964,14 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/mountains)
 "xdz" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/fabric,
-/obj/effect/landmark/start/jester{
-	dir = 8
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	dir = 1
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/town/basement/keep)
+/obj/item/natural/feather,
+/obj/item/candle/yellow/lit,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "xdA" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -70164,9 +70039,16 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/underdark)
 "xeD" = (
-/obj/structure/fluff/statue/gargoyle,
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/manor)
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/town)
 "xeE" = (
 /obj/structure/bars/passage{
 	max_integrity = 9000;
@@ -70221,9 +70103,11 @@
 	},
 /area/rogue/indoors/town)
 "xfz" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/eaglebeak/lucerne,
-/turf/open/floor/rogue/tile,
+/obj/structure/bars/tough,
+/obj/structure/roguewindow/harem2{
+	density = 0
+	},
+/turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/town/basement/keep)
 "xfC" = (
 /obj/effect/decal/cobbleedge{
@@ -70355,9 +70239,11 @@
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/mountains/decap)
 "xhH" = (
-/obj/structure/fluff/walldeco/wantedposter,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/floordoor/gatehatch/outer{
+	redstone_id = "wallbridge"
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "xhL" = (
 /obj/item/roguecoin/silver/pile,
 /turf/open/floor/rogue/blocks,
@@ -70372,6 +70258,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"xhP" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 1
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/manor)
 "xhQ" = (
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt/road,
@@ -70444,6 +70337,10 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
+"xjL" = (
+/obj/effect/landmark/start/lady,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "xjQ" = (
 /obj/structure/fluff/walldeco/stone{
 	icon_state = "walldec6"
@@ -70464,24 +70361,23 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/shelter/woods)
-"xkq" = (
-/obj/structure/chair/wood/rogue/fancy,
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "xku" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "longtable"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = 8;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
+/obj/item/reagent_containers/glass/bottle/rogue/elfred{
+	pixel_x = -12
 	},
-/area/rogue/outdoors/town/roofs/keep)
+/obj/item/reagent_containers/glass/cup/silver/small{
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/carpet/lord/left,
+/area/rogue/indoors/town/manor)
 "xkB" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -70590,9 +70486,10 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/scarymaze)
 "xma" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/pelt,
 /obj/effect/landmark/start/servant{
+	dir = 8
+	},
+/obj/structure/bed/rogue{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -70654,25 +70551,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/goblinfort)
 "xmQ" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
-/obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
+/obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -70937,19 +70816,19 @@
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "xsf" = (
-/obj/structure/fluff/railing/border{
+/obj/structure/flora/roguegrass,
+/obj/structure/fluff/railing/fence{
 	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/fence{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "xsk" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
-/area/rogue/outdoors/town/roofs/keep)
+/obj/structure/fluff/walldeco/customflag,
+/turf/closed/wall/mineral/rogue/decostone/long,
+/area/rogue/indoors/town/manor)
 "xsp" = (
 /obj/structure/composter/halffull,
 /turf/open/floor/rogue/dirt,
@@ -71122,9 +71001,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
 "xwF" = (
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/manor)
 "xwL" = (
 /obj/structure/roguerock,
@@ -71261,8 +71139,8 @@
 "xyS" = (
 /obj/structure/flora/roguegrass/bush,
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
 "xzd" = (
 /obj/structure/rack/rogue,
 /obj/item/storage/roguebag,
@@ -71291,6 +71169,9 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/woods)
+"xzG" = (
+/turf/closed/wall/mineral/rogue/roofwall/outercorner,
+/area/rogue/indoors/town/manor)
 "xzO" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = 16;
@@ -71328,20 +71209,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
-"xAj" = (
-/obj/structure/closet/crate/drawer/random{
-	pixel_y = 0
-	},
-/obj/item/roguegem/diamond,
-/obj/item/clothing/ring/active/nomag,
-/obj/item/roguekey/lord{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "xAk" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/tile,
@@ -71424,11 +71291,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
 "xBq" = (
-/obj/structure/fermentation_keg/blackgoat,
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
-	},
-/area/rogue/under/town/basement/keep)
+/turf/closed/wall/mineral/rogue/roofwall/middle,
+/area/rogue/outdoors/town/roofs)
 "xBE" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder/spear,
 /turf/open/floor/rogue/church,
@@ -71483,9 +71347,19 @@
 /turf/open/water/swamp,
 /area/rogue/under/town/sewer)
 "xCL" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/closet/crate/chest,
+/obj/item/kitchen/fork/silver,
+/obj/item/kitchen/fork/silver,
+/obj/item/kitchen/fork/silver,
+/obj/item/kitchen/fork/silver,
+/obj/item/kitchen/spoon/silver,
+/obj/item/kitchen/spoon/silver,
+/obj/item/kitchen/spoon/silver,
+/obj/item/kitchen/spoon/silver,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "xCR" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -71606,8 +71480,12 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/cave)
 "xEs" = (
-/obj/item/book/rogue/knowledge1,
-/obj/structure/bookcase,
+/obj/structure/mineral_door/wood/donjon{
+	locked = 1;
+	lockid = "garrison";
+	name = "squireroom door";
+	dir = 8
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -71636,13 +71514,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "xFl" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
-	},
+/obj/structure/fluff/wallclock,
+/obj/structure/fluff/statue/knight/interior/r,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "xFn" = (
 /obj/structure/table/wood{
@@ -71684,21 +71558,15 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/manor)
+/area/rogue/outdoors/town/roofs/keep)
 "xFR" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "longtable"
-	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/item/rogueweapon/huntingknife/scissors/steel{
-	pixel_x = -7;
-	pixel_y = -5;
-	sellprice = 8
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/storage/belt/rogue/leather/steel/tasset,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/item/clothing/shoes/roguetown/boots/nobleboot,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "xFU" = (
 /obj/structure/fluff/railing/fence{
@@ -71710,12 +71578,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/woods)
-"xFX" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "xFY" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -71841,14 +71703,17 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/woods)
 "xHI" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/carpet/lord/center,
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/effect/decal/carpet/square/black,
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "xHQ" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/tile/masonic{
-	dir = 8
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/pelt,
+/obj/structure/lever{
+	redstone_id = "thronegrille"
 	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "xHU" = (
 /obj/structure/bed/rogue/inn/hay{
@@ -71944,6 +71809,11 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
+"xKF" = (
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 10
+	},
+/area/rogue/indoors/town/manor)
 "xKG" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -72057,12 +71927,17 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "xMY" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/chair/bench/couch{
+	icon_state = "redcouch2"
 	},
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/roguegrass/bush,
-/turf/open/floor/rogue/grass,
+/obj/structure/rogue/trophy/deer,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "xNe" = (
 /obj/structure/chair/wood/rogue/throne,
@@ -72102,14 +71977,13 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "xNW" = (
-/obj/structure/table/wood{
-	icon_state = "map4"
+/obj/structure/mirror{
+	pixel_x = -28;
+	pixel_y = 0
 	},
-/obj/item/tablecloth/silk{
-	pixel_x = -6;
-	pixel_y = 6
+/turf/open/floor/rogue/tile/masonic{
+	dir = 1
 	},
-/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "xNX" = (
 /obj/item/reagent_containers/food/snacks/crow{
@@ -72164,60 +72038,12 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "xOC" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/silver{
-	name = "pewter goblet";
-	pixel_x = -11
+/obj/structure/mineral_door/wood/fancywood{
+	locked = 1;
+	lockid = "knight";
+	name = "Knight's Chamber"
 	},
-/obj/item/reagent_containers/glass/cup/silver{
-	name = "pewter goblet";
-	pixel_x = -11
-	},
-/obj/item/reagent_containers/glass/cup,
-/obj/item/reagent_containers/glass/cup,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	sellprice = 30
-	},
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	sellprice = 30
-	},
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	sellprice = 30
-	},
-/obj/item/reagent_containers/glass/bowl/iron{
-	name = "pewter bowl";
-	sellprice = 30
-	},
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter/pewter,
-/obj/item/cooking/platter/pewter,
-/obj/item/reagent_containers/glass/bowl/silver{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/glass/bowl/silver{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/glass/bowl/silver{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/glass/bowl/gold,
-/obj/item/reagent_containers/glass/bowl/gold,
-/obj/item/reagent_containers/glass/bowl/gold,
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "xOE" = (
 /obj/structure/fluff/walldeco/chains{
@@ -72236,11 +72062,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
 "xOK" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
-	pixel_y = -31
+/obj/machinery/anvil,
+/obj/item/rogueweapon/hammer/iron,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "xOV" = (
 /obj/item/natural/rock,
@@ -72295,11 +72121,11 @@
 /turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/shelter/mountains/decap)
 "xPL" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/clothing/under/roguetown/loincloth,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "knight"
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "xPN" = (
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -72412,19 +72238,11 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
 "xSh" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/table/wood{
+	icon_state = "map2"
 	},
-/obj/structure/flora/roguegrass/bush{
-	pixel_x = 5;
-	pixel_y = 0
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/basement/keep)
 "xSj" = (
 /obj/structure/chair/bench/couch,
 /obj/machinery/light/rogue/wallfire{
@@ -72570,12 +72388,11 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap)
 "xUY" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/obj/effect/landmark/start/guard_captain,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/tile/bfloorz,
+/area/rogue/under/town/basement/keep)
 "xVg" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
@@ -72640,15 +72457,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"xWN" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "heir";
-	name = "Heir's Apartment"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "xWO" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/cobble/mossy,
@@ -72683,8 +72491,10 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
 "xXA" = (
-/obj/structure/fireaxecabinet/south,
-/turf/open/floor/rogue/carpet/lord/center,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
 "xXC" = (
 /obj/effect/decal/wood/herringbone2{
@@ -72697,9 +72507,16 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "xXW" = (
-/obj/structure/fluff/clock,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/obj/item/candle/yellow/lit{
+	pixel_x = 19;
+	pixel_y = -1
+	},
+/obj/machinery/light/rogue/firebowl/standing{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/basement)
 "xYj" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
@@ -72810,7 +72627,7 @@
 	},
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/outdoors/town)
 "xZB" = (
 /obj/structure/closet/crate/chest/wicker,
 /turf/open/floor/rogue/grass,
@@ -72843,13 +72660,13 @@
 	},
 /area/rogue/indoors/town)
 "xZU" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 8;
-	locked = 1;
-	lockid = "steward"
+/obj/effect/decal/cobbleedge,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "yaf" = (
 /obj/structure/mineral_door/wood/towner/fisher{
 	locked = 0
@@ -73154,21 +72971,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/roofs)
 "yeu" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/stairs/stone/d{
+	dir = 8
 	},
-/obj/item/kitchen/rollingpin,
-/obj/structure/roguemachine/stockpile{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/item/kitchen/fork/silver{
-	pixel_x = 14;
-	pixel_y = 6
-	},
-/obj/item/kitchen/fork/tin,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/tile/bfloorz,
+/area/rogue/under/town/basement/keep)
 "yew" = (
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
@@ -73230,10 +73037,13 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
 "yfn" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
+/obj/structure/closet/crate/chest/neu_fancy,
+/obj/item/roguecoin/gold/pile,
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/turf/open/floor/rogue/tile/masonic{
+	dir = 1
 	},
-/area/rogue/indoors/town/physician)
+/area/rogue/indoors/town/vault)
 "yfs" = (
 /obj/structure/flora/roguegrass/herb/hypericum,
 /turf/open/floor/rogue/grassred,
@@ -73285,8 +73095,16 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave/skeletoncrypt)
 "ygd" = (
-/obj/structure/fluff/walldeco/bigpainting/lake,
-/turf/open/floor/rogue/tile/bfloorz,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/leather/studded,
+/obj/item/clothing/suit/roguetown/armor/leather/studded,
+/obj/item/clothing/suit/roguetown/armor/leather/studded/bikini,
+/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced,
+/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced,
+/obj/item/clothing/wrists/roguetown/bracers/leather,
+/obj/item/clothing/wrists/roguetown/bracers/leather,
+/obj/item/clothing/wrists/roguetown/bracers/leather,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "ygf" = (
 /obj/structure/hotspring,
@@ -73386,13 +73204,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
 "yhX" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
 "yib" = (
 /obj/structure/closet/crate/roguecloset/inn,
@@ -73462,9 +73277,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "yju" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town)
+/obj/structure/roguemachine/vaultbank,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/vault)
 "yjw" = (
 /mob/living/carbon/human/species/human/northern/searaider/ambush,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -73544,11 +73359,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "ykK" = (
-/obj/structure/roguewindow/openclose/reinforced{
+/turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/town/roofs)
 "ykT" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/effect/decal/cobbleedge{
@@ -163307,11 +163121,11 @@ cxZ
 cxZ
 vtx
 bYC
-iad
-iad
-iad
-iad
-iad
+lDn
+lDn
+lDn
+bYC
+hMB
 bYC
 whB
 qlM
@@ -163759,11 +163573,11 @@ cxZ
 cxZ
 vtx
 vtx
-iad
-tqO
-hof
-siF
-iad
+lDn
+lDn
+lDn
+bYC
+hMB
 bYC
 oPy
 wCC
@@ -164191,15 +164005,15 @@ cxZ
 cxZ
 cxZ
 cxZ
-dyx
 leX
-leX
-xCK
-xCK
-xCK
-leX
-leX
-leX
+bYC
+bYC
+bYC
+bYC
+bYC
+bYC
+bYC
+bYC
 bBG
 bBG
 leX
@@ -164211,11 +164025,11 @@ leX
 bYC
 bYC
 bYC
-iad
-fFz
-bHV
-xfz
-iad
+lDn
+lDn
+lDn
+bYC
+hMB
 bYC
 bZj
 wCC
@@ -164635,39 +164449,39 @@ cxZ
 cxZ
 cxZ
 cxZ
-cxZ
 eMU
 orc
 eMU
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-fAL
-dlK
-amm
-dlK
-jEk
-ogs
-ogs
-iad
-iad
-iad
-iad
-iad
-iad
-iad
-iad
-iad
-iad
-iad
-iad
-bHv
+skC
+skC
+xCK
+xCK
+xCK
+skC
+bYC
+fRL
 bHV
-ktO
+pZw
+hUf
+iSQ
+bHV
+jOP
 iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+iad
+ogs
+lDn
+lDn
+lDn
+bYC
+hMB
 bYC
 loK
 qhq
@@ -165088,38 +164902,38 @@ ogs
 ogs
 ogs
 ogs
+toJ
+skC
 ogs
-orc
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-xAN
-ylh
-mMx
-ylh
-xAN
-ogs
-ogs
-iad
-vTb
-aSm
-pZw
-iad
-jlB
-iCY
-haq
-sOa
-bJB
-nvU
-cUH
+dlK
+vVx
+vVx
+vVx
+dlK
+voe
 bHV
 bHV
-eRG
+ept
+rDO
+tMv
+uNz
+bHV
 iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+lDn
+lDn
+lDn
+lDn
+lDn
+bYC
+hMB
 bYC
 uqC
 eWv
@@ -165539,39 +165353,39 @@ ogs
 ogs
 ogs
 ogs
-ogs
+toJ
 orc
-orc
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
+skC
 ogs
 xAN
-dxA
+ylh
 mMx
 ylh
 xAN
+iad
+lGl
+bHV
+bdw
+iGT
+xSh
+jfm
+fvA
+iad
 ogs
 ogs
-iad
-ffL
-drE
-drE
-djh
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
 iBO
-iBO
-iBO
-iBO
-iBO
-iBO
-cUH
-bHV
-bHV
-loz
-iad
+lDn
+lDn
+lDn
+lDn
+bYC
+hMB
 bYC
 cjR
 eWv
@@ -165991,39 +165805,39 @@ ogs
 ogs
 ogs
 ogs
-jcb
 orc
 uvk
+skC
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-dlK
+xAN
 ylh
 mMx
 ylh
-dlK
+xAN
+iad
+aVE
+bHV
+rGx
+ijk
+mhx
+fSB
+bHV
+iad
 ogs
 ogs
-iad
-syz
-dNO
-mFr
-iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
 iBO
-iBO
-iBO
-iBO
-iBO
-iBO
-wzF
-bHV
-bHV
-ojQ
-iad
+lDn
+lDn
+lDn
+lDn
+bYC
+bYC
 bYC
 eWv
 eWv
@@ -166444,37 +166258,37 @@ ogs
 ogs
 ogs
 orc
-orc
+skC
 ogs
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
+xAN
+ylh
+mMx
+ylh
+xAN
 iad
-iad
-iad
-iad
-iad
-iad
-ogs
-ogs
-iad
-iad
-iad
-iad
-iad
-ygd
-iBO
-iad
-iad
-djh
-iad
-iad
+pCd
 bHV
+fCk
+qHm
+aOM
 bHV
-bHV
+eSn
+iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+lDn
+lDn
+lDn
+lDn
+lDn
+lDn
 iad
 bYC
 vrC
@@ -166895,38 +166709,38 @@ ogs
 ogs
 ogs
 uvk
-orc
+skC
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
+vIv
+vIv
+dlK
+ylh
+mMx
+ylh
+dlK
 iad
-iqU
+iad
 xPL
-agd
-sAf
 iad
 iad
 iad
 iad
-vTb
-aSm
-pZw
 iad
-iBO
-iBO
 iad
-vTb
-qJZ
-pZw
-iad
-erO
-bHV
-ept
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+lDn
+lDn
+lDn
+lDn
+lDn
+lDn
 iad
 bYC
 gaB
@@ -167347,38 +167161,38 @@ ogs
 ogs
 ogs
 orc
-mdL
 uvk
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
+skC
 iad
-pzs
-waK
-waK
-mmB
-aoD
-tYZ
-nWc
 iad
-ffL
-drE
-drE
-djh
-iBO
-iBO
 iad
-ffL
-drE
-drE
 iad
-gei
-bHV
-cUj
+xfz
+iad
+iad
+iad
+iJi
+wCC
+eWv
+tUV
+eWv
+tUV
+lll
+iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+lDn
+lDn
+lDn
+lDn
+lDn
+lDn
 iad
 bYC
 dVC
@@ -167799,38 +167613,38 @@ ogs
 ogs
 orc
 orc
-orc
+skC
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
+iad
+iqU
+dFk
+waK
+sAf
+iad
+iad
 iad
 mOz
-waK
-waK
-mmB
-aoD
-nWc
-nWc
-iad
+wCC
 tlQ
-dNO
-mFr
+wCC
+bhZ
+wCC
+nZP
 iad
-rLn
-jdv
-iad
-jfm
-gFm
-mFr
-iad
-hOT
-bHV
-fvC
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+lDn
+lDn
+lDn
+lDn
+lDn
+lDn
 iad
 bYC
 mIO
@@ -168253,36 +168067,36 @@ orc
 uvk
 ogs
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
 iad
-mWq
+pzs
 waK
 waK
-iCc
-hzA
-nWc
-nWc
+mmB
+aoD
+tYZ
 iad
+eMi
+wCC
+kMx
+wCC
+pIv
+wCC
+fbW
 iad
-iad
-iad
-iad
-mbG
-fXM
-iad
-iad
-iad
-iad
-iad
-iJp
-bHV
-qgS
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+lDn
+lDn
+lDn
+lDn
+lDn
+lDn
 iad
 bYC
 lDp
@@ -168705,36 +168519,36 @@ orc
 ogs
 ogs
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
 iad
-rDx
+lAF
 waK
-bJM
-qwl
-jnt
-xCr
+waK
+sRJ
+aoD
 nWc
 iad
+rDx
+wCC
+ygd
+wCC
+lVB
+wCC
+pel
+iad
 ogs
-iad
-oSS
-wCC
-wCC
-uWU
-iad
-kAF
-eWv
-vBu
-iad
-dEP
-bHV
-nTv
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+lDn
+lDn
+lDn
+lDn
+lDn
+lDn
 iad
 bYC
 qnQ
@@ -169157,36 +168971,36 @@ ogs
 ogs
 ogs
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
 iad
+mWq
+waK
+waK
+iCc
+hzA
+nWc
 iad
-iad
-iad
-crC
-iad
-iad
-iad
-iad
-iad
-iad
-iad
-iad
-jxC
+mqT
 wCC
+biX
 wCC
+nKF
 wCC
+mIU
 iad
-pWB
-eWv
-dZz
-iad
-smR
-bHV
-lSh
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+lDn
+lDn
+lDn
+lDn
+lDn
+lDn
 iad
 bYC
 jZC
@@ -169609,36 +169423,36 @@ ogs
 ogs
 ogs
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
 iad
-qBO
-wCC
-bHV
-bHV
-bHV
-wqC
-wCC
-tUV
-wCC
-wqC
-bHV
-uWE
-eWv
-wCC
-wCC
-wCC
-bko
-eWv
-eWv
+eHY
+bJM
+waK
+qwl
+jnt
+xCr
+iad
+htV
+isB
+jPl
+isB
 fVF
+isB
+lSh
 iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
 lDn
-bHV
-qZN
+lDn
+lDn
+lDn
+lDn
+lDn
 iad
 bYC
 aEr
@@ -170060,37 +169874,37 @@ ogs
 ogs
 ogs
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
 iad
-vII
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
+iad
+iad
+iad
+crC
+iad
+iad
+iad
+iad
+iad
+iad
+iad
+iad
+iad
+iad
+iad
+iad
+lDn
 tyL
-wCC
-wCC
-wCC
-eWv
-iad
-aqz
-eWv
-vbt
-iad
-iJi
-bHV
-bHV
+qrX
+qrX
+qrX
+qrX
+lZz
+lDn
+lDn
+lDn
+lDn
+lDn
+lDn
+lDn
 iad
 bYC
 bYC
@@ -170511,38 +170325,38 @@ uvk
 ogs
 ogs
 ogs
-ogs
-ogs
 iad
-iad
-iad
-iad
-iad
-iad
-wCC
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-tyL
-wCC
-wCC
-wCC
-qrX
-iad
-oic
-aal
-rSJ
-iad
-hog
-bpF
+mPH
+mmb
+mmb
+hhv
+mmb
+mmb
+mPH
+eWv
+iXX
 cUk
+eWv
+eWv
+eWv
+cUk
+eWv
+eWv
+iad
+iad
+qrX
+qrX
+kbS
+hOT
+qrX
+qrX
+lDn
+lDn
+lDn
+lDn
+lDn
+lDn
+lDn
 iad
 fAL
 opX
@@ -170963,38 +170777,38 @@ uvk
 ogs
 ogs
 ogs
-ogs
-iad
-iad
-kiz
 mmb
-kiz
-scw
-iad
-qBO
-wCC
-bHV
-bHV
-bHV
-dMk
-wCC
-isB
-wCC
-dMk
-bHV
-uWE
+qQj
+mmb
+mmb
+mmb
+mmb
+mmb
+mmb
 eWv
-wCC
-wCC
+nnq
+eXA
+nnq
+nnq
+eXA
+nnq
+nnq
+eWv
+eWv
+iad
 qrX
-iad
-hQj
-aal
-lPk
-iad
-iad
-iad
-iad
+fvC
+ivq
+erO
+kqG
+qrX
+lDn
+lDn
+lDn
+lDn
+lDn
+lDn
+lDn
 iad
 xAN
 ylh
@@ -171415,34 +171229,34 @@ orc
 orc
 ogs
 ogs
-ogs
 iad
-scw
-kiz
-oYo
+mmb
+mmb
 uMN
-kiz
-iad
-iad
-iad
-lkJ
-pnA
 iad
 iad
 iad
 iad
-iad
-iad
-iad
-iad
-iad
+eWv
+uWE
+aal
+dEP
+bqw
+iUW
+rGK
+nnq
+kUH
+eWv
+cUk
+qrX
 uoI
+vJa
 uoI
-iad
-iad
-oic
-sZH
-rSJ
+rjK
+qrX
+lDn
+aal
+aal
 iad
 ogs
 ogs
@@ -171867,32 +171681,32 @@ orc
 orc
 ogs
 ogs
-ogs
 iad
-skw
+mmb
+mmb
 uMN
-uMN
-uMN
-uMN
+iad
+iad
+iad
 kiz
-iad
+eDO
 wqC
-bHV
-bHV
-iad
-eMi
-bqw
-oBL
-rGK
+aal
+qJZ
+toX
+qJZ
+pBH
+nnq
 ijI
-iad
+ijI
+ijI
 iqX
-bkj
-wCC
-wCC
-bkj
-iad
-iad
+els
+els
+els
+yju
+qrX
+lDn
 iad
 iad
 iad
@@ -172319,33 +172133,33 @@ orc
 mdL
 ogs
 ogs
-ogs
 iad
-vPR
+mmb
+mmb
 wEL
-uMN
-uMN
-uMN
-uMN
 iad
-iXX
-bHV
-bHV
 iad
-fgq
-toX
-qJZ
-aal
-aal
-uWE
-wCC
-wCC
-wCC
-wCC
-wCC
+iad
+iad
 eWv
-iad
-dlK
+uWE
+aal
+fgq
+ebP
+fgq
+qYk
+nnq
+kUH
+eWv
+tkB
+qrX
+erO
+ivq
+erO
+oyV
+qrX
+oee
+opX
 opX
 opX
 opX
@@ -172771,32 +172585,32 @@ orc
 orc
 ogs
 ogs
-ogs
 iad
-vCO
-pda
-uMN
-uMN
-uMN
-uMN
-sKU
-bHV
-bHV
-bHV
+qQj
+mmb
+mmb
+mmb
+mmb
+mmb
+mmb
+eWv
+nnq
+eXA
+nnq
+nnq
+nnq
+nnq
+nnq
+eWv
+eWv
 iad
-cLX
-qJZ
-qJZ
-aal
-aal
-fjY
-wCC
-wCC
-wCC
-wCC
-wCC
-wCC
-swB
+qrX
+llF
+vJa
+uoI
+yfn
+qrX
+esm
 ylh
 urZ
 mMx
@@ -173223,33 +173037,33 @@ uvk
 orc
 ogs
 ogs
-ogs
 iad
-lcZ
+mPH
+mmb
 lOy
-uMN
-uMN
-uMN
-uMN
-iad
+scw
+mmb
+mmb
+mPH
+eWv
 iXX
-bHV
-bHV
-iad
-bKp
-kIs
-kIs
-aal
-aal
-uWE
-wCC
-wCC
-wCC
-wCC
-wCC
+tkB
+eWv
+eWv
+eWv
+tkB
+eWv
 eWv
 iad
-dlK
+iad
+qrX
+qrX
+rtc
+vHy
+qrX
+qrX
+oee
+opX
 opX
 opX
 opX
@@ -173675,32 +173489,32 @@ ogs
 orc
 orc
 ogs
-ogs
-iad
-kiz
-uMN
-uMN
-uMN
-aqA
-kiz
-iad
-dMk
-bHV
-bHV
-iad
-fLP
-oee
-fLP
-qYk
-aal
-iad
-ajc
-lZz
-wCC
-wCC
-lZz
 iad
 iad
+iad
+iad
+iad
+hmx
+iad
+iad
+iad
+iad
+iad
+iad
+crC
+iad
+iad
+iad
+iad
+iad
+iad
+qrX
+tyL
+qrX
+qrX
+qrX
+qrX
+lDn
 ogs
 ogs
 ogs
@@ -174127,37 +173941,37 @@ ogs
 ogs
 jcb
 ogs
-ogs
-iad
-vAg
-kiz
-uMN
-oPf
-kiz
+idG
 iad
 iad
+xXW
+nSG
+nSG
+nSG
+nSG
+fHg
+nSG
 iad
-lkJ
 pnA
+eWv
+eWv
+eWv
+eWv
+eWv
+bHv
+eWv
 iad
-iad
-iad
-iad
-iad
-iad
-iad
-iad
-iad
-uoI
-uoI
-iad
-iad
-iad
-iad
-ogs
-ogs
-ogs
-xAN
+dlK
+opX
+opX
+opX
+opX
+opX
+opX
+opX
+opX
+opX
+xSV
 ylh
 xAN
 ogs
@@ -174579,37 +174393,37 @@ ogs
 ogs
 uvk
 ogs
-ogs
+idG
 iad
 iad
-kiz
+qfy
 dWW
-kiz
-mIU
-iad
+hof
 qBO
-wCC
-bHV
-bHV
-bHV
-wqC
-wCC
-fvA
-wCC
-wqC
-bHV
-uWE
-eWv
-wCC
-wCC
+jKf
+qBO
+jKf
 iad
+cWR
+eWv
+eWv
+eWv
+eWv
+eWv
+eWv
+eWv
+swB
+ylh
+urZ
+mMx
+mMx
 iKH
-laF
-vtx
-ogs
-ogs
-ogs
-xAN
+mMx
+mMx
+iKH
+mMx
+mMx
+mMx
 urZ
 xAN
 ogs
@@ -175032,36 +174846,36 @@ orc
 orc
 ogs
 ogs
-ogs
+idG
 iad
+aEj
+bgr
+pWB
+qBO
+dNO
+qBO
+dNO
 iad
-iad
-iad
-iad
-iad
-vII
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-tyL
-wCC
-wCC
-wCC
-wAx
+aqz
 eWv
-mPH
-vtx
-ogs
-ogs
-ogs
-xAN
+fXM
+nnL
+fXM
+nnL
+fXM
+nnL
+iad
+dlK
+opX
+opX
+opX
+opX
+opX
+opX
+opX
+opX
+opX
+jEk
 mMx
 xAN
 ogs
@@ -175485,31 +175299,31 @@ orc
 ogs
 ogs
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
 iad
-wCC
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-bHV
-tyL
-wCC
-wCC
-wCC
+oDj
+vbt
+qXJ
+qBO
+tqO
+qBO
+tqO
 iad
-sfH
-rPN
+eWv
+eWv
+dMk
+aqz
+dMk
+aqz
+dMk
+aqz
 iad
+ogs
+ogs
+ogs
+ogs
+ogs
+idG
+idG
 ogs
 ogs
 ogs
@@ -175937,31 +175751,31 @@ orc
 orc
 ogs
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
 iad
-qBO
-wCC
-bHV
-bHV
-bHV
-dMk
-wCC
-isB
-wCC
-dMk
-bHV
-uWE
-lZz
-wCC
+dha
+nSG
+nSG
+nSG
+nSG
+nnb
+jZa
+iad
 eWv
+eWv
+dMk
+lcZ
+dMk
+lcZ
+dMk
+lcZ
 iad
-xdz
-dJv
-iad
+ogs
+ogs
+ogs
+ogs
+ogs
+idG
+idG
 ogs
 nnq
 nnq
@@ -176389,11 +176203,11 @@ orc
 orc
 ogs
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
+iad
+iad
+iad
+iad
+iad
 iad
 iad
 iad
@@ -176407,13 +176221,13 @@ iad
 iad
 iad
 iad
-iad
-iGT
-iad
-iad
-iad
-iad
-iad
+ogs
+ogs
+ogs
+ogs
+idG
+idG
+idG
 nnq
 nnq
 vPq
@@ -176843,27 +176657,27 @@ orc
 ogs
 ogs
 ogs
+iad
+qdH
+dIX
+yeu
+yeu
+yeu
+dIX
+oBL
+iad
 ogs
 ogs
 ogs
 ogs
-iad
-iad
-iad
-wCC
-oDj
-jAe
-jAe
-iad
-uPP
-tWO
-nKF
-iad
-vrC
-wCC
-tUV
-uNj
-vtx
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
 ogs
 ogs
 nnq
@@ -177295,27 +177109,27 @@ orc
 ogs
 ogs
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-vtx
+iad
+eKr
+xUY
+iBO
+iBO
+iBO
 pWX
-wCC
-wCC
-wCC
-pxW
+umt
 iad
-fSB
-esm
-dTQ
-vtx
-wCC
-wCC
-wCC
-aoJ
-iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
 ogs
 ogs
 nnq
@@ -177747,27 +177561,27 @@ dIV
 ogs
 ogs
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-vtx
+iad
+bpF
+hDh
+oWO
+oWO
+oWO
 iRq
-wCC
-wCC
-wCC
-wCC
-pKR
-esm
-esm
-xBq
+cke
 iad
-htV
-iad
-htV
-iad
-iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
 ogs
 ogs
 nnq
@@ -178199,26 +178013,26 @@ tQC
 ogs
 ogs
 ogs
+iad
+cUj
+hzA
+nWc
+nWc
+nWc
+vPR
+cUj
+iad
 ogs
 ogs
 ogs
 ogs
 ogs
-iad
-pWX
-wCC
-wCC
-wCC
-wCC
-iad
-esm
-esm
-nKF
-iad
-wCC
-iad
-wCC
-iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
 ogs
 ogs
 ogs
@@ -178651,26 +178465,26 @@ xCK
 xCK
 ogs
 ogs
+iad
+pxW
+nWc
+nWc
+nWc
+nWc
+nWc
+bYT
+iad
 ogs
 ogs
 ogs
 ogs
 ogs
-iad
-wCC
-dau
-bgr
-wId
-oyV
-iad
-esm
-esm
-iad
-iad
-eHY
-iad
-eHY
-iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
 ogs
 ogs
 ogs
@@ -179103,26 +178917,26 @@ xCK
 xCK
 ogs
 ogs
+iad
+nWc
+cvU
+nWc
+cvU
+nWc
+cvU
+nWc
+iad
 ogs
 ogs
 ogs
 ogs
 ogs
-iad
-vtx
-vtx
-vtx
-iad
-iad
-iad
-pKR
-iad
-iad
-iad
-iad
-iad
-iad
-iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
 ogs
 ogs
 ogs
@@ -179555,25 +179369,25 @@ xCK
 xCK
 xCK
 xCK
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
 iad
-ekz
-rTT
-qdH
 iad
-oVj
-wCC
-wCC
 iad
-ezM
-rTT
-qdH
 iad
+iad
+iad
+iad
+iad
+iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+idG
 ogs
 ogs
 ogs
@@ -179995,7 +179809,7 @@ icp
 bfT
 miF
 bhJ
-ogs
+svv
 svv
 cqz
 ogs
@@ -180013,19 +179827,19 @@ ogs
 ogs
 ogs
 ogs
-iad
-mDc
-gmR
-ebP
-iad
-pSy
-wCC
-wCC
-iad
-vIv
-gmR
-gmR
-iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+idG
 ogs
 ogs
 ogs
@@ -180465,19 +180279,19 @@ ogs
 ogs
 ogs
 ogs
-iad
-bhE
-fiP
-ebP
-nOC
-rnI
-rnI
-rnI
-nOC
-ebP
-hqc
-mcU
-vtx
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+qzO
 fAL
 opX
 opX
@@ -180917,19 +180731,19 @@ xCK
 ogs
 ogs
 ogs
-iad
-iad
-iad
-iad
-iad
-kRO
-rnI
-rnI
-iad
-iad
-iad
-vtx
-vtx
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+qzO
 xAN
 urZ
 ylh
@@ -181369,19 +181183,19 @@ xCK
 xCK
 ogs
 ogs
-iad
-wTi
-ebP
-ebP
-nOC
-rnI
-rnI
-rnI
-hmJ
-ebP
-ebP
-ebP
-iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+idG
 xAN
 ylh
 mMx
@@ -181808,8 +181622,8 @@ bhJ
 bhJ
 svv
 iTM
-svv
-svv
+crl
+crl
 ogs
 ogs
 ogs
@@ -181819,21 +181633,21 @@ ogs
 xCK
 xCK
 xCK
-xCK
+fju
 ogs
-iad
-mDc
-gmR
-rTT
-iad
-iCz
-dkt
-iCz
-iad
-wkx
-lAF
-qXJ
-iad
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+idG
 xAN
 ylh
 mMx
@@ -182260,9 +182074,9 @@ bhJ
 svv
 iTM
 iTM
-iTM
-svv
-aCJ
+crl
+crl
+crl
 ogs
 ogs
 ogs
@@ -182271,21 +182085,21 @@ ogs
 ogs
 xCK
 xCK
-xCK
+fju
 ogs
-iad
-gtR
-fiP
-qdH
-vtx
-iad
-iad
-iad
-iad
-iad
-iad
-iad
-iad
+ogs
+ogs
+ogs
+ogs
+qzO
+idG
+idG
+idG
+idG
+idG
+idG
+idG
+idG
 xAN
 ylh
 mMx
@@ -182712,9 +182526,9 @@ iTM
 iTM
 iTM
 iTM
-iTM
-iTM
-iTM
+crl
+crl
+crl
 ogs
 ogs
 ogs
@@ -182725,11 +182539,11 @@ xCK
 xCK
 xCK
 ogs
-iad
-iad
-vtx
-vtx
-vtx
+idG
+idG
+qzO
+qzO
+qzO
 dlK
 opX
 opX
@@ -183164,10 +182978,10 @@ iTM
 iTM
 iTM
 dSz
-iTM
-iTM
-iTM
-iTM
+aCJ
+crl
+crl
+crl
 ogs
 ogs
 ogs
@@ -259573,7 +259387,7 @@ fpx
 fpx
 lNb
 lGv
-fpx
+rcz
 fpx
 fpx
 cCY
@@ -260026,6 +259840,10 @@ dQI
 fpx
 fpx
 fpx
+fpx
+rcz
+fpx
+rcz
 sGj
 sGj
 sGj
@@ -260036,10 +259854,6 @@ qyR
 qyR
 wLV
 oKW
-cne
-kac
-cne
-cqj
 sns
 sns
 sns
@@ -260475,6 +260289,10 @@ sns
 vOG
 sns
 sns
+agd
+iCz
+wyE
+wyE
 fpx
 qyR
 sGj
@@ -260488,10 +260306,6 @@ dkS
 qoV
 sGj
 enk
-vmk
-bUt
-raU
-ubv
 sns
 ehB
 sns
@@ -260927,6 +260741,10 @@ phl
 phl
 eBq
 sns
+sns
+taV
+exD
+wyE
 qyR
 oSE
 sGj
@@ -260940,10 +260758,6 @@ nbL
 iUO
 tXL
 enk
-vmk
-bUt
-raU
-ubv
 sns
 eJC
 sns
@@ -261379,6 +261193,10 @@ ggq
 phl
 sns
 sns
+sns
+taV
+exD
+exD
 oSE
 rfy
 sGj
@@ -261392,10 +261210,6 @@ nbL
 rKz
 dkS
 enk
-vmk
-bUt
-raU
-ubv
 sns
 eJC
 sns
@@ -261831,6 +261645,10 @@ dYv
 uBc
 sns
 sns
+sns
+taV
+exD
+wRJ
 sGj
 sGj
 sGj
@@ -261844,10 +261662,6 @@ nbL
 shy
 dkS
 enk
-vmk
-bUt
-ylp
-bsx
 sns
 qtp
 qxe
@@ -262283,6 +262097,10 @@ vGe
 uBc
 sns
 sns
+sns
+taV
+exD
+vYL
 sGj
 eRd
 aiM
@@ -262296,10 +262114,6 @@ nbL
 vRV
 dkS
 enk
-bUt
-bUt
-raU
-ubv
 sns
 sns
 sns
@@ -262735,6 +262549,10 @@ iIc
 phl
 sns
 sns
+sns
+taV
+exD
+fjY
 sGj
 mqz
 hoS
@@ -262748,10 +262566,6 @@ nbL
 vRV
 dkS
 enk
-bUt
-eNp
-xSH
-jiZ
 sns
 sns
 sns
@@ -263187,6 +263001,10 @@ flT
 cDX
 eBq
 sns
+sns
+taV
+exD
+ehB
 dkS
 nFN
 pbq
@@ -263200,10 +263018,6 @@ nbL
 vRV
 kKf
 enk
-bUt
-bUt
-raU
-ubv
 sns
 sns
 sns
@@ -263639,6 +263453,10 @@ eGj
 veW
 sns
 sns
+sns
+taV
+exD
+vYL
 sGj
 por
 hoS
@@ -263652,10 +263470,6 @@ tdZ
 qoV
 sGj
 nab
-cne
-hYo
-cne
-cqj
 sns
 sns
 sns
@@ -264091,6 +263905,10 @@ eGj
 jCu
 sns
 sns
+sns
+exS
+siF
+exD
 sGj
 qaK
 fGp
@@ -264104,10 +263922,6 @@ kDS
 kDS
 kDS
 fER
-ibZ
-fPZ
-fBn
-dHe
 exD
 sns
 sns
@@ -264543,6 +264357,10 @@ hYx
 nvJ
 sns
 sns
+sns
+sns
+sns
+eaL
 sGj
 sGj
 sGj
@@ -264556,10 +264374,6 @@ uhV
 lHe
 sRm
 lnA
-mYS
-pWT
-fpx
-exD
 exD
 sns
 sns
@@ -264568,7 +264382,7 @@ sns
 sns
 sns
 sns
-vOG
+sns
 sns
 pWT
 hLv
@@ -264995,9 +264809,13 @@ sns
 sns
 wND
 sns
+sns
+sns
+sns
+sns
 vWX
 nXy
-dQI
+bsC
 dQI
 sns
 sns
@@ -265008,10 +264826,6 @@ ntM
 hMR
 eDT
 ntM
-tEe
-exD
-exD
-exD
 sns
 fMy
 sns
@@ -265020,7 +264834,7 @@ sns
 sns
 ykm
 lgD
-vOG
+sns
 sns
 ogT
 dHP
@@ -265457,10 +265271,10 @@ mEK
 pxc
 sns
 sns
-sns
-sns
-sns
 vOG
+sns
+sns
+sns
 sns
 sns
 sns
@@ -265472,7 +265286,7 @@ sns
 kfC
 fpx
 nJH
-vOG
+sns
 sns
 sns
 sns
@@ -265909,9 +265723,6 @@ vOG
 sns
 sns
 sns
-sns
-sns
-sns
 vOG
 sns
 sns
@@ -265920,11 +265731,14 @@ sns
 sns
 sns
 sns
-shc
-iaB
 sns
-shc
-vOG
+sns
+sns
+sns
+sns
+sns
+sns
+sns
 sns
 sns
 sns
@@ -266361,10 +266175,10 @@ vOG
 sns
 sns
 xYz
-nqN
+nan
 sns
 sns
-vOG
+sns
 sns
 cKL
 sns
@@ -266372,12 +266186,12 @@ sns
 sns
 sns
 sns
-eKH
-eKH
-mow
-eKH
-phl
-eBq
+sns
+sns
+sns
+sns
+sns
+sns
 sns
 sns
 uCs
@@ -266819,18 +266633,18 @@ smL
 smL
 vgn
 qKs
-eBq
+rnI
+pKR
 sns
 sns
 sns
 sns
-eKH
-oWi
-wBe
-wBe
-eKH
-mhx
-cNK
+sns
+sns
+sns
+sns
+sns
+sns
 bMf
 sns
 feG
@@ -267271,18 +267085,18 @@ awX
 ehv
 bUt
 ggT
-oae
+ojQ
+rUQ
 sns
 sns
 sns
-fHg
 mow
-wBe
-wBe
-wBe
-mow
+jrn
+cEN
+jfF
+adV
 sns
-kfC
+sns
 fpx
 sns
 feG
@@ -267723,18 +267537,18 @@ cbR
 ehv
 bUt
 cMz
+rUQ
+gkG
 sns
 sns
+dWk
+eva
+cne
+oVj
+cne
+cDw
 sns
 sns
-phl
-phl
-rtc
-wBe
-smZ
-eKH
-eKH
-eja
 exO
 sns
 fUk
@@ -268178,16 +267992,16 @@ cMz
 sns
 sns
 sns
-kqG
-phl
-eKH
-aIi
-aIi
-aIi
-eKH
-eKH
-eKH
-rlj
+sns
+sns
+tGR
+vmk
+bUt
+raU
+xZU
+sns
+sns
+sns
 sns
 feG
 dGW
@@ -268630,15 +268444,15 @@ cMz
 sns
 sns
 sns
-eKH
-eKH
-eKH
-sRD
-puO
-puO
-eGS
-aRC
-eKH
+sns
+sns
+tGR
+vmk
+bUt
+raU
+xZU
+sns
+sns
 kFT
 sns
 feG
@@ -269080,18 +268894,18 @@ ehv
 bUt
 ate
 ntM
+vfl
 sns
 sns
-eKH
-umv
+sns
 tGR
-puO
-sRJ
-puO
-tkB
-eKH
-eKH
-eBq
+vmk
+bUt
+raU
+xZU
+sns
+sns
+sns
 uCs
 mPk
 llx
@@ -269532,19 +269346,19 @@ oCF
 bUt
 bwJ
 sns
-sns
-sns
-eKH
-jkr
-eyl
-puO
-puO
-puO
-puO
-nat
+vfl
 sns
 sns
 sns
+tGR
+vmk
+bUt
+ylp
+whK
+sns
+sns
+saG
+ybq
 mPk
 ncM
 lHc
@@ -269983,20 +269797,20 @@ pcB
 ehv
 bUt
 ggT
-oae
+eRr
+lAt
 sns
 sns
-eKH
-eyl
+sns
 tGR
-puO
-wij
-puO
-puO
-eKH
-eKH
-pZZ
+bUt
+bUt
+raU
+xZU
 sns
+sns
+pZZ
+ocm
 llx
 arI
 arI
@@ -270435,20 +270249,20 @@ cbR
 ehv
 bUt
 cMz
+rUQ
+qfA
 sns
 sns
 sns
-eKH
-eKH
-eKH
-mON
-puO
-puO
-puO
-cvU
-eKH
-xhH
+tGR
+bUt
+eNp
+xSH
+cVo
 sns
+sns
+hpr
+uAL
 llx
 hcv
 mAr
@@ -270887,20 +270701,20 @@ cbR
 qmc
 bUt
 cMz
+qfA
+rUQ
 sns
 sns
 sns
-eKH
-eKH
-eKH
-uAL
-uAL
-uAL
+tGR
+bUt
+bUt
+raU
 xZU
-eKH
-eKH
 sns
 sns
+hpr
+mCr
 llx
 rLJ
 cuJ
@@ -271339,20 +271153,20 @@ cbR
 ehv
 bUt
 cMz
+qfA
 sns
 sns
 sns
-eKH
-eKH
-jQJ
-jdu
-jdu
-jdu
-jdu
-eKH
-eKH
+dWk
+eva
+cne
+hYo
+cne
+cDw
 sns
 sns
+hpr
+uAL
 llx
 arI
 arI
@@ -271794,17 +271608,17 @@ ate
 ntM
 sns
 sns
-eKH
-mEm
-jdu
-neg
-neg
-neg
-jdu
-qHm
-els
 sns
 sns
+vTJ
+oPf
+bYk
+mWX
+dHe
+sns
+sns
+hMR
+eDT
 mPk
 fyq
 bQG
@@ -272243,18 +272057,18 @@ smL
 smL
 xvq
 qKs
-eBq
+jph
 sns
 sns
-eKH
-uEw
-jdu
-neg
-neg
-neg
-jdu
-jdu
-els
+sns
+sns
+sns
+sns
+sns
+sns
+sns
+sns
+sns
 sns
 uCs
 qia
@@ -272698,15 +272512,15 @@ dma
 sns
 sns
 sns
-eKH
-eKH
-jdu
-neg
-neg
-neg
-jdu
-oJT
-els
+sns
+sns
+sns
+sns
+hfn
+wag
+sns
+sns
+sns
 sns
 sns
 avD
@@ -273149,16 +272963,16 @@ exD
 exD
 sns
 sns
+gAQ
+qbr
+wFK
 sns
-eKH
-eKH
-niW
-jdu
-jdu
-jdu
-jdu
-eKH
-eKH
+hSA
+gAH
+sns
+sns
+sns
+sns
 sns
 sns
 uwY
@@ -273593,7 +273407,7 @@ qIJ
 rxp
 hgX
 gKR
-iNw
+ubv
 ryO
 qUB
 exD
@@ -273601,22 +273415,22 @@ exD
 exD
 aWT
 sns
+wij
+hLv
+scT
 sns
-qgd
-eKH
-cke
-jdu
+sns
 uvR
-uvR
-jdu
-rkS
-eKH
+sns
+sns
+sns
+sns
 xAF
 xAF
 exD
 uwY
 tXc
-iXr
+rRz
 cJT
 phl
 phl
@@ -274053,22 +273867,22 @@ dnE
 hEh
 wRJ
 sns
+hmp
+cBf
+aEu
 sns
 sns
-eKH
-eKH
-jdu
-uvR
-uvR
-phz
-eKH
-eKH
+sns
+sns
+sns
+sns
+sns
 exD
 exD
 exD
 exD
 cnb
-exD
+pWT
 ktD
 phl
 wss
@@ -274507,20 +274321,20 @@ sns
 sns
 sns
 sns
-exD
-eKH
-syb
-eKH
-eKH
-eKH
-eKH
-eKH
-exD
-exD
+sns
+sns
+sns
+sns
+sns
+sns
+sns
+sns
 exD
 exD
 exD
 exD
+exD
+pWT
 ffQ
 phl
 phl
@@ -274959,20 +274773,20 @@ xhO
 sns
 sns
 sns
-vAX
+sns
+xAF
+xAF
+xAF
+xAF
+xAF
+xAF
+xAF
+exD
+siF
 exD
 exD
 exD
-exD
-exD
-gAQ
-mZv
-exD
-exD
-exD
-exD
-exD
-exD
+pWT
 hRO
 uau
 uau
@@ -275404,7 +275218,7 @@ exD
 exD
 pWT
 pWT
-pWT
+lPk
 rgV
 lAO
 sns
@@ -275419,9 +275233,9 @@ exD
 exD
 exD
 exD
-exD
-pWT
-exD
+jAe
+sns
+uPP
 exD
 exD
 exD
@@ -275871,9 +275685,9 @@ sns
 sns
 qok
 pWT
-aFv
-pWT
-exD
+sns
+sns
+sns
 exD
 wfT
 exD
@@ -276323,9 +276137,9 @@ bge
 sns
 gkG
 gkG
-avX
-aFv
-pWT
+sns
+uLv
+sns
 exD
 exD
 exD
@@ -276775,9 +276589,9 @@ bge
 bge
 bge
 gkG
-qok
-pWT
-aFv
+sns
+sns
+umL
 pWT
 exD
 exD
@@ -277226,10 +277040,10 @@ bge
 bge
 bge
 bge
-qfA
-qfA
-qok
-avX
+rUQ
+dgc
+sns
+ooz
 aFv
 pWT
 lnE
@@ -277627,7 +277441,7 @@ fpx
 bge
 aFv
 mTe
-wMX
+ihP
 gZB
 njB
 hvv
@@ -277641,24 +277455,24 @@ jBu
 noZ
 jNP
 vVY
-fWy
-sZD
-gHl
-lVE
-qfA
-rUQ
-sns
-sns
-sns
-gkG
-rUQ
-qfA
-sns
-sns
-sns
-sns
-sns
-sns
+pWT
+pWT
+aFv
+wMX
+wWq
+wsf
+wsf
+wsf
+wsf
+wsf
+wWq
+wsf
+wsf
+wWq
+wsf
+wsf
+wsf
+wWq
 rUQ
 rUQ
 bge
@@ -277680,8 +277494,8 @@ bge
 bge
 bge
 rUQ
+iCY
 rUQ
-sns
 sns
 sns
 sns
@@ -278079,9 +277893,9 @@ fpx
 fpx
 fpx
 aFv
-lVE
-gZB
-mQr
+wMX
+wMX
+adH
 yap
 hvv
 yap
@@ -278093,25 +277907,25 @@ qVc
 edT
 edT
 iQE
-njB
-njB
-pWT
-lVE
-qfA
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
+fpx
+fpx
+aFv
+xkZ
+bIg
+pgL
+vAo
+kRA
+vAo
+tpg
+bZC
+ruD
+uWp
+bIg
+qML
+wbA
+xma
+bIg
+fpx
 bge
 bge
 bge
@@ -278529,40 +278343,40 @@ fpx
 fpx
 fpx
 fpx
-sxr
+bge
+bge
+bge
+bge
+bge
+bge
+bge
+hvv
+hvv
 pWT
-wMX
-gZB
-hvv
-hvv
-hvv
-hvv
-ldE
+nnJ
+njB
 pWT
-cnb
-exD
-jBu
 noZ
 edT
 lnA
+pWT
 njB
-rII
-vsW
-phl
-qfA
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
+pWT
+njB
+bIg
+pgL
+mqZ
+mqZ
+mqZ
+vAo
+bIg
+kpa
+uWp
+bIg
+kzy
+uQS
+nkG
+bIg
 bge
 bge
 bge
@@ -278981,40 +278795,40 @@ pWT
 njB
 pWT
 pWT
-njB
-aFv
-lVE
-gZB
-yap
+bge
+bge
+bge
+bge
+bge
+bge
+bge
+bge
+bge
+nnJ
+nnJ
+qKs
 pWT
 njB
-puz
-njB
 pWT
 njB
-exD
-ovf
-sZD
-sZD
-gHl
-aZo
 pWT
-pLh
-phl
-phl
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
-bge
+pWT
+njB
+njB
+bIg
+fdb
+mqZ
+ovA
+mqZ
+vAo
+bIg
+iCZ
+uWp
+bIg
+dTb
+uQS
+vIP
+bIg
 bge
 bge
 bge
@@ -279433,43 +279247,43 @@ pWT
 mQr
 tFL
 qyR
-pWT
-pLh
+bge
+bge
+bge
+bge
+bge
+bge
+bge
+bge
+nnJ
+nnJ
 phl
 phl
-vFh
+phl
 njB
-mQr
-rII
-pWT
-jiQ
-pWT
-lnE
-pWT
 njB
-pWT
-waf
-pWT
-pLh
-pLh
-phl
-phl
+njB
+njB
 phl
 phl
 pLh
-pLh
-pLh
-phl
-phl
-phl
-phl
-phl
-phl
-phl
-pLh
-phl
-phl
-phl
+bIg
+bPN
+mqZ
+lrk
+mqZ
+vAo
+bIg
+vBQ
+uWp
+gjv
+vDM
+uQS
+txn
+vxe
+uqB
+uqB
+uqB
 jWw
 jWw
 jWw
@@ -279885,46 +279699,46 @@ aZo
 qyR
 qyR
 qyR
-pLh
-pLh
+bge
+bge
+bge
+njB
+pWT
+pWT
+bge
+bge
 phl
 phl
 phl
-gyu
-gyu
-cDX
-gyu
-gyu
-cDX
-gyu
-gyu
-cDX
-gyu
-gyu
-cDX
+phl
+phl
 pLh
 phl
 phl
 phl
 phl
-phl
-phl
-phl
-phl
-phl
-phl
-phl
-phl
-phl
-phl
-phl
-phl
-phl
-phl
-phl
-jWw
-jWw
-jWw
+sLn
+lvT
+bIg
+nrO
+mqZ
+mXi
+mqZ
+vAo
+gjv
+tjj
+uWp
+sQw
+pav
+pav
+vxe
+jwe
+tga
+weQ
+weQ
+iWa
+iWa
+iWa
 hQG
 wGW
 hrE
@@ -280337,48 +280151,48 @@ qyR
 qyR
 qyR
 pWT
+bge
+bge
+bge
+pWT
+njB
+njB
+mWD
+njB
 phl
 phl
 cDX
 phl
-pLh
-lKO
-pqo
-lKo
-lKO
-pqo
-lKo
-lKO
-pqo
-lKo
-lKO
-pqo
-lKo
 phl
 phl
 phl
-phl
-phl
-phl
-phl
-phl
-phl
-phl
-pLh
-pLh
-phl
-phl
-phl
-phl
-phl
-phl
-phl
-phl
-jWw
-jWw
+pyE
+fJL
+pyE
+sLn
+qFy
+bIg
+vAJ
+mqZ
+bpK
+mqZ
+vAo
+uMf
+uWp
+uWp
+ggg
+xZf
+iZi
+vxe
+cpa
+pyE
+weQ
+weQ
+iWa
+iWa
 cIt
 dXR
-fOB
+shc
 qIg
 rBm
 bgY
@@ -280789,45 +280603,45 @@ wyE
 qyR
 qyR
 njB
-phl
-phl
-phl
-pLh
-pLh
-gyu
-gyu
-cDX
-gyu
-gyu
-cDX
-gyu
-gyu
-cDX
-gyu
-gyu
-cDX
+bge
+bge
+bge
+pWT
+fGv
+uYm
+tKP
+pWT
 phl
 phl
 phl
 phl
 pLh
-pLh
-pLh
 phl
 phl
-phl
-pLh
-phl
-phl
-phl
-pLh
-pLh
-pLh
-phl
-phl
-phl
-hrE
+pyE
+cXk
+pyE
+pyE
+pyE
+gjv
+vAo
+mqZ
+mqZ
+mqZ
+vAo
+ggg
+fMx
+uWp
+bIg
+ogR
+pyE
+pyE
+pyE
+cpa
+uqB
+jdk
 jWw
+iWa
 oLY
 hQG
 fOB
@@ -281241,47 +281055,47 @@ qyR
 jiQ
 pWT
 rII
+bge
+bge
+bge
 njB
-phl
-phl
-pLh
-rMf
-mgq
-nwG
-nwG
-nwG
-rni
-rMf
-mgq
-nwG
-nwG
-nwG
-rni
-rMf
-phl
-phl
-phl
-pLh
-pLh
-rni
-rni
-bAU
+jCt
+uJY
+mWD
+mWD
+mWD
+wWq
+vxe
+dPu
+vxe
+dPu
+vxe
+pyE
+hXX
+xZf
+xZf
+xZf
+jUL
+vAo
+vAo
+uEt
+hWA
 xCL
-rMf
-rMf
+bIg
+wnD
+uWp
+gjv
+xZf
+xZf
 weQ
 weQ
 weQ
-weQ
-weQ
-weQ
-weQ
-sRn
+iCI
 gzy
-gzy
+uqB
 jWw
 jWw
-fOB
+laF
 fOB
 jWw
 xOI
@@ -281693,42 +281507,42 @@ pWT
 pWT
 pWT
 pWT
-pWT
-lKo
-pqo
-lKo
-uhI
-uhI
-uhI
-uhI
-uhI
-uhI
-uhI
-uhI
-rMf
-rMf
-rMf
-rMf
-uhI
-rMf
-phl
-phl
-pLh
-rMf
-rMf
-uhI
-uhI
-dMi
-uhI
+bge
+bge
+bge
+bge
+jWn
+daQ
+daQ
+daQ
+daQ
+bIg
+vFh
+hbx
+uWp
+vxe
+vxe
+dPu
+vxe
+wWq
+oIo
+jUL
+wWq
+oIo
+rrN
+aVY
+wsf
+rfb
+wWq
+wsf
+xsk
+wWq
+wsf
+xsk
+wsf
+wWq
 weQ
-weQ
-weQ
-weQ
-weQ
-weQ
-weQ
-weQ
-sRn
+gzy
 gzy
 gzy
 gzy
@@ -282137,8 +281951,6 @@ fpx
 exD
 exD
 exD
-fpx
-fpx
 pWT
 tXM
 fLz
@@ -282146,41 +281958,43 @@ bax
 bax
 tAO
 pWT
-lKo
-lKO
-lKo
-rMf
-uhI
-uhI
-tYN
-waL
-uhI
-rMf
-rMf
-vlL
-rMf
-rMf
-waL
-uhI
-uhI
-rMf
-phl
-rMf
-rMf
-uhI
-uhI
-uhI
-nTh
-rMf
-gUZ
-vxe
-vxe
-vxe
-vxe
+bge
+bge
+bge
+bge
+bge
+jWn
+daQ
+daQ
+tKP
+jWn
+bIg
+lfI
+lfb
+uWp
+wmt
+uWp
+crD
+uWp
+gjv
+jiA
+jiA
+gjv
+kBZ
+jiA
+jiA
+wNM
+bHU
+mIj
+bHU
+bHU
+bHU
+lDK
+bHU
 uQs
-vxe
-vxe
-vnq
+bIg
+aYU
+gzy
 gzy
 gzy
 gzy
@@ -282588,9 +282402,7 @@ fpx
 fpx
 exD
 exD
-exD
-fpx
-pwF
+eKa
 bax
 iZO
 fpx
@@ -282598,48 +282410,50 @@ fpx
 fpx
 lAi
 fLz
-fZu
-gyu
-cDX
-mgq
-uhI
-uhI
-waL
-aat
-aat
-rMf
-rMf
-rMf
-izp
-aat
-aat
-tYN
-uhI
-uhI
-rMf
-rMf
-rMf
-rMf
-rMf
-uhI
-nTh
-uhI
+pbL
+bge
+bge
+bge
+bge
+kVf
+daQ
+daQ
+jWn
+amM
+bIg
+jWl
+uWp
+uWp
 vxe
-vxe
+uWp
+uWp
+uWp
+dOj
+fZT
+fZT
+vKj
+fZT
+fZT
+fZT
+gxw
+bbz
 gIs
-tga
-bPN
-tjY
-bpK
-vxe
-vxe
+gIs
+gIs
+gIs
+gIs
+bbz
+yhX
+bIg
 nXW
-pww
-pww
-nTh
-njP
-ppQ
-rMf
+weQ
+nXW
+weQ
+weQ
+gzy
+gzy
+gzy
+gzy
 jQE
 uMp
 teu
@@ -283040,9 +282854,7 @@ qhj
 exD
 exD
 exD
-exD
-fpx
-eFM
+aQt
 fpx
 fpx
 fpx
@@ -283050,46 +282862,48 @@ fpx
 fpx
 fpx
 fpx
-dsl
-pqo
-lKo
+vSY
+bge
+bge
+bge
+bge
 bAU
-uhI
-uhI
-rMf
+daQ
+daQ
+pWT
+amM
+bIg
+vxe
+dPu
+vxe
+dPu
+uWp
 aat
 aat
-aat
-uhI
-rMf
-aat
-aat
-aat
-aat
-uhI
-rMf
-rMf
-uhI
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
+ggg
+huV
+lzQ
+akc
+huV
+lzQ
+njj
+wic
+bbz
+phw
+rTU
 gjo
-tjY
-tjY
-tjY
-tjY
-tjY
-tjY
-vxe
-dEQ
+bZJ
+oLl
+hao
+bHU
+bIg
+oIo
+hkj
+aVY
 aHM
-aHM
-rni
 nTh
+njP
+ppQ
 rMf
 rMf
 jQE
@@ -283490,10 +283304,8 @@ wnM
 fpx
 fpx
 exD
-exD
-exD
 eKa
-ksg
+cEM
 rYO
 fpx
 fpx
@@ -283502,47 +283314,49 @@ fpx
 fpx
 fpx
 fpx
-dsl
-lKO
-lKo
+vSY
+bge
+bge
+bge
+bge
 bAU
-uhI
-waL
-rMf
-rMf
-aat
-vlL
-uhI
-uhI
-rMf
-rMf
-rMf
-rMf
-rMf
-rMf
-vxe
-vxe
-vxe
-gKk
+daQ
+jWn
+pWT
+pWT
+bIg
+vFh
+hbx
 uWp
 vxe
+uWp
+grk
+qkv
+bIg
+qIt
+qIt
+ggg
+gKk
+gKk
+gKk
+wsf
 aLr
 tbZ
-jiA
-jiA
-jiA
-jiA
-jiA
-vxe
-tXs
+vwo
+vwo
+iuM
+gCd
+hao
+bHU
+bIg
 iND
-vxe
 vSw
-cpI
-noW
-noW
-pww
-jJH
+vSw
+bIg
+lSR
+nTh
+kAx
+kAx
 rMf
 jQE
 weQ
@@ -283943,8 +283757,6 @@ fpx
 exD
 exD
 exD
-exD
-exD
 aFa
 tUy
 fpx
@@ -283954,46 +283766,48 @@ fpx
 fpx
 fpx
 fpx
-rnN
-gyu
-cDX
-nwG
-uhI
-waL
-aat
-rMf
-uhI
-uhI
-uhI
-rMf
-rMf
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-gpw
+vSY
+bge
+bge
+bge
+bge
+bAU
+daQ
+jWn
+amM
+pWT
+bIg
+lfI
+lfb
 uWp
-vxe
-vAo
-byl
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-vxe
-fdb
-fSz
-vxe
-huL
-noW
-jjT
-noW
+cwe
+uWp
+nAZ
+dWM
+wWq
+wsf
+wsf
+wWq
+pRi
+gpw
+rpi
+uQf
+bbz
+kJS
+kJS
+kJS
+kJS
+kJS
+bbz
+bHU
+dtH
+nDt
+vSw
+mQw
+bIg
+crj
 pww
+jJH
 rMf
 rMf
 jQE
@@ -284394,8 +284208,6 @@ fpx
 fpx
 exD
 exD
-exD
-exD
 uTJ
 uSl
 tUy
@@ -284406,47 +284218,49 @@ fpx
 fpx
 fpx
 fpx
-dsl
-pqo
-lKo
-rni
-uhI
-vlL
-aat
+vSY
+bge
+bge
+bge
+bge
+kVf
+daQ
+jhP
+amM
+pWT
+bIg
+jWl
+uWp
+uWp
+vxe
+tXs
+tYN
+tYN
+bIg
+wWL
+dtH
+akc
+lvE
+gpw
+dir
+uQf
+bHU
+bHU
+bHU
+bHU
+bHU
+bHU
+bHU
+bHU
+niY
+jiA
+jiA
+jxB
+bIg
+deO
+iaB
 rMf
 rMf
-uhI
-rMf
-rMf
-vxe
-vxe
-wWq
-wsf
-wsf
-wsf
-wsf
-wsf
-wsf
-wsf
-drS
-wsf
-wsf
-wsf
-wWq
-huV
-fAA
-fAA
-fAA
-vxe
-vxe
-vxe
-vxe
-vxe
-lnu
-noW
-noW
-njP
-msF
 rMf
 jQE
 weQ
@@ -284844,8 +284658,6 @@ fpx
 jTf
 fpx
 fpx
-fpx
-exD
 exD
 exD
 uTJ
@@ -284858,23 +284670,25 @@ fpx
 fpx
 fpx
 fpx
-dsl
-lKO
-lKo
-rMf
-uhI
-rMf
-rMf
-izp
-rMf
-rMf
+vSY
+bge
+bge
+bge
+jCt
+njB
+daQ
+njB
+pWT
+rII
+bIg
 vxe
+dPu
 vxe
-vxe
+dPu
+uWp
+uWp
+uWp
 wWq
-akc
-kRA
-shj
 lpr
 uBe
 piN
@@ -284883,23 +284697,23 @@ wyi
 dir
 uQf
 fZc
-piN
-wWq
-wWq
+bHU
 ciG
-fAA
-fAA
-hPG
-bcB
-bcB
-iXI
-vxe
-cOh
-awz
-noW
-nTh
+bHU
+ciG
+bHU
+ciG
+bHU
+fZT
+fZT
+fZT
+hGk
+bIg
+deO
+njP
+msF
 rMf
-rMf
+rGA
 jQE
 weQ
 weQ
@@ -285296,8 +285110,6 @@ fpx
 fpx
 fpx
 fpx
-fpx
-fpx
 exD
 exD
 uTJ
@@ -285310,48 +285122,50 @@ fpx
 fpx
 fpx
 fpx
-rnN
-gyu
-cDX
-rMf
-rMf
-rMf
-rMf
-rMf
-rMf
-weQ
-vxe
-vxe
-vxe
+vSY
+bge
+bge
+uJY
+jWn
+pWT
+pWT
+pWT
+pWT
+pWT
 bIg
-ihP
+bpb
+myt
+uWp
+uWp
+uWp
 rXn
-nix
-ewz
-tCI
-uBe
-lvE
-rbU
-uBe
-lvE
-rbU
-uBe
-vWB
+rXn
 bIg
-vxe
-feo
-vxe
-vxe
-kpa
-bcB
-tlk
-vxe
-cOh
-noW
-noW
-pww
-jJH
-rMf
+ewz
+dtH
+akc
+lvE
+gpw
+dir
+uQf
+bHU
+bHU
+bHU
+bHU
+bHU
+bHU
+bHU
+bHU
+lzQ
+lzQ
+lzQ
+eNM
+bIg
+gei
+nTh
+kAx
+kAx
+vAw
 jQE
 weQ
 weQ
@@ -285748,9 +285562,7 @@ fpx
 njB
 pWT
 njB
-fpx
-nIq
-exD
+wIl
 exD
 uTJ
 uSl
@@ -285762,48 +285574,50 @@ fpx
 fpx
 fpx
 fpx
-dsl
-pqo
-lKo
-nwG
-uhI
-rMf
-rMf
-rMf
-weQ
-weQ
-xZf
-oPm
-vxe
+vSY
+bge
+bge
+jWn
+daQ
+bAU
+daQ
+pWT
+pWT
+pWT
 bIg
+eIK
+fAA
+uWp
+uWp
+uWp
 ssc
-rXn
-uzO
-ddf
-dir
-tCI
+gFC
+wWq
+wsf
+wsf
+wWq
 hFP
-qdL
-tCI
+gpw
+xhP
 eSD
 bbz
-fIG
-uBe
+gIs
+gIs
+gIs
+gIs
+bHU
+bbz
+bHU
+dtH
+nDt
+vSw
+mQw
 bIg
-oyx
-tjY
-tjY
-vxe
-wXL
-bcB
-rTU
-vxe
-eXA
-dNg
-noW
+gei
 pww
+jJH
 rMf
-rMf
+vAw
 jQE
 weQ
 weQ
@@ -286200,8 +286014,6 @@ njB
 mhj
 njB
 pWT
-njB
-fpx
 exD
 exD
 uTJ
@@ -286214,46 +286026,48 @@ khe
 pMc
 pMc
 pMc
-dsl
-lKO
-lKo
-waL
-uhI
-tYN
-rMf
-rMf
-weQ
-weQ
-xZf
+vSY
+bge
+bge
+nix
+daQ
+vsW
+daQ
+tKP
+pWT
+pWT
+bIg
+vxe
+dPu
 cwe
+dPu
+vxe
+dPu
 vxe
 bIg
-uWp
-rXn
-sQw
 noc
-uBe
-phw
+noc
+akc
 igK
-vIP
-dir
-igK
-vIP
+gKk
+gKk
+wsf
+aLr
 phw
 tCI
+gjo
+gjo
+oLl
+hao
+bHU
+mXV
+vSw
+agm
+kCs
 bIg
-qIt
-tjY
-tjY
-vxe
-vxe
-vxe
-vxe
-vxe
-kbS
-heB
-noW
+uMM
 pww
+kAx
 rMf
 rMf
 jQE
@@ -286652,8 +286466,6 @@ aCr
 qfA
 mKI
 mhj
-pWT
-exD
 exD
 exD
 uTJ
@@ -286666,48 +286478,50 @@ fpx
 fpx
 fpx
 fpx
-rnN
-gyu
-cDX
-waL
-waL
-uhI
-uhI
-rMf
-weQ
-weQ
-xZf
-sWV
-vxe
+vSY
+bge
+bge
+nix
+daQ
+vsW
+jWn
+daQ
+daQ
+pWT
 bIg
+vFh
+hbx
+uWp
+vxe
+fSz
 dgz
-uWp
-uWp
-ewz
-tCI
-wWq
-bOt
-tCI
-uBe
-dir
-tCI
-wWq
-bOt
-wWq
+mvH
+gjv
+oyx
+jiA
 akc
+oyx
+jiA
+ocA
+dat
+bbz
+bVW
+bOt
+vwo
+oUL
 gCd
-tjY
-bpK
-gjo
-vxe
-vxe
-aaE
-weQ
-pyE
-noW
-njP
-ppQ
-vAw
+hao
+bHU
+wWq
+wsf
+wsf
+wsf
+wWq
+deO
+pww
+kAx
+rMf
+rMf
 jQE
 weQ
 teu
@@ -287106,8 +286920,6 @@ qfA
 qfA
 uSx
 exD
-exD
-exD
 uTJ
 uSl
 tUy
@@ -287118,48 +286930,50 @@ fpx
 fpx
 fpx
 fpx
-dsl
-pqo
-lKo
+vSY
+bge
+bge
+uJY
+daQ
 dqi
 vOt
-dqi
-uhI
-weQ
-weQ
-weQ
-xZf
-cyA
-vxe
+qNn
+daQ
+sns
 bIg
-kSj
-pbK
+lfI
+lfb
 uWp
-fdR
-bZJ
-uQf
-uBe
-dir
-tCI
-uBe
-dir
-uQf
-uBe
+dPu
+fSz
+kSj
+sLn
+stc
+fZT
+fZT
+vKj
+fZT
+fZT
+fZT
+gxw
+bbz
 kJS
-dtH
-tjY
-tjY
-tjY
-tjY
-gjo
-vxe
+kJS
+kJS
+kJS
+kJS
+bbz
+yhX
+bIg
+rGA
+rMf
 cGC
-weQ
-fSG
-weQ
-weQ
+qvp
+usN
+njP
+ppQ
 vAw
-rLU
+vAw
 jQE
 weQ
 lqg
@@ -287556,8 +287370,6 @@ qfA
 qUL
 qfA
 qdA
-qfA
-exD
 exD
 exD
 uTJ
@@ -287570,47 +287382,49 @@ fpx
 fpx
 fpx
 fpx
-dsl
-lKO
-lKo
+vSY
+bge
+bge
+oYb
+daQ
 hLN
-weQ
-weQ
-weQ
-weQ
-weQ
-weQ
-xZf
-wsu
-vxe
-dtH
+sns
+sns
+sns
+sns
 bIg
+jWl
+fmU
+uWp
+vxe
+fSz
+kSj
 mvH
-jiA
-aLr
-jiA
-jiA
-jiA
-jiA
-jiA
-jiA
-jiA
-jiA
-jiA
-jiA
+ggg
+lzQ
+lzQ
+ggg
+byl
+lzQ
+lzQ
+wic
 bHU
-jiA
-jiA
-jiA
-jiA
-jiA
-bSa
-weQ
-weQ
-ncy
-weQ
-wkv
-xDj
+dqz
+bHU
+bHU
+bHU
+dqz
+bHU
+bHU
+bIg
+wEV
+rMf
+ddf
+fSG
+noW
+vQt
+vAw
+mFr
 xDj
 weQ
 weQ
@@ -288008,9 +287822,7 @@ qfA
 tZa
 qfA
 nlW
-uIr
-exD
-exD
+nSj
 exD
 uTJ
 uSl
@@ -288022,46 +287834,48 @@ fpx
 fpx
 fpx
 rcz
-rnN
-gyu
-cDX
+vSY
+bge
+bge
+bge
+xeD
 hLN
-weQ
-weQ
-weQ
-weQ
-weQ
-pGZ
-xZf
-wsu
+sns
+sns
+hLv
+sns
+wWq
 vxe
-dtH
-bIg
-cpa
-fZT
-vKj
+dPu
+vxe
+dPu
+vxe
+dPu
+vxe
+wWq
+oIo
 aNj
-fZT
-fZT
-fZT
-xHI
-fZT
-fZT
-fZT
-fZT
-fZT
-fZT
-fZT
-fZT
-xHI
-fZT
-fZT
-vxe
+wWq
+wsf
+wsf
+wsf
+wsf
+xsk
+wsf
+wsf
+xsk
+wsf
+wsf
+xsk
+wsf
+wWq
+noW
+noW
 ufK
-weQ
-ncy
-weQ
-vQt
+noW
+noW
+wxR
+xDj
 weQ
 weQ
 weQ
@@ -288463,8 +288277,6 @@ rYO
 vaq
 exD
 exD
-exD
-exD
 aFa
 tUy
 fpx
@@ -288474,46 +288286,48 @@ fpx
 fpx
 fpx
 fpx
-dsl
-pqo
-lKo
+vSY
+bge
+bge
+bge
+daQ
 hLN
-weQ
-weQ
-weQ
-weQ
-weQ
-weQ
-xZf
-wsu
-vxe
-dtH
+sns
+sns
+sns
+sns
 bIg
-sUn
-lzQ
-vAo
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-bSa
+vxe
+snb
+cXk
+uPI
+cXk
+cXk
+uPI
+cXk
+cXk
+uPI
+cXk
+mcU
+ovY
+ovY
+ovY
+ovY
+ovY
+ovY
+ovY
+ovY
+ovY
+ovY
+ovY
+ovY
+noW
+noW
+tKV
+noW
+noW
 weQ
-weQ
-ncy
-weQ
-wxR
+baE
 baE
 baE
 baE
@@ -288914,10 +288728,8 @@ qfA
 nlW
 nPJ
 exD
-exD
-exD
-wZp
-eZu
+uwY
+tXc
 rYO
 fpx
 fpx
@@ -288926,48 +288738,50 @@ fpx
 fpx
 fpx
 fpx
-dsl
-lKO
-lKo
+vSY
+bge
+bge
+bge
+bge
+tgY
 xZw
 xZw
-xZw
-uhI
-weQ
-weQ
-weQ
-xZf
-cwe
-vxe
-bIg
+daQ
+sns
+wWq
+wsf
+wsf
+wsf
+wsf
+wsf
 dnA
-pbK
-uWp
+wsf
+wsf
 mnB
-iuM
+wsf
+wsf
+wWq
 ovY
-kMx
-xwF
-ruD
-kMx
-xwF
+wWq
 ovY
-kMx
-xwF
-dtH
-jwe
-tjY
-tjY
-tjY
-huV
-vxe
-cGC
-weQ
-fSG
-weQ
-weQ
-vAw
+wWq
+ovY
+wWq
+ovY
+wWq
+ovY
+wWq
+sZH
+wWq
+rkS
+noW
+agp
+noW
+noW
+njP
+mkj
 fXm
+vAw
 vAw
 vAw
 vAw
@@ -289364,61 +289178,61 @@ qfA
 qfA
 gGS
 uqL
-qfA
 exD
 exD
 exD
 exD
-fpx
-kzy
-fpx
+brE
 fpx
 fpx
 fpx
 fpx
 fpx
 fpx
-rnN
-gyu
-cDX
-aat
-aat
-uhI
-uhI
+fpx
+vSY
+bge
+bge
+bge
+bge
+vsW
+amM
+daQ
+daQ
+pWT
+uqB
+uqB
+uqB
+weQ
+weQ
+lkJ
+dkt
+lkJ
+dkt
+lkJ
+dkt
+lkJ
+dkt
+lkJ
+gmR
+lkJ
 rMf
-weQ
-weQ
-xZf
-sWV
-vxe
-bIg
-dgz
-uWp
-uWp
-xFl
-ruD
-wWq
-wfS
-ruD
-kMx
-xwF
-ruD
-wWq
-wfS
-wWq
-akc
-gCd
-tjY
-qML
-huV
-vxe
-vxe
-aaE
-weQ
-agp
+rMf
+qgS
+rMf
+rMf
+rMf
+qgS
+rMf
+rMf
+rMf
+rMf
+smR
+fSG
 noW
-njP
-ppQ
+nTh
+rMf
+rMf
 rMf
 rMf
 rMf
@@ -289816,13 +289630,11 @@ gTf
 qfA
 tWP
 uQM
-qfA
 exD
 exD
 exD
 exD
-fpx
-wZp
+uwY
 miv
 tQj
 fpx
@@ -289830,46 +289642,48 @@ fpx
 fpx
 sLN
 xGG
-dFa
-pqo
-lKo
-aat
-rMf
-tYN
-rMf
-rMf
+rji
+bge
+bge
+bge
+bge
+vsW
+pWT
+tKP
+pWT
+pWT
+uqB
+uqB
+uqB
 weQ
 weQ
-xZf
-cyA
-vxe
-bIg
-wic
-rXn
-txn
-dWM
-kMx
-xHQ
-key
-fUm
-xwF
-key
-fUm
-xHQ
-ruD
-bIg
-agm
-tjY
-tjY
-vxe
-vxe
-vxe
-vxe
-vxe
-xSh
-usN
+dkt
+pEB
+dkt
+pEB
+dkt
+pEB
+dkt
+pEB
+dkt
+pEB
+dkt
+dPu
+dPu
+dPu
+dPu
+dPu
+dPu
+dPu
+dPu
+rMf
+rMf
+rMf
+crj
+noW
 noW
 nTh
+rMf
 rMf
 aJK
 aym
@@ -290268,13 +290082,11 @@ njB
 tWP
 qyR
 njB
-qfA
 exD
 exD
 exD
 exD
-exD
-rfc
+vaq
 pWT
 uHL
 sZD
@@ -290282,46 +290094,48 @@ sZD
 sZD
 rRz
 njB
-lKo
-lKO
-lKo
+bge
+bge
+bge
+bge
+bge
 bAU
-uhI
-uhI
-rMf
-rMf
-weQ
-weQ
-xZf
+daQ
+daQ
+njB
+njB
+jdk
+uqB
+uqB
 oPm
-vxe
-bIg
-gxw
-rXn
-oAc
-mnB
-xwF
-ruD
-jvx
-oYb
-ruD
-vwo
-pOI
-jyZ
-kMx
-mXV
-tjY
-tjY
-tjY
-vxe
-hbx
-njj
-vUp
-vxe
-eXA
+weQ
+lkJ
+dkt
+hqc
+hqc
+hqc
+hqc
+hqc
+hqc
+hqc
+dkt
+lkJ
+dPu
+sXr
+tDn
+sLn
+sRn
+wzF
+sLn
+pLb
+rMf
+rMf
+mbG
+deO
 noW
 noW
 nTh
+rMf
 rMf
 qQo
 oSt
@@ -290726,54 +290540,54 @@ exD
 exD
 exD
 exD
-fpx
-pWT
 jiQ
 qyR
 pWT
 aZo
 pWT
 ncw
-cDX
-hJC
-cDX
-uhI
-uhI
-uhI
-uhI
-rMf
+bge
+bge
+bge
+bge
+bge
+pWT
+daQ
+fGv
+daQ
+pWT
+uqB
+uqB
+jdk
 weQ
 weQ
-vxe
-vxe
-vxe
-bIg
-bZC
-rXn
-sQw
-xFl
-ruD
-kMx
-kAv
-lUs
-kMx
-kAv
-lUs
-kMx
-ovA
-bIg
-vxe
-lSo
-vxe
-vxe
-qat
-uQS
-xmQ
-vxe
-eXA
+dkt
+pEB
+wTi
+oWi
+aoM
+eyl
+ida
+oWi
+wTi
+pEB
+dkt
+dPu
+dZz
+dPu
+iFA
+sLn
+byI
+sLn
+dPu
+lLV
+lLV
+njP
+jkr
 noW
 noW
 nTh
+rMf
 kAx
 oSt
 pSa
@@ -291178,53 +290992,53 @@ exD
 exD
 exD
 fpx
-fpx
-pWT
 tFL
 qyR
 njB
 pWT
 oOv
 aFv
-lKo
-jdu
-lKo
-rni
-rMf
-izp
-rMf
-uhI
+bge
+bge
+bge
+bge
+bge
+kVf
+pWT
+rII
+pWT
+daQ
+uqB
+uqB
+jdk
 weQ
 weQ
-vxe
-vxe
-vxe
-wWq
-akc
-kRA
+lkJ
+dkt
 vDT
-mmy
-kMx
-adH
-maL
-ocA
-xwF
-bVl
-dTb
-adH
-wWq
-wWq
-wNM
-uQS
-wfI
-vxe
-sZm
-bvB
-rQv
-vxe
+mHf
+syz
+syz
+syz
+rSH
+vDT
+dkt
+lkJ
+dPu
+sLn
+skw
+sLn
+sLn
+pJG
+sLn
+sOa
+dKe
+dKe
+ezM
+njP
 cOh
 noW
-noW
+nTh
 qQo
 oSt
 qQo
@@ -291630,53 +291444,53 @@ exD
 exD
 exD
 fpx
-pWT
-pWT
 mQr
 qyR
 qyR
 njB
 aFv
 aFv
-lKo
-jdu
-lKo
-nwG
-vlL
-rMf
-uhI
-uhI
+bge
+bge
+bge
+bge
+bge
+bAU
+jhP
+pWT
+daQ
+daQ
+uqB
+uqB
+uqB
 weQ
 weQ
-rMf
-nwG
-vxe
-vxe
-wWq
-wsf
-wsf
-wsf
-wsf
-wsf
-wsf
-wsf
-kVf
-wsf
-wsf
-wsf
-wWq
-qFy
-xZf
-enm
-hao
-vxe
-uQS
-lUZ
-mQb
-vxe
-cOh
+dkt
+pEB
+vDT
+syz
+foK
+foK
+foK
+syz
+vDT
+pEB
+dkt
+dPu
+haq
+sLn
+sLn
+sLn
+oYo
+sLn
+sOa
+dKe
+dKe
+dKe
+lLV
 noW
 noW
+nTh
 nII
 axM
 jgU
@@ -292082,53 +291896,53 @@ exD
 exD
 exD
 fpx
-jiQ
-tFL
 qyR
 qyR
 qyR
 qyR
 pWT
 hyp
-cDX
-jdu
-cDX
-nwG
-rMf
-uhI
-uhI
-uhI
-weQ
-weQ
-rMf
-uhI
+bge
+bge
+bge
+bge
+bge
 bAU
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-ogR
-crD
-pBF
-uWp
-amM
-fJL
-pRi
-vxe
-mXi
-ggg
-xZf
-pav
-mno
-sna
-tgY
-xOC
-vxe
-lnu
+pWT
+daQ
+daQ
+daQ
+jdk
+uqB
+uqB
+weQ
+weQ
+lkJ
+dkt
+vDT
+sfH
+fSz
+drE
+fSz
+rSH
+vDT
+dkt
+lkJ
+dPu
+rUb
+sLn
+ibZ
+sLn
+qZN
+sLn
+sOa
+dKe
+dKe
+dKe
+lLV
 noW
-msF
+noW
+nTh
 nII
 lZu
 qha
@@ -292534,52 +292348,52 @@ exD
 exD
 xzx
 fpx
-pWT
-pWT
 njB
 qyR
 qyR
 qyR
 njB
 aFv
-lKo
-jdu
-lKo
+bge
+bge
+bge
+bge
+jcT
 pqC
-rMf
-uhI
-uhI
-rMf
+pWT
+daQ
+daQ
+pWT
+jdk
+uqB
+jdk
 weQ
 weQ
-rMf
-vlL
-uhI
-dqE
-rMf
-uhI
-weQ
-weQ
-vER
-uWp
-uWp
-uWp
-uWp
-uWp
-uWp
-iCZ
-vxe
-tjj
-xsf
-utH
-pCk
-vxe
-vxe
-vxe
-vxe
-vxe
-pBH
-tKV
+dkt
+pEB
+vDT
+oWi
+oWi
+oWi
+aoM
+wkv
+vDT
+pEB
+dkt
+dPu
+xdz
+sLn
+vBu
+aOc
+sLn
+bhE
+dPu
+wQL
+dKe
+mON
+njP
+noW
+rkS
 nTh
 nII
 xQT
@@ -292986,53 +292800,53 @@ exD
 exD
 fpx
 fpx
-pWT
-njB
 pMG
 wyE
 qyR
 pWT
 aFv
 ftO
-lKo
-jdu
-lKo
+aFv
+aFv
+bge
+bge
+jcT
 xyS
-kAx
+njB
 aBq
-vlL
+jhP
 lKw
+rLB
+uqB
+jdk
 weQ
 weQ
-rMf
-rMf
-rMf
-uhI
-rMf
-rMf
-weQ
-weQ
-vxe
-iAM
-uWp
-uWp
-uWp
-uWp
-fAA
-wFJ
-vxe
-grk
-xsf
-xZf
-rTE
-vxe
-fbW
-oLl
-iZi
-vxe
-tOx
-noW
-noW
+lkJ
+dkt
+kac
+mXZ
+mXZ
+mXZ
+rTT
+syz
+vDT
+dkt
+lkJ
+dPu
+dPu
+vUZ
+dPu
+dPu
+kRO
+dPu
+vUZ
+lLV
+lLV
+njP
+jkr
+tKV
+nTh
+njP
 nII
 vUy
 qha
@@ -293446,45 +293260,45 @@ njB
 jiQ
 ftO
 aFv
-cDX
-jdu
-cDX
+pWT
+bge
+izp
 paw
 mbx
-kAx
-rMf
-wxu
+njB
+pWT
+aZo
+uqB
+uqB
+uqB
 weQ
 weQ
-weQ
-weQ
-weQ
-weQ
-weQ
-weQ
-weQ
-nDt
-vxe
-fAA
-nrO
-nrO
-uWp
-uWp
-woi
-jiV
-vxe
-nkG
-biT
+dkt
+pEB
+vFY
+mca
+qad
+syz
+syz
+qad
+vDT
+pEB
+dkt
+dPu
 xZf
-toI
-mno
-toI
-toI
-toI
-vxe
-fXg
+xZf
+xZf
+xZf
+xZf
+rtL
+iLV
+weQ
+rLn
+bko
+tOx
 noW
 noW
+rMf
 nII
 fzq
 lsN
@@ -293898,45 +293712,45 @@ rII
 mQr
 pWT
 aFv
-lKo
-jdu
-lKo
-vJq
-mbx
-asw
-kAx
-rMf
+pWT
+bge
+bge
+dEQ
+pWT
+pWT
+njB
+pWT
+dyQ
+uqB
+uqB
 weQ
 weQ
+lkJ
+dkt
+vDT
+dTu
+fBn
+nvU
+wpb
+gDG
+vDT
+dkt
+lkJ
+dPu
+xZf
+neg
+neg
+neg
+neg
+xZf
+iLV
 weQ
-weQ
-weQ
-weQ
-weQ
-weQ
-weQ
-weQ
-vxe
-bpb
-hWA
-vFd
-uWp
-uWp
-fAA
-btu
-vxe
-jWl
-mqZ
-bpp
-uQS
-vxe
-snS
-uQS
-ukx
-vxe
+rLn
+tMd
 fXg
-hhv
 noW
+noW
+rMf
 qQo
 oSt
 oSt
@@ -294350,45 +294164,45 @@ qyR
 pWT
 njB
 njB
-lKo
-jdu
-lKo
-akS
-tTc
-tJd
+pWT
+pWT
+bge
+dEQ
+mWD
+pWT
 hlN
 hlN
-rMf
-rMf
-rMf
-rMf
-rMf
-uhI
-rMf
-uhI
+uqB
+uqB
+jdk
 weQ
 weQ
-vxe
-eIK
-rCi
-pcI
-uWp
-uWp
-dat
-dat
-vxe
-bVW
-gMg
-uQS
-stc
-vxe
-gno
-xma
-xma
-vxe
+dkt
+pEB
+wTi
+oWi
+oWi
+oWi
+oWi
+oWi
+wTi
+pEB
+dkt
+dPu
+xZf
+neg
+neg
+neg
+neg
+xZf
+iLV
+weQ
+rLn
+rMf
 fXg
 noW
 noW
+rMf
 nTh
 vJq
 kAx
@@ -294801,44 +294615,44 @@ njB
 qyR
 pWT
 jiQ
-wSh
-cDX
-jdu
-cDX
-nwG
+daQ
+daQ
+fGv
+bge
+xsf
 kve
-rMf
+kve
 ftc
 hlN
-wxu
-vJq
-uhI
-rMf
-rMf
-rMf
-tYN
-uhI
+uqB
+uqB
+jdk
 weQ
 weQ
-vxe
-fAA
-ewD
-ewD
-uWp
-uWp
-vBQ
-fSz
-vxe
-vxe
-vxe
-eKq
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-tOx
+lkJ
+dkt
+lkJ
+dkt
+lkJ
+dkt
+lkJ
+dkt
+lkJ
+dkt
+lkJ
+dPu
+xZf
+xZf
+xZf
+xZf
+xZf
+hQj
+iLV
+gMS
+rLn
+rGA
+fXg
+noW
 noW
 noW
 sYm
@@ -295254,45 +295068,45 @@ pWT
 aZo
 daQ
 daQ
-lKo
-jdu
-lKo
-nwG
-nAZ
+fGv
+fGv
+bge
+bge
+bge
 tJd
+mWD
+lKw
+uqB
+jdk
+jdk
+weQ
+weQ
 rMf
-aoO
-kAx
-akS
 uhI
-dqE
-rMf
-rMf
-uhI
 rMf
 weQ
 weQ
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-fBd
 weQ
 weQ
 weQ
-wnx
-vAw
-vAw
-vAw
-vAw
-aUk
+weQ
+weQ
+weQ
+dPu
+dPu
+dPu
+dPu
+dPu
+kRO
+dPu
+dPu
+weQ
+rLn
+vFt
+igz
 noW
 noW
+rMf
 nTh
 wjz
 kAx
@@ -295706,19 +295520,21 @@ njB
 daQ
 daQ
 daQ
-lKo
-jdu
-lKo
-nwG
-qer
-akS
+fGv
+fGv
+bge
+bge
+bge
+bge
 idI
-wxu
-lKw
-uhI
-vlL
-rMf
-rMf
+aZo
+jdk
+jdk
+uqB
+weQ
+weQ
+weQ
+weQ
 weQ
 weQ
 weQ
@@ -295734,14 +295550,12 @@ tWl
 weQ
 weQ
 weQ
-weQ
-weQ
 nEd
+gMS
+weQ
+weQ
+weQ
 wnx
-rMf
-rMf
-rMf
-rMf
 noW
 noW
 noW
@@ -296158,42 +295972,42 @@ uJY
 uJY
 uJY
 mQg
-phl
-lDK
-phl
-mgq
-nwG
-rni
-pqC
-nwG
-bAU
-rni
-uhI
-rMf
-phl
-ank
+fGv
+fGv
 pLh
+bge
+bge
+bge
+wbt
+nnJ
+jdk
+uqB
+uqB
+uqB
+jdu
+jdu
+jdu
 rMf
 mgq
 nwG
 nwG
 nwG
-mgq
 weQ
-weQ
+eja
+etH
+rni
+oic
 weQ
 tWl
 weQ
 weQ
 weQ
 weQ
-weQ
-weQ
 pZi
-vAw
-vAw
-vAw
-vAw
+weQ
+weQ
+weQ
+dyx
 noW
 nRv
 gqP
@@ -296611,26 +296425,26 @@ gyu
 cDX
 phl
 pLh
-jdu
+hYg
 pLh
 phl
-gyu
-gyu
-gyu
-gyu
-gyu
-gyu
-gyu
+iEx
+bzY
+bzY
 phl
 phl
-mEm
+phl
+phl
+phl
+phl
+phl
 pLh
 pLh
 gyu
 gyu
 cDX
 gyu
-gyu
+iRt
 cDX
 gyu
 gyu
@@ -297055,34 +296869,34 @@ pcQ
 pcQ
 phl
 snM
+phl
+phl
+phl
+phl
+phl
+phl
+phl
 jdu
 jdu
 jdu
-jdu
-jdu
-jdu
-aqr
-jdu
-jdu
-jdu
-aqr
-jdu
-jdu
-jdu
-jdu
-jdu
-jdu
-jdu
-aqr
-jdu
-tSF
+phl
+iEx
+bzY
+bzY
+phl
+phl
+cDX
+phl
+phl
+phl
+phl
 phl
 phl
 lKO
 pqo
 lKo
-lKO
-pqo
+oea
+mtb
 lKo
 lKO
 pqo
@@ -297518,14 +297332,14 @@ pLh
 tSF
 pLh
 phl
-gyu
-gyu
-gyu
-gyu
-gyu
-gyu
-gyu
+bzY
+bzY
+bzY
 phl
+phl
+phl
+phl
+pLh
 phl
 phl
 phl
@@ -297973,14 +297787,14 @@ hzG
 rZO
 rZO
 rZO
-ebU
-ebU
-ebU
-aoe
+ezs
+ezs
+ezs
+spe
+pLh
 jcY
-phl
-phl
-phl
+jcY
+jcY
 jcY
 aoe
 aoe
@@ -298425,11 +298239,11 @@ ebU
 ebU
 ebU
 ebU
-ebU
-ebU
-ebU
-ebU
-aoe
+aXW
+ezs
+ezs
+spe
+cJa
 aoe
 aoe
 aoe
@@ -375287,6 +375101,10 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
 sGj
 sGj
 sGj
@@ -375296,10 +375114,6 @@ bGf
 bGf
 bGf
 bGf
-bGf
-kSK
-kSK
-kSK
 bGf
 bGf
 bGf
@@ -375735,6 +375549,10 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
 sGj
 sGj
 sGj
@@ -375748,10 +375566,6 @@ dkS
 dkS
 dkS
 sGj
-bGf
-kSK
-kSK
-kSK
 bGf
 bGf
 bGf
@@ -376187,6 +376001,10 @@ uBc
 uBc
 cDX
 bGf
+bGf
+bGf
+bGf
+bGf
 sGj
 hRB
 pbq
@@ -376200,10 +376018,6 @@ kle
 eMg
 kkJ
 dkS
-bGf
-kSK
-kSK
-kSK
 bGf
 bGf
 bGf
@@ -376639,6 +376453,10 @@ uxy
 sYZ
 uBc
 bGf
+bGf
+bGf
+bGf
+bGf
 sGj
 huQ
 pbq
@@ -376652,10 +376470,6 @@ atF
 eMg
 meD
 dkS
-bGf
-kSK
-kSK
-kSK
 bGf
 bGf
 bGf
@@ -377091,6 +376905,10 @@ hut
 sYZ
 uBc
 bGf
+bGf
+bGf
+bGf
+bGf
 sGj
 pbq
 sen
@@ -377104,10 +376922,6 @@ eyn
 eMg
 imA
 dkS
-bGf
-kSK
-kSK
-kSK
 bGf
 bGf
 bGf
@@ -377543,6 +377357,10 @@ xWk
 ejh
 uBc
 bGf
+bGf
+bGf
+bGf
+bGf
 sGj
 hRB
 pbq
@@ -377556,10 +377374,6 @@ kzf
 eMg
 vuU
 dkS
-bGf
-kSK
-kSK
-kSK
 bGf
 bGf
 bGf
@@ -377995,6 +377809,10 @@ jBj
 skz
 uBc
 bGf
+bGf
+bGf
+bGf
+bGf
 sGj
 sGj
 wtd
@@ -378008,10 +377826,6 @@ oNx
 eMg
 pai
 dkS
-bGf
-kSK
-kSK
-kSK
 bGf
 bGf
 bGf
@@ -378447,6 +378261,10 @@ cDX
 uBc
 cDX
 pYH
+bGf
+bGf
+bGf
+bGf
 sGj
 aXg
 eMg
@@ -378460,10 +378278,6 @@ eMg
 eMg
 uee
 dkS
-bGf
-kSK
-kSK
-kSK
 bGf
 bGf
 bGf
@@ -378899,6 +378713,10 @@ nUP
 fXz
 mYW
 efz
+bGf
+bGf
+bGf
+bGf
 sGj
 gGr
 eMg
@@ -378912,10 +378730,6 @@ eMg
 eMg
 uzC
 dkS
-bGf
-kSK
-kSK
-kSK
 bGf
 bGf
 bGf
@@ -379351,6 +379165,10 @@ cDX
 wLb
 gWO
 efz
+bGf
+bGf
+bGf
+bGf
 sGj
 lsf
 eMg
@@ -379364,10 +379182,6 @@ gqT
 eMg
 tgw
 dkS
-bGf
-bGf
-bGf
-bGf
 bGf
 bGf
 bGf
@@ -379803,6 +379617,10 @@ pFA
 pYP
 pYP
 bCk
+bGf
+bGf
+bGf
+bGf
 sGj
 sGj
 aic
@@ -379816,10 +379634,6 @@ dkS
 dkS
 dkS
 sGj
-bGf
-bGf
-bGf
-bGf
 bGf
 bGf
 bGf
@@ -380258,18 +380072,18 @@ bGf
 bGf
 bGf
 bGf
+bGf
 spC
+bGf
+bGf
+bGf
 gPs
 lMS
 quq
 quq
 efz
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+spC
 bGf
 bGf
 bGf
@@ -380710,8 +380524,8 @@ bGf
 bGf
 bGf
 bGf
-spC
-pFA
+bGf
+ajc
 pYP
 pYP
 pYP
@@ -380721,7 +380535,7 @@ bGf
 bGf
 bGf
 bGf
-bGf
+spC
 bGf
 bGf
 bGf
@@ -381162,6 +380976,17 @@ bGf
 bGf
 bGf
 bGf
+bGf
+spC
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 spC
 bGf
 bGf
@@ -381178,17 +381003,6 @@ bGf
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-kSK
-kSK
-kSK
-kSK
-lIn
-kSK
 kSK
 kSK
 kSK
@@ -381614,6 +381428,17 @@ bGf
 bGf
 bGf
 bGf
+bGf
+spC
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 spC
 bGf
 bGf
@@ -381630,17 +381455,6 @@ bGf
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-kSK
-kSK
-kSK
-eKH
-eKH
-ykK
-eKH
-kSK
 kSK
 mPk
 eZd
@@ -382085,14 +381899,14 @@ bGf
 bGf
 bGf
 bGf
-kSK
-kSK
-eKH
-eKH
-wtb
-cMj
-eKH
-eKH
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 kSK
 eZd
 kYU
@@ -382536,15 +382350,15 @@ bGf
 bGf
 bGf
 bGf
-kSK
-kSK
-eKH
-eKH
-eKH
-bYk
-cMj
-lmP
-eKH
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 kSK
 eZd
 ngj
@@ -382987,16 +382801,16 @@ kSK
 bGf
 bGf
 bGf
-kSK
-kSK
-eKH
-eKH
-eKH
-eKH
-iUW
-dra
-vZI
-eKH
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 ikL
 eJq
@@ -383439,16 +383253,16 @@ kSK
 bGf
 bGf
 bGf
-kSK
-eKH
-eKH
-eKH
-eKH
-eKH
-mjw
-xWk
-fyA
-eKH
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 eZd
 toq
@@ -383891,16 +383705,16 @@ kSK
 bGf
 bGf
 bGf
-kSK
-eKH
-puO
-wag
-puO
-orR
-dra
-xWk
-wQL
-eKH
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 kSK
 eZd
 jlT
@@ -384343,16 +384157,16 @@ kSK
 bGf
 bGf
 bGf
-kSK
-eKH
-qbr
-puO
-puO
-eKH
-eKH
-eKH
-eKH
-eKH
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 kSK
 mPk
 eZd
@@ -384795,16 +384609,16 @@ kSK
 bGf
 bGf
 bGf
-kSK
-eKH
-eKH
-puO
-puO
-dra
-crj
-uMM
-taV
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 kSK
 kSK
 eZd
@@ -385247,16 +385061,16 @@ kSK
 bGf
 bGf
 bGf
-kSK
-eKH
-eKH
-xWk
-xWk
-pCd
-rtL
-vfl
-eKH
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 kSK
 kSK
 eZd
@@ -385699,16 +385513,16 @@ kSK
 bGf
 bGf
 bGf
-kSK
-kSK
-rUb
-xWk
-xWk
-pCd
-oWO
-cNi
-eKH
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 kSK
 kSK
 eZd
@@ -386150,17 +385964,17 @@ iNw
 kSK
 bGf
 bGf
-kSK
-kSK
-kSK
-rUb
-xWk
-xWk
-qVA
-kCN
-kCN
-taV
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 kSK
 kSK
 eZd
@@ -386602,17 +386416,17 @@ iNw
 kSK
 bGf
 bGf
-kSK
-eKH
-eKH
-eKH
-deO
-puO
-eKH
-eKH
-eKH
-eKH
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 kSK
 kSK
 mPk
@@ -387054,17 +386868,17 @@ oCF
 kSK
 bGf
 bGf
-kSK
-eKH
-cEb
-uZN
-puO
-puO
-eSn
-yeu
-jOP
-eKH
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 kSK
 kSK
 eZd
@@ -387506,17 +387320,17 @@ kSK
 kSK
 bGf
 bGf
-kSK
-eKH
-cEb
-szy
-puO
-puO
-ocX
-ocX
-ocX
-taV
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 kSK
 kSK
 uuu
@@ -387958,17 +387772,17 @@ bGf
 bGf
 bGf
 bGf
-kSK
-eKH
-mca
-puO
-yju
-puO
-mHf
-aVE
-gMS
-eKH
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 kSK
 eZd
@@ -388410,17 +388224,17 @@ bGf
 bGf
 bGf
 bGf
-kSK
-eKH
-eKH
-eKH
-eKH
-bdw
-eKH
-eKH
-eKH
-eKH
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 kSK
 mPk
@@ -388825,7 +388639,7 @@ bGf
 bGf
 bGf
 bGf
-bGf
+mDc
 bGf
 bGf
 bGf
@@ -388862,17 +388676,17 @@ bGf
 bGf
 bGf
 bGf
-kSK
-kSK
-eKH
-jPl
-xWk
-dra
-bdV
-etH
-eKH
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 kSK
 kSK
@@ -389315,15 +389129,15 @@ bGf
 bGf
 bGf
 bGf
-kSK
-eKH
-eKH
-tDn
-qVA
-dra
-eKH
-eKH
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 bGf
 bGf
@@ -389767,15 +389581,15 @@ bGf
 bGf
 bGf
 bGf
-kSK
-kSK
-eKH
-jKf
-eKH
-jKf
-eKH
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 bGf
 bGf
@@ -390220,13 +390034,13 @@ bGf
 bGf
 bGf
 bGf
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 bGf
 bGf
@@ -392002,7 +391816,7 @@ bGf
 bGf
 bGf
 bGf
-bGf
+kSK
 kSK
 kSK
 kSK
@@ -392471,7 +392285,7 @@ bGf
 bGf
 bGf
 bGf
-bGf
+kSK
 kSK
 kSK
 bsK
@@ -392906,20 +392720,20 @@ bGf
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+tlk
+dPu
+vxe
+sna
+vxe
+dPu
+vxe
+sna
+vxe
+dPu
+vxe
+wli
+vxe
+dPu
 bGf
 bGf
 bGf
@@ -393358,20 +393172,20 @@ bGf
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+rJA
+fIG
+gno
+tGv
+drS
+xNW
+fXd
+tGv
+drS
+vxe
+utY
+bEj
+xFR
+vxe
 bGf
 bGf
 bGf
@@ -393800,15 +393614,6 @@ bGf
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
 hrE
 bGf
 bGf
@@ -393819,11 +393624,20 @@ bGf
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+rJA
+vxe
+kRp
+drS
+fAA
+fAA
+fAA
+drS
+nJS
+dPu
+lfb
+fAA
+lfb
+vFd
 bGf
 bGf
 bGf
@@ -394251,33 +394065,33 @@ bGf
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
 jWw
 hrE
 hrE
-kSK
-kSK
-kSK
-bsK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-bsK
-kSK
-kSK
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+fdR
+fIG
+bqW
+waf
+kQf
+lUO
+wFJ
+waf
+qdL
+vxe
+lUZ
+sLn
+pcI
+vxe
+bGf
+bGf
 kSK
 kSK
 hrE
@@ -394695,15 +394509,6 @@ bGf
 bGf
 bGf
 bGf
-jWw
-jWw
-jWw
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
 bGf
 bGf
 bGf
@@ -394715,22 +394520,31 @@ jWw
 jWw
 yjG
 hrE
-hrE
-hrE
-iVE
+jWw
+bGf
+bGf
+bGf
+bGf
+rCV
+jWw
+jWw
+dPu
+vxe
+fAi
+vxe
+vxe
+vxe
+vxe
+vxe
+vxe
+dPu
+vxe
+xOC
+vxe
+dPu
 jWw
 iVE
 jWw
-iVE
-jWw
-hrE
-jWw
-jWw
-iVE
-jWw
-iVE
-jWw
-iVE
 jWw
 hrE
 mnC
@@ -395146,41 +394960,41 @@ bGf
 bGf
 bGf
 bGf
-hrE
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 jWw
+mnC
 dJt
+iWa
+jWw
 jWw
 hrE
-vgL
-vgL
-iVE
-vgL
-iVE
-vgL
-iVE
-vgL
-iVE
-vgL
-iVE
-vgL
 jWw
-iWa
-iWa
-iWa
+hrE
 jWw
-iWa
-iWa
-iWa
-iWa
-iWa
-iWa
-iWa
-iWa
-iWa
-iWa
-iWa
-iWa
-iWa
+qer
+dqE
+lvT
+sLn
+sLn
+sLn
+sLn
+sLn
+sRn
+sLn
+sLn
+sLn
+sLn
+sLn
+jwe
+fSz
+dMi
 iWa
 iWa
 iWa
@@ -395598,41 +395412,41 @@ bGf
 bGf
 bGf
 bGf
-iVE
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+jWw
 iWa
+iWa
+iWa
+eps
 iWa
 yjG
-eps
-wBK
-wBK
-wBK
-wBK
-wBK
-vAJ
-wBK
-wBK
-wBK
-vAJ
-wBK
-wBK
-eps
+dJt
+dJt
 iWa
-iWa
-iWa
-eps
-iWa
-aQQ
-iWa
-iWa
-iWa
-iWa
-aQQ
-iWa
-iWa
-iWa
-iWa
-aQQ
-iWa
+qer
+dMi
+jwe
+sLn
+sLn
+sLn
+sLn
+sLn
+sLn
+sLn
+sLn
+sLn
+sLn
+sLn
+nFf
+jiD
+shj
 iWa
 iWa
 iWa
@@ -396050,44 +395864,44 @@ bGf
 bGf
 bGf
 bGf
-hrE
-hrE
-vvv
-jWw
-jWw
-ukB
-nsK
-nsK
-nsK
-nsK
-nsK
-nsK
-nsK
-nsK
-nsK
-nsK
-nsK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 jWw
 vvv
 iWa
 iWa
+pyE
+vxe
+vxe
+dPu
+vxe
+vxe
+dPu
+vxe
+vxe
+dPu
+vxe
+xOC
+vxe
+dPu
+vxe
+xOC
+vxe
+dPu
+vxe
+xOC
+vxe
+dPu
 jWw
 jWw
 jWw
 jWw
-hrE
-hrE
-hrE
-jWw
-jWw
-jWw
-jWw
-jWw
-hrE
-hrE
-hrE
-jWw
-hrE
 hrE
 vrH
 vrH
@@ -396503,40 +396317,40 @@ bGf
 bGf
 bGf
 bGf
-hrE
-eps
-jWw
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 jWw
 jWw
-dJt
-hrE
-hrE
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+iWa
+jWw
+pIl
+jKx
+rQv
+pIl
+fUm
+rCi
+pIl
+jKx
+rQv
+dPu
+lUZ
+sLn
+huL
+xwF
+lUZ
+sLn
+huL
+dPu
+lUZ
+sLn
+huL
+nqr
+wXL
 vmi
 lMc
 lMc
@@ -396955,40 +396769,40 @@ bGf
 bGf
 bGf
 bGf
-vgL
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-jWw
-hrE
-hrE
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+pyE
+key
+pyE
+pIl
+xHI
+rTE
+pIl
+vUp
+aaE
+pIl
+frA
+heB
+dPu
+lfb
+fAA
+cpI
+dPu
+lfb
+fAA
+cpI
+dPu
+lfb
+fAA
+cpI
+nqr
+wXL
 vmi
 vmi
 lMc
@@ -397407,40 +397221,40 @@ bGf
 bGf
 bGf
 bGf
-iVE
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-hrE
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 vxe
-vxe
+tzI
+uQS
+pIl
+jxs
+rTE
+pIl
+hxZ
+aaE
+pIl
+jxs
+rTE
+dPu
 utY
-vxe
+ewD
+xFR
+dPu
 utY
-vxe
-vxe
+ewD
+xFR
+dPu
+utY
+ewD
+xFR
+nqr
+wXL
 vmi
 vmi
 vmi
@@ -397859,41 +397673,41 @@ bGf
 bGf
 bGf
 bGf
-vgL
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 vxe
+uQS
+uQS
+pIl
+pIl
+enm
+pIl
+pIl
+enm
+pIl
+pIl
+enm
+dPu
 vxe
-vOf
-oih
-rKa
-nyU
-hxZ
+wha
 vxe
+dPu
 vxe
+wha
+vxe
+dPu
+vxe
+wha
+vxe
+nqr
+wXL
+vmi
 vmi
 vmi
 vmi
@@ -398311,43 +398125,43 @@ bGf
 bGf
 bGf
 bGf
-iVE
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 vxe
+uQS
+uQS
 vxe
+gHd
+bcB
+ulU
+oih
+pbK
+vJs
+fvf
+cdL
+vWB
 vxe
-vxe
-vxe
-vxe
-vxe
+sLn
+mxj
 hWW
-fAA
-uQS
-jyb
-uQS
-uQS
-eVb
-vxe
-vmi
-vmi
+hWW
+hWW
+hWW
+hWW
+hWW
+hWW
+xKF
+nqr
+uQL
+uQL
+uQL
+uQL
 vmi
 vmi
 vmi
@@ -398763,43 +398577,43 @@ bGf
 bGf
 bGf
 bGf
-vgL
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 vxe
+xmQ
 vxe
+dPu
+sWI
+bcB
+bcB
 vxe
+sqP
+fSz
+fSz
+oAs
+gMg
 pKH
-jiA
+mxj
 gTK
 fSz
-vxe
-vxe
-kQf
-fAA
-uQS
-uQS
-fAA
-tGv
-fAA
-drt
-vmi
-vmi
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+kUO
+pKH
+uQL
+uQL
+uQL
+uQL
 vmi
 vmi
 vmi
@@ -399215,43 +399029,43 @@ bGf
 bGf
 bGf
 bGf
-iVE
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 vxe
-utY
+uQS
+vxe
+deQ
+bcB
+bcB
+bcB
+bSa
+gJY
+ufl
+gZn
 vxe
 vxe
 vxe
-vxe
-ghh
-vxe
-lzQ
-gdb
-iol
+ctB
 fSz
-vxe
-vxe
-rJA
-fAA
-pfi
-uEt
-fAA
-qkv
-mxu
-vxe
-vmi
-vmi
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+uvq
+nqr
+uQL
+uQL
+uQL
+uQL
 vmi
 vmi
 vmi
@@ -399667,43 +399481,43 @@ bGf
 bGf
 bGf
 bGf
-vgL
-qJz
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 vxe
-vxe
+uQS
+dPu
+beu
+bcB
+dPu
 oxU
-ljl
+jiA
 bPd
-vhZ
-oRt
-brE
-cEN
-tjY
-ctB
-lfI
-nFf
-mPo
-vxe
-vxe
-rrN
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vmi
+nzo
+jiA
+iol
+dPu
+dPu
+nCB
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+nqr
+uQL
+uQL
+uQL
+uQL
 vmi
 vmi
 vmi
@@ -400119,43 +399933,43 @@ bGf
 bGf
 bGf
 bGf
-iVE
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 vxe
-vxe
-vxe
-vxe
-wli
+xmQ
+jTb
 bcB
-bcB
+dPu
+vxe
+rfL
+fZT
 esG
+fZT
+fZT
+eKq
 vxe
-uwJ
-swS
-fAA
-tjY
-tjY
-tjY
-tjY
-tjY
-slQ
-tjY
-tjY
-vxe
+rjF
+ctB
+fSz
+jCv
+fSz
+fSz
 vbR
-gyY
-jcT
-ida
-aYU
-vxe
-vmi
+fSz
+fSz
+vbR
+fSz
+nqr
+uQL
+uQL
+uQL
+uQL
 vmi
 vmi
 vmi
@@ -400571,45 +400385,45 @@ bGf
 bGf
 bGf
 bGf
-vgL
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-trl
-gJY
-bPd
-bcB
-bcB
-bcB
-bcB
-bcB
-vhZ
-iqA
-bso
-fAA
-tjY
-tjY
-tjY
-tjY
-tjY
-tjY
-tjY
-tjY
-tkZ
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vxe
 uQS
-mxj
-lyq
-mxj
-gzi
-drt
-gUD
-gUD
-wzO
+dPu
+beu
+bSa
+dPu
+rQk
+lzQ
+gdb
+nyU
+lzQ
+oAc
+dPu
+dPu
+nCB
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+nqr
+uQL
+uQL
+uQL
+uQL
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -401023,46 +400837,46 @@ bGf
 bGf
 bGf
 bGf
-iVE
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-trl
-gJY
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vxe
+uQS
+vxe
 bcB
 bcB
 bcB
-pgL
+bcB
 rHK
 gJY
-vxe
-vxe
-vRR
-vRR
-vRR
-vRR
-vRR
-vxe
-dsi
-fAA
+hee
+bpd
 vxe
 vxe
 vxe
-vOf
+ctB
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
 mxj
 nqr
-mxj
-jxB
-vxe
-dmo
-hAe
-aOc
-wzO
+uQL
+uQL
+uQL
+uQL
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -401475,46 +401289,46 @@ bGf
 bGf
 bGf
 bGf
-vgL
-vVX
-uSi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vxe
+uQS
+vxe
+dPu
+sWI
+bcB
+mno
+vxe
+sqP
+fSz
+fSz
+utH
+gMg
+pKH
+oXg
+dUr
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+fSz
+kUO
+pKH
+uQL
+uQL
+uQL
+uQL
 vmi
 vmi
 vmi
-vmi
-vmi
-vxe
-vxe
-vxe
-wWm
-isS
-wWm
-vxe
-vxe
-vxe
-vxe
-fSz
-fSz
-fSz
-fSz
-fSz
-fSz
-ovk
-fAA
-stR
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-piQ
-vIR
-hAe
-hvN
 wzO
 vmi
 vmi
@@ -401927,46 +401741,46 @@ bGf
 bGf
 bGf
 bGf
-iVE
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 vxe
-deQ
-xZf
-xZf
-xZf
-gjv
+xmQ
 vxe
 vxe
+xFl
+jdT
+bcB
+oKB
+cgt
+akS
+wxu
+ncy
+vWB
 vxe
-fSz
-fSz
-wWq
-fSz
-fSz
-fSz
+sLn
 oXg
 fGt
-fAA
-fAA
-xeD
-vxe
-vxe
-wFH
+fGt
+fGt
+fGt
+fGt
+fGt
+fGt
 dnk
 fyX
-xFR
-vxe
-wdE
-cXk
-cXk
-vIR
-sIJ
+uQL
+uQL
+uQL
+uQL
+vmi
+vmi
+vmi
 dmU
 vmi
 vmi
@@ -402379,46 +402193,46 @@ bGf
 bGf
 bGf
 bGf
-vgL
-qJz
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-trl
-xZf
-jxs
-jxs
-fAA
-xZf
-kFL
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vxe
+uQS
+uQS
+vxe
 pIl
-fSz
-fSz
-fSz
-fSz
-fSz
-fSz
-oXg
-rDc
-qUQ
-fAA
-mxu
-vxe
-vxe
-vxe
-wPp
-fAA
+aZH
+pIl
+pIl
+pIl
+rBV
+pIl
+pIl
+pIl
 dPu
-fAA
 vxe
-kpN
-cXk
-cXk
-iVM
-sIJ
+rDc
+dPu
+vxe
+vxe
+rDc
+vxe
+vxe
+rDc
+vxe
+dPu
+wXL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 dmU
 vmi
 vmi
@@ -402831,46 +402645,46 @@ bGf
 bGf
 bGf
 bGf
-iVE
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-trl
-fAA
-xNW
-fmO
-lLP
-fAA
-kFL
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vxe
+uQS
+uQS
+vxe
+mdm
+uWp
+uWp
 pIl
-fSz
-fSz
-fSz
-fSz
-fSz
-fSz
-ovk
-jiA
-jiA
-jiA
-jiA
+gIz
+uWp
+uWp
+uWp
+uWp
+vxe
+mPo
+xHQ
+vxe
+wDV
+eVb
 iFa
-vxe
-vxe
+toI
+bpp
 gAn
-uQS
-uQS
-uQS
-drt
-cXk
-cXk
-wBT
-gxR
-iVM
+bVl
+vxe
+wXL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 dmU
 vmi
 vmi
@@ -403283,46 +403097,46 @@ bGf
 bGf
 bGf
 bGf
-vgL
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 vxe
-xkq
-qNn
-wNb
-lLP
+uQS
+pCk
+vxe
+lfb
 lfb
 kFL
 pIl
-fSz
+jyZ
 hox
-fSz
-fSz
 hox
-fSz
-ovk
-fZT
-fZT
-fZT
-fZT
-iFa
+hox
+uWp
+uVb
+sLn
+sLn
+dNg
+slQ
+slQ
+slQ
+slQ
+slQ
+slQ
+gWb
 vxe
-vxe
-wzy
-uQS
-uQS
-uQS
-oHt
-cXk
-cXk
-fRL
-nnJ
-vIR
+wXL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 dmU
 vmi
 vmi
@@ -403735,46 +403549,46 @@ bGf
 bGf
 bGf
 bGf
-iVE
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-trl
-fAA
-sqP
-oKB
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vxe
+xmQ
+fSz
+vxe
 lLP
-fAA
-kFL
+ttA
+cVe
 pIl
-fSz
-fSz
-fSz
-fSz
-fSz
-fSz
-ovk
-lzQ
-lzQ
-lzQ
-lzQ
-iFa
+wFH
+pOI
+gzr
+pOI
+fmO
 vxe
+pGZ
+sLn
 vxe
-jvF
-fAA
-fAA
-fAA
-drt
-cXk
-cXk
-wBT
 iVM
-hAe
+rbU
+sZm
+sLa
+maL
+xbs
+gDT
+vxe
+wXL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 dmU
 vmi
 vmi
@@ -404187,46 +404001,46 @@ bGf
 bGf
 bGf
 bGf
-vgL
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-trl
-xZf
-dPu
-dPu
-fAA
-xZf
-kFL
-pIl
-fSz
-fSz
-fSz
-fSz
-fSz
-fSz
-dqz
-sLa
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vxe
+pzw
+vxe
+vxe
+vxe
+vxe
+vxe
+vxe
+vxe
+vxe
+vxe
+vxe
+vxe
+vxe
+vxe
+vxe
 qUQ
-fAA
-mxu
 vxe
 vxe
 vxe
-snS
-fAA
-vJs
-fAA
 vxe
-kpN
-cXk
-cXk
-gxR
-dmo
+vxe
+vxe
+vxe
+dPu
+wXL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 dmU
 vmi
 vmi
@@ -404639,46 +404453,46 @@ bGf
 bGf
 bGf
 bGf
-iVE
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vgL
 vVX
-uSi
+rBQ
+vmi
+biT
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+lyq
 vmi
 vmi
 vmi
 vmi
 vmi
-vxe
-kCs
-xZf
-xZf
-xZf
-gjv
-vxe
-vxe
-vxe
-fSz
-fSz
-wWq
-fSz
-fSz
-fSz
-dqz
-ttA
-fAA
-fAA
-xeD
-vxe
-vxe
-uQS
-nzo
-qFa
-gWb
-vxe
-wdE
-cXk
-cXk
-nnJ
-dmo
+vmi
 dmU
 vmi
 vmi
@@ -405091,46 +404905,46 @@ bGf
 bGf
 bGf
 bGf
-vgL
-vVX
-pNs
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+iVE
+wBK
+pMW
+vmi
+vmi
+vmi
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+vmi
+dPu
+dPu
+dPu
+dPu
+dPu
+dPu
+dPu
+dPu
+dPu
 vmi
 vmi
 vmi
 vmi
 vmi
-vxe
-vxe
-vxe
-wWm
-isS
-wWm
-vxe
-vxe
-vxe
-vxe
-fSz
-fSz
-fSz
-fSz
-fSz
-fSz
-ovk
-fAA
-stR
-vxe
-vxe
-vxe
-xWN
-vxe
-vxe
-vxe
-vxe
-vxe
-piQ
-hAe
-iVM
-vaN
+vmi
+vmi
 tvg
 vmi
 vmi
@@ -405543,46 +405357,46 @@ bGf
 bGf
 bGf
 bGf
-iVE
-jZq
-wpO
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vgL
+tod
+rBQ
+vmi
+vmi
+vmi
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+vmi
+dPu
+uWp
+crD
+rlj
+crD
+aSm
+prx
+dau
+dPu
 vmi
 vmi
 vmi
 vmi
 vmi
 vmi
-trl
-cjs
-bcB
-bcB
-bcB
-ljl
-rji
-ljl
-vxe
-vxe
-vRR
-vRR
-vRR
-vRR
-vRR
-vxe
-dsi
-fAA
-vxe
-ixs
-myt
-uQS
-vxe
-eRm
-tkH
-mdm
-vxe
-dmo
-vIR
-kBl
-tvg
+vmi
 vmi
 vLA
 vLA
@@ -405995,45 +405809,45 @@ bGf
 bGf
 bGf
 bGf
-vgL
-oZk
-wpO
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+iVE
+wBK
+pMW
+vmi
+vmi
+vmi
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+vmi
+dPu
+szy
+nat
+kAv
+vAo
+vAo
+vAo
+hPG
+dPu
 vmi
 vmi
 vmi
 vmi
 vmi
 vmi
-trl
-qsQ
-jZO
-bcB
-bcB
-bcB
-bcB
-bcB
-vhZ
-oRt
-brE
-fAA
-tjY
-tjY
-tjY
-tjY
-tjY
-tjY
-oHt
-fAA
-fAA
-uQS
-vxe
-pLt
-tkH
-rBB
-vxe
-szS
-szS
-tvg
 vmi
 vmi
 vLA
@@ -406447,46 +406261,46 @@ bGf
 bGf
 bGf
 bGf
-iVE
-bwV
-gMr
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vgL
+aft
+rBQ
+vmi
+vmi
+vmi
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+vmi
+dPu
+dPu
+fSz
+sKU
+uWp
+vII
+ekz
+ekz
+dPu
 vmi
 vmi
 vmi
 vmi
 vmi
 vmi
-vxe
-vxe
-vxe
-vxe
-kNL
-bcB
-bcB
-xOK
-vxe
-uwJ
-swS
-fAA
-tjY
-tjY
-tjY
-tjY
-tjY
-fQw
-vxe
-wbb
-foa
-uQS
-xWN
-tkH
-tkH
-tkH
-drt
 vmi
-vmi
-vmi
-vLA
 vLA
 vLA
 vLA
@@ -406899,9 +406713,39 @@ bGf
 bGf
 bGf
 bGf
-vgL
-vVX
-uSi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+iVE
+wBK
+pMW
+vmi
+vmi
+vmi
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+vmi
+dPu
+tWO
+fFz
+rLU
+uWp
+lfb
+kFL
+kFL
+dPu
 vmi
 vmi
 vmi
@@ -406909,36 +406753,6 @@ vmi
 vmi
 vmi
 vmi
-vmi
-vmi
-vxe
-vxe
-tex
-jKV
-cMu
-vhZ
-iqA
-bso
-hRe
-tjY
-tjY
-hRU
-lqJ
-usE
-vxe
-vxe
-xWN
-vxe
-vxe
-vxe
-sOx
-wlV
-mOD
-vxe
-vmi
-vmi
-vmi
-vLA
 vLA
 vLA
 vLA
@@ -407351,9 +407165,39 @@ bGf
 bGf
 bGf
 bGf
-iVE
-vVX
-uSi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vgL
+tod
+rBQ
+vmi
+vmi
+vmi
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+vmi
+dPu
+vAo
+vAo
+vAo
+vAo
+laf
+lnu
+njb
+dPu
 vmi
 vmi
 vmi
@@ -407361,36 +407205,6 @@ vmi
 vmi
 vmi
 vmi
-vmi
-vmi
-vmi
-vxe
-lfz
-vxe
-vxe
-vxe
-vxe
-dsv
-vxe
-jsJ
-vxe
-vxe
-vxe
-vxe
-vxe
-uDa
-uQS
-rjF
-vxe
-atE
-atE
-atE
-atE
-vxe
-vmi
-vmi
-vmi
-vLA
 vLA
 vLA
 vLA
@@ -407803,9 +407617,39 @@ bGf
 bGf
 bGf
 bGf
-vgL
-vVX
-uSi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+iVE
+wBK
+pMW
+vmi
+vmi
+vmi
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+vmi
+dPu
+uxY
+kcz
+uWp
+uWp
+laf
+vwp
+vqB
+dPu
 vmi
 vmi
 vmi
@@ -407813,36 +407657,6 @@ vmi
 vmi
 vmi
 vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vxe
-qjb
-nDI
-uQS
-vxe
-vfL
-uQS
-rfb
-vxe
-wzy
-uQS
-uQS
-uQS
-qNC
-vxe
-atE
-tKl
-atE
-atE
-vxe
-vmi
-vmi
-vmi
-vPZ
 vPZ
 vPZ
 vPZ
@@ -408255,9 +408069,39 @@ bGf
 bGf
 bGf
 bGf
-iVE
-vVX
-uSi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vgL
+aft
+rBQ
+vmi
+vmi
+vmi
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+vmi
+dPu
+uWp
+uWp
+uWp
+uWp
+lfb
+cqj
+oSS
+dPu
 vmi
 vmi
 vmi
@@ -408265,36 +408109,6 @@ vmi
 vmi
 vmi
 vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vxe
-oIo
-jyb
-uQS
-vxe
-oIo
-ida
-uFc
-vxe
-jvF
-uQS
-uQS
-ida
-aDb
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-wzO
-vmi
-vmi
-iIg
 iIg
 iIg
 iIg
@@ -408707,9 +408521,39 @@ bGf
 bGf
 bGf
 bGf
-vgL
-qJz
-uSi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+iVE
+wBK
+pMW
+vmi
+vmi
+vmi
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+vmi
+dPu
+sXL
+vAo
+uEt
+elZ
+uEt
+vAo
+vAo
+dPu
 vmi
 vmi
 vmi
@@ -408717,36 +408561,6 @@ vmi
 vmi
 vmi
 vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vxe
-iAO
-uQS
-uQS
-vxe
-iAO
-uQS
-uQS
-vxe
-wkf
-fAA
-fAA
-fAA
-elY
-vxe
-kpN
-cXk
-cXk
-xFQ
-iqT
-dmU
-vmi
-vmi
-iIg
 iIg
 iIg
 iIg
@@ -409159,9 +408973,39 @@ bGf
 bGf
 bGf
 bGf
-iVE
-vVX
-uSi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vgL
+tod
+rBQ
+vmi
+vmi
+vmi
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+vmi
+dPu
+pIl
+rPN
+pIl
+dPu
+pIl
+rPN
+pIl
+dPu
 vmi
 vmi
 vmi
@@ -409169,36 +409013,6 @@ vmi
 vmi
 vmi
 vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vxe
-hPp
-rTD
-fAA
-vxe
-hPp
-rTD
-fAA
-vxe
-oIo
-fAA
-oKr
-fAA
-uQS
-oHt
-cXk
-cXk
-cXk
-tmV
-vmr
-dmU
-vmi
-vmi
-iIg
 iIg
 iIg
 iIg
@@ -409611,43 +409425,43 @@ bGf
 bGf
 bGf
 bGf
-vgL
-vVX
-uSi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+iVE
+wBK
+pMW
+vmi
+vmi
+vmi
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+wkx
+vmi
+dPu
+hox
+hox
+cVX
+pIl
+hox
+hox
+cVX
+dPu
 vmi
 vmi
 vmi
 vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vxe
-uwf
-fAA
-fAA
-vxe
-uwf
-fAA
-fAA
-vxe
-sdc
-fAA
-qFa
-fAA
-ukx
-vxe
-cXk
-cXk
-cXk
-cHp
-vmr
-dmU
 vmi
 vmi
 vmi
@@ -410063,9 +409877,17 @@ bGf
 bGf
 bGf
 bGf
-iVE
-vVX
-uSi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+vgL
+aft
+rBQ
 vmi
 vmi
 vmi
@@ -410079,27 +409901,19 @@ vmi
 vmi
 vmi
 vmi
-vxe
-vxe
-kgb
-qFa
-vxe
-vxe
-kgb
-qFa
-vxe
-vxe
-vxe
-lfz
-lfz
-vxe
-vxe
-iqT
-vmr
-vmr
-vmr
-iqT
-dmU
+dPu
+vCO
+pFh
+gij
+pIl
+vCO
+pFh
+gij
+dPu
+vmi
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -410515,9 +410329,17 @@ bGf
 bGf
 bGf
 bGf
-vgL
-vVX
-uSi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+rCV
+wBK
+pMW
 vmi
 vmi
 vmi
@@ -410531,27 +410353,19 @@ vmi
 vmi
 vmi
 vmi
-vmi
-vxe
-lfz
-vxe
-vxe
-vxe
-lfz
-vxe
-vxe
-vxe
-vxe
+dPu
+qSC
+dPu
+qSC
+dPu
+qSC
+dPu
+qSC
+dPu
 vmi
 vmi
 vmi
-hxH
-szS
-szS
-szS
-szS
-szS
-tvg
+vmi
 vmi
 vmi
 vmi
@@ -410967,17 +410781,17 @@ bGf
 bGf
 bGf
 bGf
-iVE
-vVX
-uSi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+jWw
+eps
+hrE
 vmi
 vmi
 vmi
@@ -411422,18 +411236,18 @@ bGf
 jWw
 eps
 jWw
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-hrE
-iVE
+bGf
+bGf
+bGf
+bGf
 jWw
+jWw
+iWa
+hrE
+jWw
+rCV
+rCV
+rCV
 vmi
 vmi
 vmi
@@ -411875,23 +411689,23 @@ jWw
 vvv
 jWw
 hrE
-gHO
-gHO
-gHO
-gHO
-gHO
-gHO
-gHO
+xhH
+lSo
+xhH
 jWw
+mnC
+iWa
+iWa
 jWw
+dMM
 osX
-jWw
-hrE
+dMM
+osX
 gHO
-uRY
-gHO
-uRY
-gHO
+qNT
+rBC
+bXS
+shK
 uRY
 gHO
 uRY
@@ -412327,23 +412141,23 @@ iWa
 iWa
 iWa
 eps
-wBK
-wBK
-vVX
-pee
-wBK
-vVX
-wBK
-eps
+xhH
+bsx
+xhH
+blj
+iWa
 iWa
 dJt
-iWa
 eps
+vTb
+smZ
+vTb
+nBo
 vVX
 wBK
-vVX
-pee
-vVX
+eas
+aUk
+ixL
 wBK
 vVX
 wBK
@@ -412394,7 +412208,7 @@ eps
 iWa
 iWa
 iWa
-iVE
+jyb
 gLt
 gLt
 gLt
@@ -412779,18 +412593,18 @@ jWw
 tca
 jWw
 jWw
-vgL
-iVE
-iVE
-vgL
-iVE
-iVE
-vgL
+xhH
+lSo
+xhH
 jWw
-hrE
-vvv
+qJz
+iWa
+uFc
 jWw
 jWw
+vgL
+iVE
+vgL
 iVE
 vgL
 iVE
@@ -413234,14 +413048,14 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
 jWw
-iVE
 jWw
+iWa
+jWw
+hrE
+rCV
+rCV
+rCV
 aBB
 aBB
 aBB
@@ -413687,13 +413501,13 @@ aBB
 aBB
 aBB
 aBB
+jWw
+iVE
+jWw
 aBB
 aBB
 aBB
 aBB
-rQI
-aBB
-rQI
 aBB
 aBB
 aBB
@@ -414140,7 +413954,7 @@ aBB
 aBB
 aBB
 aBB
-aBB
+rCV
 aBB
 aBB
 aBB
@@ -490544,18 +490358,18 @@ bGf
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-fnN
-fVk
-fVk
-vwp
-bGf
-bGf
-bGf
-bGf
+tUx
+tUx
+tUx
+tUx
+rqW
+rqW
+rqW
+rqW
+jdB
+cLX
+cLX
+ykK
 bGf
 bGf
 bGf
@@ -490996,6 +490810,10 @@ bGf
 bGf
 bGf
 bGf
+kAF
+kAF
+kAF
+kAF
 fnN
 vrN
 fVk
@@ -491005,14 +490823,10 @@ gxX
 iDj
 vPO
 vrN
-fVk
-fVk
-vrN
-vwp
-bGf
-bGf
-bGf
-bGf
+cLX
+cLX
+pSy
+ykK
 bGf
 bGf
 bGf
@@ -491448,6 +491262,10 @@ oOM
 oOM
 oOM
 bGf
+kAF
+kAF
+kAF
+kAF
 hyE
 sPu
 hoS
@@ -491457,14 +491275,10 @@ hRB
 qko
 rqW
 tIs
-pbq
-pbq
-gAH
-dFk
-bGf
-bGf
-bGf
-bGf
+aUO
+aUO
+bdV
+xBq
 bGf
 bGf
 bGf
@@ -491900,6 +491714,10 @@ oOM
 oOM
 oOM
 bGf
+kAF
+kAF
+kAF
+kAF
 hyE
 rpt
 ncE
@@ -491909,14 +491727,10 @@ pbq
 qko
 rqW
 tIs
-pbq
-pbq
-gAH
-dFk
-bGf
-bGf
-bGf
-bGf
+aUO
+aUO
+bdV
+xBq
 bGf
 bGf
 bGf
@@ -492352,6 +492166,10 @@ oOM
 oOM
 oOM
 bGf
+kAF
+kAF
+kAF
+kAF
 hyE
 eLe
 aUl
@@ -492361,14 +492179,10 @@ pbq
 sen
 fzm
 fzm
-elE
-pbq
-bqk
-dFk
-bGf
-bGf
-bGf
-bGf
+vAg
+aUO
+vnq
+xBq
 bGf
 bGf
 bGf
@@ -492804,6 +492618,10 @@ oOM
 oOM
 oOM
 bGf
+kAF
+kAF
+kAF
+kAF
 hyE
 pwV
 xqr
@@ -492813,14 +492631,10 @@ rZJ
 kgY
 pbq
 pbq
-pbq
-vBn
-nnL
-dFk
-bGf
-bGf
-bGf
-bGf
+aUO
+vZI
+elC
+xBq
 bGf
 bGf
 bGf
@@ -493256,6 +493070,10 @@ oOM
 oOM
 oOM
 bGf
+kAF
+kAF
+kAF
+kAF
 hyE
 tYa
 jXF
@@ -493265,14 +493083,10 @@ tYa
 wkR
 tYa
 tbn
-tYa
-tYa
-tYa
-dFk
-bGf
-bGf
-bGf
-bGf
+jdv
+jdv
+jdv
+xBq
 bGf
 bGf
 bGf
@@ -493708,6 +493522,10 @@ oOM
 oOM
 oOM
 bGf
+kAF
+kAF
+kAF
+kAF
 hyE
 gxX
 xqr
@@ -493717,14 +493535,10 @@ pzu
 mZP
 fff
 xqr
-dnn
-mXZ
-cDw
-dFk
-bGf
-bGf
-bGf
-bGf
+nZB
+orR
+wAx
+xBq
 bGf
 bGf
 bGf
@@ -494160,6 +493974,10 @@ oOM
 bGf
 bGf
 bGf
+kAF
+kAF
+kAF
+kAF
 hyE
 vDd
 xqr
@@ -494169,14 +493987,10 @@ hoS
 mZP
 seI
 xqr
-xqr
-mXZ
-hvV
-dFk
-bGf
-bGf
-bGf
-bGf
+bKp
+orR
+atr
+xBq
 bGf
 bGf
 bGf
@@ -494612,6 +494426,10 @@ oOM
 bGf
 bGf
 bGf
+kAF
+kAF
+kAF
+kAF
 hyE
 iis
 xqr
@@ -494621,14 +494439,10 @@ xqr
 mZP
 fdZ
 dnn
-xqr
-mXZ
-cVo
-dFk
-bGf
-bGf
-bGf
-bGf
+bKp
+orR
+aIi
+xBq
 bGf
 bGf
 bGf
@@ -495064,6 +494878,10 @@ bGf
 bGf
 bGf
 bGf
+kAF
+kAF
+kAF
+kAF
 opr
 xkI
 bIu
@@ -495073,14 +494891,10 @@ yib
 mZP
 fSD
 wcX
-xqr
-nnb
-uxY
-yfn
-bGf
-bGf
-bGf
-bGf
+bKp
+eGS
+hsS
+uEw
 bGf
 bGf
 bGf
@@ -495516,7 +495330,11 @@ bGf
 bGf
 bGf
 bGf
-bGf
+tUx
+kAF
+kAF
+kAF
+rqW
 opr
 dgd
 dgd
@@ -495524,14 +495342,10 @@ dgd
 rgj
 rgj
 rgj
-dgd
-dgd
-dgd
-yfn
-bGf
-bGf
-bGf
-bGf
+oJT
+oJT
+oJT
+uEw
 bGf
 bGf
 bGf
@@ -497799,13 +497613,13 @@ bGf
 bGf
 bGf
 bGf
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 ycO
 mPk
@@ -498248,16 +498062,16 @@ efz
 bGf
 bGf
 bGf
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 ycO
 eZd
@@ -498700,16 +498514,16 @@ efz
 bGf
 bGf
 bGf
-kSK
-eKH
-eKH
-eKH
-eKH
-tod
-eKH
-eKH
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 ycO
 eZd
@@ -499152,16 +498966,16 @@ efz
 bGf
 bGf
 bGf
-kSK
-eKH
-eKH
-eKH
-hkj
-sXL
-sXL
-eKH
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 ycO
 eZd
@@ -499603,17 +499417,17 @@ quq
 efz
 bGf
 bGf
-kSK
-kSK
-eKH
-bzY
-eKH
-uPI
-uPI
-sXr
-eKH
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 ycO
 mPk
@@ -500055,17 +499869,17 @@ quq
 efz
 bGf
 bGf
-kSK
-eKH
-eKH
-oID
-eKH
-voe
-puO
-puO
-eKH
-eKH
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 ycO
 eZd
@@ -500507,17 +500321,17 @@ qfC
 bCk
 bGf
 bGf
-kSK
-eKH
-cNg
-sYZ
-eKH
-fCk
-sYZ
-sYZ
-rGx
-eKH
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 ycO
 eZd
@@ -500959,17 +500773,17 @@ bMm
 bGf
 bGf
 bGf
-kSK
-eKH
-hUf
-sYZ
-eKH
-eKH
-lVB
-sYZ
-tpg
-eKH
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 ycO
 eZd
@@ -501410,18 +501224,18 @@ rXZ
 bMm
 bGf
 bGf
-kSK
-kSK
-eKH
-sYZ
-sYZ
-tjI
-frA
-sYZ
-iFA
-rGx
-eKH
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 ycO
 eZd
@@ -501862,18 +501676,18 @@ jXq
 bMm
 bGf
 bGf
-kSK
-eKH
-eKH
-eKH
-aEj
-eKH
-eKH
-eKH
-eKH
-eKH
-eKH
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 ycO
 eZd
@@ -502314,18 +502128,18 @@ lvw
 bMm
 bGf
 bGf
-kSK
-eKH
-prx
-dTu
-kRg
-xXW
-lAt
-eKH
-kSK
-kSK
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 ycO
 mPk
@@ -502766,17 +502580,17 @@ vaz
 cbr
 bGf
 bGf
-kSK
-paa
-kRg
-kRg
-hMB
-kRg
-kRg
-jrn
-kSK
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 bGf
 ycO
@@ -503218,17 +503032,17 @@ iNw
 bGf
 bGf
 bGf
-kSK
-paa
-kRg
-rjK
-rjK
-rjK
-kRg
-jrn
-kSK
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 bGf
 ycO
@@ -503670,17 +503484,17 @@ iNw
 bGf
 bGf
 bGf
-kSK
-paa
-kRg
-jdB
-ocm
-umt
-kRg
-jrn
-kSK
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 bGf
 ycO
@@ -504122,16 +503936,16 @@ iNw
 bGf
 bGf
 bGf
-kSK
-eKH
-jph
-uWd
-lGl
-xcp
-weg
-eKH
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 bGf
 bGf
@@ -504574,16 +504388,16 @@ vaz
 qfC
 bGf
 bGf
-kSK
-eKH
-eKH
-eKH
-eKH
-eKH
-eKH
-eKH
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 bGf
 bGf
@@ -505026,15 +504840,15 @@ cZI
 cbr
 bGf
 bGf
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 bGf
 bGf
@@ -506833,11 +506647,11 @@ bGf
 bGf
 bGf
 bGf
-tCB
-nZA
-xBf
-nZA
-tCB
+gpv
+iVE
+vgL
+iVE
+gpv
 bGf
 bGf
 bGf
@@ -507284,13 +507098,13 @@ bGf
 bGf
 bGf
 bGf
-xpH
-xpH
-pRP
-icG
-pRP
-xpH
-xpH
+jWw
+jWw
+iWa
+yjG
+iWa
+jWw
+jWw
 bGf
 bGf
 bGf
@@ -507736,13 +507550,13 @@ bGf
 bGf
 bGf
 bGf
-nZA
-pRP
-pRP
-pRP
-pRP
-pRP
-nZA
+iVE
+iWa
+iWa
+iWa
+iWa
+iWa
+iVE
 bGf
 bGf
 bGf
@@ -508167,20 +507981,20 @@ bGf
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+vmi
+dPu
+pdO
+rDc
+vxe
+rDc
+dPu
+vxe
+dPu
+rDc
+vxe
+rDc
+vxe
+dPu
 bGf
 bGf
 bGf
@@ -508188,13 +508002,13 @@ bGf
 bGf
 lMc
 lMc
-nZA
-pRP
-pRP
-pRP
-pRP
-pRP
-nZA
+iVE
+iWa
+iWa
+iWa
+iWa
+iWa
+iVE
 lMc
 lMc
 lMc
@@ -508619,20 +508433,20 @@ bGf
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+sOx
+vxe
+bmn
+uQS
+awz
+eFM
+hFO
+vxe
+mXe
+iry
+wfI
+uQS
+uSi
+vxe
 bGf
 bGf
 bGf
@@ -508640,13 +508454,13 @@ bGf
 lMc
 lMc
 lMc
-xpH
-xpH
-pRP
-vlh
-pRP
-xpH
-xpH
+jWw
+jWw
+iWa
+dJt
+iWa
+jWw
+jWw
 lMc
 lMc
 lMc
@@ -509061,6 +508875,7 @@ bGf
 bGf
 bGf
 bGf
+iXI
 bGf
 bGf
 bGf
@@ -509070,34 +508885,33 @@ bGf
 bGf
 bGf
 bGf
+sOx
+vxe
+mKP
+uQS
+rTD
+uQS
+xOK
+vxe
+cyA
+lfb
+lfb
+lfb
+uQS
+oZk
+bGf
+bGf
+bGf
+bGf
+lMc
+lMc
+lMc
+lMc
 jWw
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-lMc
-lMc
-lMc
-lMc
-xpH
-wrR
-xBf
-wrR
-xpH
+eps
+vgL
+eps
+jWw
 lMc
 lMc
 lMc
@@ -509512,6 +509326,9 @@ bGf
 bGf
 bGf
 bGf
+iXI
+iXI
+iXI
 bGf
 bGf
 bGf
@@ -509520,23 +509337,20 @@ bGf
 bGf
 bGf
 bGf
-bGf
-jWw
-jWw
-jWw
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+fSz
+vxe
+bmn
+uQS
+uQS
+uQS
+uQS
+vxe
+uyd
+khf
+lfb
+lfb
+dDx
+vxe
 vmi
 vmi
 vmi
@@ -509553,22 +509367,22 @@ hCF
 lMc
 lMc
 lMc
-gij
-aft
-aft
-aft
-aft
-aft
-kUH
-obd
-gij
-aft
-aft
-aft
-aft
-aft
-kUH
-bGf
+lMc
+lMc
+lMc
+lMc
+vgL
+jAV
+iVE
+toG
+iVE
+jAV
+vgL
+lMc
+lMc
+lMc
+lMc
+lMc
 bGf
 bGf
 bGf
@@ -509956,27 +509770,39 @@ bGf
 bGf
 bGf
 bGf
-jWw
-iVE
-jWw
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-jWw
-jWw
-yjG
-jWw
-jWw
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+xpH
+xpH
+icG
+xpH
+pyE
+fSz
+fSz
+fSz
+fSz
+pyE
+pyE
+pyE
+pyE
+vxe
+ixs
+ftV
+dsv
+uIr
+wFY
+vxe
+tCk
+vOf
+lfb
+lfb
+uQS
+oZk
 lMc
 lMc
 lMc
@@ -509997,30 +509823,18 @@ lMc
 lMc
 lMc
 lMc
+pqR
+ktO
+iCo
+jiZ
+iCo
+fLP
+pqR
 lMc
 lMc
 lMc
 lMc
 lMc
-lMc
-lMc
-gij
-aoM
-jWw
-jWw
-jWw
-jWw
-jWw
-cXP
-kSN
-cXP
-jWw
-jWw
-jWw
-jWw
-jWw
-vFY
-kUH
 lMc
 lMc
 jWw
@@ -510407,72 +510221,72 @@ bGf
 bGf
 bGf
 bGf
-jWw
-jWw
-dJt
-jWw
-jWw
-qad
-qad
-qad
-qad
-qad
-qad
-qad
-qad
-qad
-qad
-qad
-qad
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+nZA
+pRP
+vlh
+pRP
+mxO
+fGt
+fGt
+fGt
+fGt
+dPu
+uQS
+scY
+iag
+vxe
+xEs
+vxe
+vxe
+vxe
+vxe
+vxe
+tex
+lfb
+lfb
+lfb
+dDx
+vxe
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
 iVE
-iWa
-iWa
-iWa
-iVE
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-vHy
-jWw
-jWw
-tMv
-vUZ
-tMv
 lju
-kSN
-kSN
-kSN
-pMW
-laf
-gDG
-ijk
-jWw
-jWw
-iLV
+iCo
+iCo
+iCo
+iCo
+iVE
+lMc
+lMc
+lMc
+lMc
+lMc
 lMc
 lMc
 iVE
@@ -510859,28 +510673,40 @@ bGf
 bGf
 bGf
 bGf
-iVE
-iWa
-iWa
-iWa
-eps
-vVX
-vVX
-vVX
-vVX
-vVX
-vVX
-vVX
-vVX
-vVX
-vVX
-vVX
-vVX
-eps
-iWa
-iWa
-iWa
-eps
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+xBf
+pRP
+pRP
+pRP
+key
+oHF
+oHF
+nDI
+oHF
+vaN
+uQS
+jwe
+fSz
+hvW
+uQS
+uQS
+uQS
+btu
+uQS
+oRt
+uQS
+lfb
+foa
+lfb
+uQS
+oZk
 lMc
 lMc
 lMc
@@ -510901,30 +510727,18 @@ lMc
 lMc
 lMc
 lMc
+pqR
+nTv
+iCo
+iCo
+iCo
+uWd
+pqR
 lMc
 lMc
 lMc
 lMc
 lMc
-lMc
-lMc
-vHy
-jWw
-iSQ
-tMv
-tMv
-tMv
-jWw
-aOM
-kSN
-kSN
-jWw
-nBo
-nBo
-nBo
-nBo
-aCu
-iLV
 lMc
 lMc
 eps
@@ -511311,72 +511125,72 @@ bGf
 bGf
 bGf
 bGf
-jWw
-jWw
-mnC
-jWw
-jWw
-vJa
-vJa
-vJa
-vJa
-vJa
-vJa
-vJa
-vJa
-vJa
-vJa
-vJa
-vJa
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+nZA
+mYz
+pRP
+mYz
+mxO
+oHF
+oHF
+wbb
+oHF
+dPu
+uQS
+bwV
+sbB
+wlV
+uQS
+uQS
+uQS
+wsu
+uQS
+vxe
+uEo
+fZu
+iAH
+rGe
+imB
+vxe
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
 iVE
-iWa
-iWa
-iWa
+aRC
+iCo
+iCo
+iCo
+gtR
 iVE
 lMc
 lMc
 lMc
 lMc
 lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-vHy
-jWw
-dha
-igz
-igz
-igz
-jWw
-nZB
-kSN
-qvp
-jWw
-igz
-igz
-igz
-ivq
-jWw
-iLV
 lMc
 lMc
 iVE
@@ -511763,39 +511577,48 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+xpH
+xpH
+wrR
+xpH
+vxe
+vxe
+wfS
+vxe
+vxe
+vxe
+oRZ
+vxe
+vxe
+gyY
+vxe
+vxe
+dPu
+vxe
+dPu
+vxe
+dPu
+vxe
+dPu
+dPu
+vxe
+dPu
 vmi
-jWw
-eps
-jWw
 vmi
 vmi
 vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-jWw
-jWw
-dJt
-jWw
-jWw
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+lMc
+lMc
+lMc
+lMc
 vmi
 vmi
 vmi
@@ -511805,30 +511628,21 @@ lMc
 lMc
 lMc
 lMc
-vmi
-vmi
-vmi
-vmi
-vmi
 lMc
 lMc
-vHy
-jWw
-tMv
-rDO
-rDO
+lMc
 pqR
-jWw
-fiK
-fiK
-fiK
-jWw
-njb
-rDO
+jxC
+hvV
+hvV
+hvV
+syb
 pqR
-nBo
-jWw
-iLV
+lMc
+lMc
+lMc
+lMc
+lMc
 lMc
 vmi
 jWw
@@ -512215,40 +512029,40 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-jWw
-jWw
-jWw
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+isS
+ank
+vxe
+nsK
+rBB
+jjT
+jvF
+pIl
+iAO
+iqA
+wdr
+rTE
+wpO
+sUn
+vxe
+iln
+wkf
+dFa
+usE
+xku
+riq
+jvx
+vxe
+uQL
+uQL
 vmi
 vmi
 vmi
@@ -512264,23 +512078,23 @@ vmi
 vmi
 lMc
 lMc
-vHy
-jWw
-iSQ
-siN
-xUY
-hmx
-jWw
+lMc
+lMc
+lMc
+lMc
+lMc
+iVE
+gFm
 rCV
-vdf
 rCV
-jWw
-vYL
-pLb
-siN
-nBo
-aCu
-iLV
+rCV
+djh
+iVE
+lMc
+lMc
+lMc
+lMc
+lMc
 lMc
 vmi
 vmi
@@ -512667,78 +512481,78 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+isS
+ank
+wfS
+swS
+sWV
+swS
+hvN
+pIl
+lfz
+sdc
+rTE
+rTE
+ant
+akC
+vxe
+oSk
+fZT
+fZT
+ljl
+fZT
+fZT
+fZT
+pKH
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+pqR
+umv
+cNi
+cNi
+cNi
+aqA
+pqR
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+vmi
 vmi
 rfp
 vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-jWw
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-gij
-aoM
-jWw
-tMd
-jWw
-jWw
-jWw
-jWw
-hrE
-jWw
-jWw
-jWw
-jWw
-jWw
-jWw
-blj
-jWw
-iLV
-lMc
-vmi
-vmi
-rfp
-vVX
-xBf
+ghh
 vmi
 bGf
 kSK
@@ -513119,20 +512933,40 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+isS
+ank
+txn
+swS
+aqr
+swS
+kBl
+pIl
+pqi
+lyG
+aoO
+aoO
+aoO
+uDa
+vxe
+lNt
+pmh
+lzQ
+lzQ
+lzQ
+pmh
+kgb
+vxe
+uQL
+uQL
 vmi
 vmi
 vmi
@@ -513153,44 +512987,24 @@ lMc
 lMc
 lMc
 lMc
-lMc
-lMc
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-vHy
-jWw
-jWw
-mkj
-qSC
-gDG
-nBo
-jWw
-jWw
-jWw
-jWw
+vgL
 jAV
-pIv
-elZ
-atr
-scT
-jWw
-iLV
+iVE
+toG
+iVE
+jAV
+vgL
+lMc
+lMc
+lMc
+lMc
+lMc
 lMc
 vmi
 vmi
 rfp
 vVX
-nZA
+ghh
 vmi
 bGf
 kSK
@@ -513571,78 +513385,78 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+hAe
+oou
+vxe
+vxe
+vxe
+kpN
+iMQ
+pIl
+pIl
+rnN
+pIl
+cik
+lyG
+lyG
+vxe
+dPu
+vxe
+bQX
+vxe
+dPu
+vxe
+dPu
+dPu
+uQL
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+hCF
+lMc
+lMc
+lMc
+hCF
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+vmi
 vmi
 rfp
 vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-vHy
-jWw
-viS
-nBo
-llF
-pel
-nBo
-siN
-lvc
-jWw
-foK
-jsG
-mqT
-mqT
-mqT
-hDh
-jWw
-iLV
-lMc
-vmi
-vmi
-rfp
-vVX
-xBf
+ghh
 vmi
 bGf
 kSK
@@ -514023,78 +513837,78 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+vfL
+vxe
+xXA
+pIl
+bcB
+bcB
+bcB
+bcB
+bcB
+vxe
+pIl
+lqJ
+pIl
+dPu
+wLC
+bcB
+bcB
+oih
+bcB
+vta
+vxe
+uQL
+uQL
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+vmi
 vmi
 rfp
 vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-vHy
-jWw
-mCr
-nBo
-exS
-tUx
-cVX
-siN
-fNC
-jWw
-vTJ
-nBo
-vmI
-vmI
-vmI
-hsS
-jWw
-iLV
-lMc
-vmi
-vmi
-rfp
-vVX
-nZA
+ghh
 vmi
 bGf
 kSK
@@ -514475,78 +514289,78 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+isS
+dmo
+cry
+bcB
+bcB
+pNs
+pNs
+fAA
+bcB
+kby
+bcB
+bcB
+bcB
+vxe
+rKa
+bcB
+bcB
+bcB
+bcB
+tKl
+vxe
+uQL
+uQL
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+vmi
 vmi
 rfp
 vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-lMc
-lMc
-lMc
-lMc
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-vHy
-jWw
-nZP
-nBo
-pFh
-lLV
-nBo
-siN
-hmp
-jWw
-dKe
-siN
-siN
-siN
-siN
-siN
-jWw
-iLV
-lMc
-vmi
-vmi
-rfp
-vVX
-xBf
+ghh
 vmi
 bGf
 kSK
@@ -514927,78 +514741,78 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-vxe
-vxe
-vxe
-dkT
-qMS
-tkH
-tkH
-fBC
-azd
-atE
-atE
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+isS
+jKV
+cry
+bcB
+fAA
+sAj
+cjs
+wSh
+fAA
+pIl
+fSz
+iol
+jiA
+dPu
+wZp
+jiA
+jiA
+ukx
+uwJ
 wZr
-atE
-vxe
+pKH
+uQL
+uQL
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 lMc
 lMc
 lMc
 lMc
 lMc
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
 lMc
-vHy
-jWw
-jWw
-eeK
-nBo
-nBo
-nBo
-jWw
-jWw
-jWw
-jWw
-nan
-aEu
-siN
-siN
-pJG
-jWw
-iLV
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
 lMc
 vmi
 vmi
 rfp
 vVX
-nZA
+ghh
 vmi
 bGf
 kSK
@@ -515379,78 +515193,78 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+isS
+jKV
 vxe
-vxe
-vxe
-mWk
-fmU
-fAA
-tkH
-lNt
+beu
+azd
+oyt
+jQC
+wSh
+kwQ
+pIl
+fSz
+eKq
+fZT
+stR
+fZT
+fZT
 rwM
-atE
-atE
-atE
+pYz
+gzi
 atE
 vxe
+uQL
+uQL
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 lMc
 lMc
 lMc
 lMc
 lMc
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
 lMc
-vHy
-jWw
-jWw
-jWw
-qqK
-qqK
-jWw
-hrE
-jWw
-hrE
-jWw
-jWw
-jWw
-qqK
-qqK
-jWw
-jWw
-iLV
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
 lMc
 vmi
 vmi
 rfp
 vVX
-xBf
+ghh
 vmi
 bGf
 kSK
@@ -515831,43 +515645,41 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-vxe
-vxe
-vxe
-vxe
-vxe
-eIK
-aaK
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+isS
+jKV
+cry
+bcB
 fAA
-tkH
-imB
-wLC
-atE
-atE
-atE
-atE
-vxe
+bso
+jiV
+wSh
+fAA
+pIl
+fSz
+oAc
+lzQ
+dPu
+dsi
+lzQ
+lzQ
+joB
+hQM
+lzQ
+pKH
 uQL
 uQL
 uQL
-pdO
-lMc
+uQL
 vmi
 vmi
 vmi
@@ -515878,31 +515690,33 @@ vmi
 vmi
 vmi
 vmi
-lMc
-toG
-pEB
-pEB
-vFt
+vmi
+vmi
 lMc
 lMc
-toG
-pEB
-pEB
-pEB
-pEB
-pEB
-vFt
 lMc
 lMc
-toG
-pEB
-vFt
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
 lMc
 vmi
 vmi
 rfp
 vVX
-nZA
+ghh
 vmi
 bGf
 bGf
@@ -516283,45 +516097,45 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+isS
+dmo
+cry
+bcB
+bcB
+pyP
+pyP
+fAA
+bcB
+kby
+bcB
+bcB
+bcB
 vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-tkH
-tkH
-tkH
-oyt
-tkH
-tkH
-tkH
-tkH
-fBC
-htK
-atE
-atE
+vRR
+bcB
+bcB
+bcB
+bcB
 tKl
-atE
 vxe
-ulU
-vTc
-lnQ
-xku
-pdO
-lMc
-lMc
+uQL
+uQL
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -516354,7 +516168,7 @@ vmi
 vmi
 rfp
 vVX
-xBf
+ghh
 vmi
 bGf
 kSK
@@ -516735,46 +516549,46 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-lMc
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+hAe
 vxe
 xXA
-oqN
-mxO
-oRZ
+pIl
+bcB
+bcB
+bcB
+bcB
+bcB
 vxe
-joB
-iln
-rLB
-vxe
-tkH
-hii
-xbs
+pIl
+rov
+pIl
+dPu
 pVP
-kwQ
+trl
+bcB
+xjL
+cMu
+hii
 vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-wdE
-cXk
-tzI
-wIl
-xku
-pdO
-lMc
-lMc
+uQL
+uQL
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -516806,7 +516620,7 @@ vmi
 vmi
 rfp
 vVX
-nZA
+ghh
 vmi
 bGf
 kSK
@@ -517187,47 +517001,47 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-fXf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+vfL
 vxe
 vxe
 vxe
-lzQ
-lzQ
-bfR
+vxe
 iMQ
-vxe
-vxe
-vxe
-vxe
-vxe
-aLW
-vxe
-vxe
-vxe
-vxe
-vxe
-iAH
-oSk
-uyd
-hbc
-vxe
-vxe
-cXk
+pIl
+pIl
+oHt
+pIl
+lyG
+lyG
 weS
-jQC
-wIl
-mXe
-lMc
-lMc
-lMc
+vxe
+dPu
+vxe
+bQX
+vxe
+dPu
+vxe
+dPu
+dPu
+uQL
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -517258,7 +517072,7 @@ vmi
 vmi
 rfp
 vVX
-xBf
+ghh
 vmi
 bGf
 kSK
@@ -517639,47 +517453,47 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-tRE
-dmo
-trl
-whK
-uQS
-fAA
-fAA
-ezs
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+isS
+iqT
+ank
+ank
 vxe
-fvf
-gJJ
+wzy
+uQS
+uQS
+uQS
 rov
 lyG
-uQS
 lyG
-pyP
+lyG
+dPu
 lLL
-vxe
-nCB
-jHQ
-ugB
-ugB
+jiA
+jiA
+jiA
+jiA
+jiA
 fat
-hbc
 vxe
-piQ
-cXk
-cXk
-xMY
-mXe
-lMc
-lMc
-lMc
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -517710,7 +517524,7 @@ vmi
 vmi
 rfp
 vVX
-nZA
+ghh
 vmi
 bGf
 kSK
@@ -518091,78 +517905,78 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+isS
+vmr
+xFQ
+ank
+vxe
+xMY
+uQS
+uQS
+uQS
+pIl
+vIR
+fAA
+lfb
+vxe
+hPp
+fZT
+fZT
+fZT
+fZT
+fZT
+fZT
+pKH
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 vmi
 rfp
 vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-tRE
-hAe
-trl
-xAj
-fAA
-eoH
-fAA
-fAA
-vxe
-jiA
-jiA
-jiA
-jiA
-jiA
-jiA
-jiA
-jiA
-vxe
-pqi
-ngD
-fSz
-hfn
-aLs
-sLn
-cVU
-cXk
-cXk
-pOU
-kBZ
-mXe
-lMc
-lMc
-lMc
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-rfp
-vVX
-xBf
+ghh
 vmi
 bGf
 kSK
@@ -518543,47 +518357,47 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-tRE
-hAe
-vxe
-tGW
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+isS
+vmr
+kNL
+ank
+rov
+aLW
 fAA
+oKr
 fAA
-fAA
-fAA
+pIl
+qjb
+wSh
+ciy
+dPu
+hRe
 mYs
-fZT
-fZT
-fZT
-fZT
-fZT
-fZT
-fZT
-fZT
-mYs
-fAA
+mOD
 ngD
-fSz
-oHF
-sLn
-sLn
-gSi
-cXk
-cXk
-wQW
-kBZ
-mXe
-lMc
-lMc
-lMc
+pmh
+lzQ
+jsJ
+vxe
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -518614,7 +518428,7 @@ vmi
 vmi
 rfp
 vVX
-nZA
+ghh
 vmi
 bGf
 kSK
@@ -518995,78 +518809,78 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+isS
+iqT
+cHp
+ank
+vxe
+fBC
+fQw
+qFa
+vTc
+pIl
+qNC
+fAA
+htK
+vxe
+dPu
+vxe
+dPu
+vxe
+dPu
+vxe
+dPu
+dPu
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 vmi
 rfp
 vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-tRE
-hAe
-trl
-lXR
-fAA
-mSd
-fAA
-fAA
-vxe
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-lzQ
-vxe
-pqi
-ngD
-fSz
-aaH
-fat
-sLn
-cVU
-cXk
-cXk
-cik
-kBZ
-mXe
-lMc
-lMc
-lMc
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-rfp
-vVX
-xBf
+ghh
 vmi
 dos
 kSK
@@ -519447,47 +519261,47 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-tRE
-dmo
-trl
-gzi
-uQS
-fAA
-fAA
-ukx
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+isS
+iqT
+vmr
+vmr
+vxe
+vxe
 vxe
 wha
-dyQ
-pzw
-bQX
-uQS
-bQX
-xEs
-dDx
 vxe
-riq
-akC
-hQM
-hQM
-aLs
-mQw
 vxe
-piQ
-cXk
-cXk
-xMY
-mXe
-lMc
-lMc
-lMc
+vxe
+wha
+vxe
+vxe
+bvB
+uQL
+uQL
+uQL
+uQL
+uQL
+uQL
+uWU
+uQL
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -519518,7 +519332,7 @@ vmi
 vmi
 rfp
 vVX
-nZA
+ghh
 vmi
 ggH
 kSK
@@ -519899,78 +519713,78 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+uwf
+hAe
+oou
+oou
+oou
+vlL
+uwf
+uwf
+uwf
+uwf
+uwf
+uwf
+uwf
+uwf
+uwf
+lyq
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+dTQ
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 vmi
 rfp
 vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-hxH
-vxe
-vxe
-vxe
-jiA
-jiA
-jiA
-gOQ
-vxe
-vxe
-vxe
-vxe
-vxe
-kby
-vxe
-vxe
-vxe
-vxe
-vxe
-sLn
-sLn
-hny
-mQw
-vxe
-vxe
-cXk
-weS
-snb
-pYz
-mXe
-lMc
-lMc
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-rfp
-vVX
-xBf
+ghh
 vmi
 dos
 kSK
@@ -520351,46 +520165,46 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+wPp
 vmi
-rfp
-vVX
-rBQ
 vmi
 vmi
 vmi
 vmi
 vmi
-lMc
-lMc
-vxe
-hvW
-cry
-fZT
-ciy
-vxe
-vxe
-vxe
-mYz
-lyG
-uQS
-gyY
-cJk
-rov
-vxe
-vxe
-vxe
-beu
-vxe
-vxe
-vxe
-wdE
-cXk
-snb
-noX
-iry
-xsk
-lMc
-lMc
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+xzG
+bqk
+bqk
+bqk
+bqk
+bqk
+bqk
+uZN
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -520422,7 +520236,7 @@ gUD
 gUD
 tCB
 vVX
-nZA
+ghh
 vmi
 bGf
 kSK
@@ -520803,45 +520617,45 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+wPp
 vmi
-rfp
-vVX
-rBQ
 vmi
 vmi
 vmi
 vmi
 vmi
 vmi
-lMc
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-bEd
-fAA
-fAA
-fAA
-fAA
-uQS
-vxe
-khf
-gyY
-uQS
-wxD
-oou
-vxe
-pmh
-ltS
-pYz
-iry
-xsk
-lMc
-lMc
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+aCu
+eRG
+rlj
+pIl
+nOC
+myt
+lmP
+loz
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -520874,7 +520688,7 @@ vVX
 vVX
 vVX
 vVX
-xBf
+ghh
 vmi
 bGf
 bGf
@@ -521255,43 +521069,43 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+wPp
 vmi
-rfp
-vVX
-rBQ
 vmi
 vmi
 vmi
 vmi
 vmi
 vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-vxe
-vxe
-vxe
-qFk
-woi
-wFY
-bmn
-xFX
-uQS
-kby
-uQS
-uQS
-uQS
-wxD
-vta
-vxe
-jdT
-jdT
-jdT
-xsk
-lMc
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+aCu
+fSz
+sKU
+pIl
+fNC
+uNj
+lyG
+oZk
+uQL
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -521707,43 +521521,43 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+wPp
 vmi
-rfp
-vVX
-rBQ
 vmi
 vmi
 vmi
 vmi
 vmi
 vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-vxe
-uQS
-woi
-mKP
-gpi
-xFX
-uQS
-iag
-yhX
-yhX
-yhX
-hFO
-wdr
-vxe
-lMc
-lMc
-lMc
-lMc
-lMc
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+aCu
+sRD
+sKU
+pIl
+fBd
+fPZ
+wQW
+loz
+uQL
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -522159,10 +521973,17 @@ bGf
 bGf
 bGf
 bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+wPp
 vmi
-rfp
-vVX
-rBQ
 vmi
 vmi
 vmi
@@ -522172,30 +521993,23 @@ vmi
 vmi
 vmi
 vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-vxe
-tCk
-woi
-fgP
-rSH
-xFX
-uQS
-vxe
-spe
-scY
-ant
-aQt
-vxe
-vxe
-lMc
-lMc
-lMc
-lMc
-lMc
+vmi
+vmi
+vmi
+vmi
+vmi
+bJB
+uWp
+rLU
+fiP
+lyG
+lyG
+lyG
+oZk
+uQL
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -522611,43 +522425,43 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+wPp
 vmi
 vmi
-lMc
-lMc
-lMc
-lMc
-vxe
-bQX
-uQS
-uQS
-uQS
-uQS
-bQX
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-vxe
-lMc
-lMc
-lMc
-lMc
-lMc
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+aCu
+uWp
+uWp
+pIl
+pda
+fAA
+ine
+loz
+uQL
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -523063,43 +522877,43 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+wPp
 vmi
 vmi
 vmi
 vmi
 vmi
-lMc
-vxe
-vxe
-ftV
-sAj
-uEo
-sbB
-vxe
-vxe
-vxe
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+aCu
+pIl
+pIl
+pIl
+pIl
+eeK
+pIl
+loz
+uQL
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -523515,43 +523329,43 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+wPp
 vmi
 vmi
 vmi
 vmi
 vmi
-lMc
-lMc
-vxe
-vxe
-lfz
-lfz
-vxe
-vxe
-vxe
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+aCu
+mjw
+fAA
+ffL
+lyG
+lyG
+lyG
+loz
+uQL
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -523586,7 +523400,7 @@ vVX
 vVX
 vVX
 vVX
-xBf
+ghh
 vmi
 bGf
 kSK
@@ -523967,43 +523781,43 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+wPp
 vmi
 vmi
 vmi
 vmi
 vmi
-lMc
-lMc
-lMc
-rGe
-jdT
-jdT
-xsk
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+bJB
+aoJ
+fAA
+wtb
+lyG
+jQJ
+lyG
+oZk
+uQL
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -524038,7 +523852,7 @@ szS
 szS
 tCB
 vVX
-nZA
+ghh
 vmi
 bGf
 kSK
@@ -524419,43 +524233,16 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+wPp
 vmi
 vmi
 vmi
@@ -524463,6 +524250,39 @@ vmi
 vmi
 vmi
 vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+aCu
+lyG
+lyG
+lyG
+lyG
+lyG
+lyG
+loz
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+rUy
 vmi
 vmi
 vmi
@@ -524474,12 +524294,6 @@ vmi
 vmi
 vmi
 vmi
-rUy
-vmi
-vmi
-vmi
-vmi
-vmi
 vmi
 vmi
 vmi
@@ -524490,7 +524304,7 @@ vmi
 vmi
 rfp
 vVX
-xBf
+ghh
 vmi
 bGf
 kSK
@@ -524871,43 +524685,16 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+wPp
 vmi
 vmi
 vmi
@@ -524916,6 +524703,39 @@ vmi
 vmi
 vmi
 vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+aCu
+vdf
+hox
+hox
+hox
+lyG
+tEW
+oZk
+uQL
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+egu
+uZh
+fCh
 vmi
 vmi
 vmi
@@ -524925,12 +524745,6 @@ fCh
 vmi
 vmi
 vmi
-egu
-uZh
-fCh
-vmi
-vmi
-vmi
 vmi
 vmi
 vmi
@@ -524942,7 +524756,7 @@ vmi
 vmi
 rfp
 vVX
-nZA
+ghh
 vmi
 bGf
 kSK
@@ -525323,43 +525137,43 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+wPp
 vmi
 vmi
 vmi
 vmi
 vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+aCu
+dJv
+jlB
+fyA
+iJp
+hog
+viS
+loz
+uQL
+vmi
+vmi
+vmi
 vmi
 vmi
 vmi
@@ -525394,7 +525208,7 @@ vmi
 vmi
 rfp
 vVX
-xBf
+ghh
 vmi
 bGf
 kSK
@@ -525775,40 +525589,40 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
-lMc
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+wPp
+jWw
 vmi
 vmi
 vmi
 vmi
 vmi
 vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+vmi
+rSJ
+vmI
+vmI
+vmI
+vmI
+vmI
+vmI
+jsG
+uQL
 vmi
 vmi
 vmi
@@ -525846,7 +525660,7 @@ vmi
 vmi
 rfp
 vVX
-nZA
+ghh
 vmi
 bGf
 kSK
@@ -526227,18 +526041,18 @@ bGf
 bGf
 bGf
 bGf
-vmi
-rfp
-vVX
-rBQ
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+jWw
+jWw
+jWw
 vmi
 vmi
 vmi
@@ -526298,7 +526112,7 @@ vmi
 vmi
 rfp
 vVX
-xBf
+ghh
 vmi
 bGf
 bGf
@@ -526683,15 +526497,15 @@ vmi
 jWw
 eps
 jWw
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+bGf
+bGf
+bGf
+bGf
+jWw
+jWw
+yjG
+jWw
+jWw
 lMc
 lMc
 lMc
@@ -527136,14 +526950,14 @@ jWw
 iWa
 jWw
 jWw
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
+bGf
+bGf
+bGf
+iVE
+iWa
+iWa
+iWa
+iVE
 lMc
 lMc
 lMc
@@ -527588,14 +527402,14 @@ iWa
 iWa
 iWa
 iVE
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-lMc
+bGf
+bGf
+bGf
+vgL
+iWa
+iWa
+dJt
+eps
 lMc
 lMc
 lMc
@@ -528040,14 +527854,14 @@ jWw
 wux
 jWw
 jWw
-iXc
-iXc
-iXc
-iXc
-iXc
-iXc
-iXc
-lMc
+nUS
+nUS
+nUS
+iVE
+iWa
+iWa
+iWa
+iVE
 lMc
 lMc
 lMc
@@ -528491,15 +528305,15 @@ vmi
 jWw
 iVE
 jWw
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
-vmi
+aBB
+aBB
+aBB
+aBB
+jWw
+jWw
+iWa
+jWw
+jWw
 lMc
 lMc
 lMc
@@ -528948,9 +528762,9 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
+jWw
+jWw
+jWw
 aBB
 aBB
 aBB
@@ -529401,7 +529215,7 @@ aBB
 aBB
 aBB
 aBB
-aBB
+jWw
 aBB
 aBB
 aBB


### PR DESCRIPTION
## About The Pull Request

The Azure Peak keep is an enormous, indefensible mansion that looks like the pleasure palace of an Arch-Duke and not the grimdark keep of an embattled Barony. 

The new keep features all the amenities of the normal keep in a much smaller footprint. 

So much smaller that I also moved the steward's office into a tower inside the walls with room to spare for a bathhouse.

The steward in town has been replaced with a town square. The guillotine platform has been moved to the center while the physician's office has been moved down four tiles to compensate. 

The keep has a more rustic feel while still being luxurious. 

It has rooms and spawn locations for two heirs, three guests, the lord, the jester, servants, the butler, four knights, hostages, the knight captains, the squires, the marshal, the hand, three councilors (can be used as backup guest rooms) and the physician.

A wing for the court physician, the hospital and his lab. 

It has a chapel, a vault and a "great hall" that functions as a throne room and a feast hall. 

A reduced but still significant armory for the knights.

The vault and steward's office contain a bounty of keys, with generic role's keys in the steward office while specific role's keys are found in the vault.

Loot in general has been lowered from AP's gold silverware everywhere. 

The lord's office has a lever that drops the chair sitting across from him down from the third floor into the ground floor great hall.

There's a small 'panic room' hidden behind a painting in the great hall for the lord.

There are numerous entrances to the main keep but at a minimum they're defended by donjon doors or require being in the walls already and careful maneuvering on roofs.

A drawbridge has been added to isolate the keep from the usually unguarded northern town wall. It currently uses the Kybraxor sprite.

The garden at the rear of the courtyard has been eliminated, with a moat being 'added' on that side in place of the wall.

The mage's tower, garrison and training yard have remained untouched currently.

## Testing Evidence

All doors have been tested, all stairs have been tested, the lighting has been tested, the floor hatch and drawbridge have been tested. I'm not skilled enough at Dream Daemon to test spawn locations but they all look like they're there. 

## Why It's Good For The Game

Complaints about AP's keep have been endless, from its opulence to its openness to its being incredibly full of holes defensively. I hope that this will improve Keep gameplay for everyone involved. 
