### PR TITLE
Humble Druid PR: brother may I have more slots

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -4,8 +4,8 @@
 	flag = DRUID
 	department_flag = CHURCHMEN
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 5
+	spawn_positions = 5
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS


### PR DESCRIPTION

**## About The Pull Request**

- Increases the slots from 2 to 5.
- 
## Testing Evidence

It is two values numerically, it shall work.

**## Why It's Good For The Game**

Druids are not fully treated as members of the church, though they are dendorites. Having a lock on them that is similiar to church acolytes helps them to stand out and roleplay around their focus.

Druids are also very isolationist and solitary, meaning they tend to spread out very far across the map or otherwise huddle together.

I believe that 5 slots will serve scarlet reach's current population boost as a good place for a while.
