### PR TITLE
The moderate option: Makes the keep reasonably harder to break into

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -2077,11 +2077,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "aIC" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/obj/structure/flora/roguetree/pine,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/exposed/town/keep)
 "aIJ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -7380,6 +7378,12 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
+"cwT" = (
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/magician)
 "cwY" = (
 /obj/structure/stairs,
 /turf/open/transparent/openspace,
@@ -8454,11 +8458,6 @@
 	dir = 10;
 	icon_state = "cobbleedge-w"
 	},
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/obj/item/book/rogue/law,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "cPa" = (
@@ -8838,7 +8837,7 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "cVU" = (
-/obj/structure/roguewindow/openclose{
+/obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
 	},
 /turf/open/floor/rogue/hexstone,
@@ -8930,6 +8929,26 @@
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
+"cXj" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/paper{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/paper{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/paper{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/natural/feather,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/garrison)
 "cXk" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
@@ -12766,23 +12785,6 @@
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/paper{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/paper{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/paper{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/natural/feather,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "eok" = (
@@ -15007,7 +15009,7 @@
 	},
 /area/rogue/indoors/town/tavern)
 "fbp" = (
-/obj/structure/roguewindow/openclose{
+/obj/structure/roguewindow/openclose/reinforced{
 	dir = 4
 	},
 /turf/open/floor/rogue/concrete,
@@ -15817,6 +15819,12 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
+"fmG" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "fmO" = (
 /obj/structure/table/wood{
 	icon_state = "map1"
@@ -19574,9 +19582,6 @@
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "gyR" = (
@@ -20659,10 +20664,13 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "gSi" = (
-/obj/structure/mineral_door/wood/fancywood{
+/obj/structure/mineral_door/wood/donjon{
+	desc = "a large door. It seems big enough to fit a mount.";
+	dir = 1;
 	locked = 1;
 	lockid = "royal";
-	name = "Lord's Apartment"
+	name = "keep entrance";
+	ridethrough = 1
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
@@ -24043,7 +24051,9 @@
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
-/obj/structure/chair/stool/rogue,
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
+	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
 "hUf" = (
@@ -24478,6 +24488,17 @@
 /obj/effect/landmark/start/villager,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
+"ice" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/garrison)
 "icf" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -25950,6 +25971,14 @@
 /obj/item/roguestatue/steel,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"iAJ" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/obj/item/book/rogue/law,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/garrison)
 "iAM" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -31657,11 +31686,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
 "kwA" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/turf/closed/wall/mineral/rogue/stone/window,
+/area/rogue/outdoors/town/roofs/keep)
 "kwI" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt/road,
@@ -36327,9 +36353,6 @@
 	dir = 10;
 	icon_state = "cobbleedge-n"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "lZX" = (
@@ -36658,6 +36681,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/physician)
+"meP" = (
+/obj/structure/flora/roguetree/pine/dead,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "meU" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -37232,6 +37259,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
+/obj/item/quiver/arrows,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "mpz" = (
@@ -38272,9 +38300,6 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
 "mHO" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "mIc" = (
@@ -41725,6 +41750,27 @@
 /obj/item/paper,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"nOQ" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "vertw"
+	},
+/area/rogue/indoors/town/garrison)
 "nOW" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
@@ -41998,6 +42044,9 @@
 /obj/structure/fluff/railing/wood{
 	dir = 8;
 	pixel_x = -8
+	},
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
@@ -43027,14 +43076,6 @@
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = -6
-	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "ojM" = (
@@ -44033,7 +44074,7 @@
 /obj/structure/closet/crate/chest/neu,
 /obj/item/rope/chain,
 /obj/structure/fluff/railing/border{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
@@ -45818,6 +45859,9 @@
 	dir = 8;
 	pixel_x = -8
 	},
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
+	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
 "piN" = (
@@ -47094,6 +47138,16 @@
 /obj/item/reagent_containers/glass/bottle/rogue/beer/voddena,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
+"pFm" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "pFn" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/concrete,
@@ -47503,6 +47557,9 @@
 	dir = 8
 	},
 /obj/machinery/light/rogue/torchholder/c,
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
+	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
 "pLW" = (
@@ -48365,6 +48422,12 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement)
+"qah" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "qat" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -50674,13 +50737,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "qNm" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/fluff/railing/border,
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
 "qNn" = (
 /obj/structure/table/wood{
@@ -51999,14 +52057,13 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
 "rlK" = (
-/obj/structure/rack/rogue,
-/obj/item/quiver/arrows,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 8
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "rlQ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -60487,7 +60544,7 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/tavern)
 "tYN" = (
-/obj/structure/flora/newtree,
+/obj/structure/flora/roguetree/pine/dead,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
 "tYO" = (
@@ -62258,6 +62315,9 @@
 	dir = 8;
 	pixel_x = -10
 	},
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
+	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
 "uCg" = (
@@ -63008,11 +63068,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/garrison)
 "uPj" = (
 /obj/effect/landmark/mapGenerator/rogue/beach{
@@ -64361,7 +64417,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
 "vlL" = (
-/obj/structure/flora/newtree,
+/obj/structure/flora/roguetree/pine,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "vlP" = (
@@ -65172,6 +65228,9 @@
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 10
+	},
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
@@ -68795,9 +68854,14 @@
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "wGW" = (
 /obj/effect/decal/cobbleedge{
-	dir = 4
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "wHb" = (
 /obj/structure/closet/crate/chest/wicker,
@@ -177330,7 +177394,7 @@ bHV
 bHV
 bHV
 cUH
-mMx
+dVJ
 mMx
 mMx
 mMx
@@ -278568,17 +278632,17 @@ bge
 bge
 hrE
 jWw
-kwA
 iWa
+usR
 kXD
 hrE
 bUG
 gzy
 wCT
 hrE
-cMf
-cMf
-cMf
+cXj
+iAJ
+ice
 jWw
 jWw
 bge
@@ -279020,7 +279084,7 @@ bge
 bge
 hrE
 hrE
-vgL
+fmG
 iWa
 usR
 hrE
@@ -279472,9 +279536,9 @@ phl
 phl
 jWw
 jWw
-jWw
-eps
-jWw
+vgL
+iWa
+iWa
 hrE
 flt
 jwl
@@ -279925,8 +279989,8 @@ phl
 jWw
 jWw
 jWw
-hQG
 wGW
+jWw
 hrE
 vEn
 axl
@@ -282613,7 +282677,7 @@ rMf
 izp
 aat
 aat
-tYN
+aIC
 uhI
 uhI
 rMf
@@ -286219,7 +286283,7 @@ lKO
 lKo
 waL
 uhI
-tYN
+aIC
 rMf
 rMf
 weQ
@@ -289835,7 +289899,7 @@ pqo
 lKo
 aat
 rMf
-tYN
+aIC
 rMf
 rMf
 weQ
@@ -291642,7 +291706,7 @@ lKo
 jdu
 lKo
 nwG
-vlL
+meP
 rMf
 uhI
 uhI
@@ -294816,7 +294880,7 @@ uhI
 rMf
 rMf
 rMf
-tYN
+aIC
 uhI
 weQ
 weQ
@@ -295716,7 +295780,7 @@ idI
 wxu
 lKw
 uhI
-vlL
+rMf
 rMf
 rMf
 weQ
@@ -296168,7 +296232,7 @@ pqC
 nwG
 bAU
 rni
-uhI
+aIC
 rMf
 phl
 ank
@@ -392927,14 +392991,14 @@ kSK
 kSK
 jWw
 jWw
-iVE
+cMf
 hrE
-iVE
-iVE
-iVE
+cMf
+cMf
+cMf
 jWw
 jWw
-iVE
+cMf
 jWw
 jWw
 kSK
@@ -393832,11 +393896,11 @@ jWw
 lZX
 mLc
 gIi
-icA
+aIJ
 lZW
 mHO
 gyM
-aIC
+iWa
 hVb
 aIJ
 iWa
@@ -394284,10 +394348,10 @@ hrE
 qNm
 iWa
 ptv
-uOV
-rCV
-rCV
-rCV
+icA
+qah
+qah
+qah
 oEv
 hVb
 aIJ
@@ -394717,26 +394781,26 @@ yjG
 hrE
 hrE
 hrE
-iVE
+cMf
 jWw
-iVE
+cMf
 jWw
-iVE
-jWw
-hrE
-jWw
-jWw
-iVE
-jWw
-iVE
-jWw
-iVE
+cMf
 jWw
 hrE
-mnC
+jWw
+jWw
+cMf
+jWw
+cMf
+jWw
+cMf
+jWw
+hrE
+pFm
 iWa
 hVb
-uOV
+nOQ
 rCV
 rCV
 rCV
@@ -394747,20 +394811,20 @@ iWa
 hrE
 hrE
 jWw
-iVE
+cMf
 jWw
-iVE
+cMf
 hrE
-iVE
+cMf
 jWw
 jWw
-iVE
+cMf
 jWw
-iVE
+cMf
 jWw
-iVE
+cMf
 hrE
-iVE
+cMf
 jWw
 jWw
 jWw
@@ -395192,7 +395256,7 @@ uOV
 rCV
 rCV
 rCV
-rlK
+jWw
 hVb
 iWa
 iWa
@@ -395598,7 +395662,7 @@ bGf
 bGf
 bGf
 bGf
-iVE
+cMf
 iWa
 iWa
 yjG
@@ -406966,7 +407030,7 @@ vmi
 vmi
 tRE
 vVX
-iVE
+cMf
 iWa
 iWa
 dJt
@@ -411432,7 +411496,7 @@ vmi
 vmi
 vmi
 hrE
-iVE
+cMf
 jWw
 vmi
 vmi
@@ -412322,7 +412386,7 @@ aDs
 aDs
 aDs
 aDs
-iVE
+cMf
 iWa
 iWa
 iWa
@@ -412394,7 +412458,7 @@ eps
 iWa
 iWa
 iWa
-iVE
+cMf
 gLt
 gLt
 gLt
@@ -413228,7 +413292,7 @@ aBB
 aBB
 aBB
 hrE
-iVE
+cMf
 jWw
 aBB
 aBB
@@ -413240,7 +413304,7 @@ aBB
 aBB
 aBB
 jWw
-iVE
+cMf
 jWw
 aBB
 aBB
@@ -413296,7 +413360,7 @@ aBB
 aBB
 aBB
 jWw
-iVE
+cMf
 hrE
 aBB
 aBB
@@ -413720,10 +413784,10 @@ sqG
 sqG
 nlt
 vrU
-xOX
+cwT
 vrU
 vrU
-xOX
+cwT
 vrU
 iSm
 iSm
@@ -506834,9 +506898,9 @@ bGf
 bGf
 bGf
 tCB
-nZA
-xBf
-nZA
+kwA
+xpH
+kwA
 tCB
 bGf
 bGf
@@ -507736,13 +507800,13 @@ bGf
 bGf
 bGf
 bGf
-nZA
+kwA
 pRP
 pRP
 pRP
 pRP
 pRP
-nZA
+kwA
 bGf
 bGf
 bGf
@@ -508188,13 +508252,13 @@ bGf
 bGf
 lMc
 lMc
-nZA
+kwA
 pRP
 pRP
 pRP
 pRP
 pRP
-nZA
+kwA
 lMc
 lMc
 lMc
@@ -509095,7 +509159,7 @@ lMc
 lMc
 xpH
 wrR
-xBf
+xpH
 wrR
 xpH
 lMc
@@ -509957,7 +510021,7 @@ bGf
 bGf
 bGf
 jWw
-iVE
+cMf
 jWw
 vmi
 vmi
@@ -510424,11 +510488,11 @@ qad
 qad
 qad
 qad
-iVE
+cMf
 iWa
 iWa
 iWa
-iVE
+cMf
 lMc
 lMc
 lMc
@@ -510475,11 +510539,11 @@ jWw
 iLV
 lMc
 lMc
-iVE
+cMf
 iWa
 iWa
 iWa
-iVE
+cMf
 bGf
 kSK
 kSK
@@ -510859,7 +510923,7 @@ bGf
 bGf
 bGf
 bGf
-iVE
+cMf
 iWa
 iWa
 iWa
@@ -511328,11 +511392,11 @@ vJa
 vJa
 vJa
 vJa
-iVE
+cMf
 iWa
 iWa
 iWa
-iVE
+cMf
 lMc
 lMc
 lMc
@@ -511379,11 +511443,11 @@ jWw
 iLV
 lMc
 lMc
-iVE
+cMf
 iWa
 iWa
 iWa
-iVE
+cMf
 bGf
 kSK
 kSK
@@ -522227,11 +522291,11 @@ vmi
 vmi
 tRE
 vVX
-iVE
+cMf
 afp
 iWa
 dJt
-iVE
+cMf
 bGf
 kSK
 kSK
@@ -523536,8 +523600,8 @@ lMc
 lMc
 vxe
 vxe
-lfz
-lfz
+rlK
+rlK
 vxe
 vxe
 vxe
@@ -527583,11 +527647,11 @@ bGf
 bGf
 bGf
 bGf
-iVE
+cMf
 iWa
 iWa
 iWa
-iVE
+cMf
 vmi
 vmi
 vmi
@@ -527651,11 +527715,11 @@ vmi
 vmi
 vmi
 vmi
-iVE
+cMf
 iWa
 iWa
 iWa
-iVE
+cMf
 bGf
 bGf
 bGf
@@ -528489,7 +528553,7 @@ bGf
 bGf
 vmi
 jWw
-iVE
+cMf
 jWw
 vmi
 vmi
@@ -528557,7 +528621,7 @@ vmi
 vmi
 vmi
 jWw
-iVE
+cMf
 jWw
 vmi
 bGf


### PR DESCRIPTION
## About The Pull Request
After reviewing the other Keep PR open currently, it reminded me there's significant concern for just _how easy the keep is to break into;_ so, I grabbed my friends that play Knight, opened up strongDMM, and I got to work. The goal was simply to make _tweaks_ to our nice manor that reduce the easiest, most prevalent break-and-enter and escape routes without making it impervious to infiltration. It turns out, there's a significant number of windows, doors and places around the keep that seem _intentionally_ more vulnerable even than common areas around the town!

<img width="503" height="575" alt="StrongDMM_IErtTtgldT" src="https://github.com/user-attachments/assets/a9965f52-cd0c-4a3f-997d-4146e603a6b4" />

I was told apparently the wizard apprentice's room is a fairly common place to enter via the roofing outside the Keep wall on the east. These windows are now the stronger variation.


<img width="357" height="431" alt="StrongDMM_BJQoSaWMyH" src="https://github.com/user-attachments/assets/f5957a17-671d-442a-9d4a-ac5b21b1f413" />

This sewer is apparently also used to break into the basements. I simply doubled up the bars so it takes longer loudly bashing on the metal to get in through here, so you're at more of a risk alerting people by doing this.


<img width="574" height="639" alt="StrongDMM_n4MAOUh5tN" src="https://github.com/user-attachments/assets/45687247-c959-4a15-8e24-06dc25565dba" />
<img width="643" height="500" alt="StrongDMM_opRZ6rM7XX" src="https://github.com/user-attachments/assets/954070e4-bf29-40b8-8134-a6b1551f064c" />

Two areas of the Duke's apartment have had windows, and one door, replaced with the stronger variations. The fact that vulnerable, roof-accessible portions of the Duke apartment were using weaker windows than the Inn ones was kind of a huh moment to me. Yes, the door should be keyed properly.


<img width="573" height="788" alt="StrongDMM_E9W7Eh1SUk" src="https://github.com/user-attachments/assets/9fe33576-655d-4a4a-9527-ad7a516b5420" />

This area where you can shoot down into the Keep's main gate has been reduced and tweaked to be harder to climb into. A pillar has been placed where people were apparently just able to climb up? (???) And I placed a symmetrical pillar opposite to make it look a little nicer. I also added a wicker basket full of rocks like the north town gate, because it's fucking hilarious. It is actually still possible to climb up into here, possibly, in one place - it's just harder to do so..


<img width="569" height="442" alt="dreamseeker_1j1JHaN5dK" src="https://github.com/user-attachments/assets/26088b6b-6a1e-4f62-9444-8baabffb591f" />
<img width="705" height="522" alt="dreamseeker_V4qzBesqyb" src="https://github.com/user-attachments/assets/58353877-4b8c-44f4-8c4b-d1ef5861ce23" />
North and south gate areas have been made harder to bridge into with the addition of reinforced windows. This means the north room is harder to break into; before, you could literally just jump over the fences and be in. The south room is now also a viable place to break and enter, however. I wanted to make these stone windows, but my Knight friend thought it would be too "thief proof".

![dreamseeker_PZuDjw8DIX](https://github.com/user-attachments/assets/afa77537-c2d6-4503-9338-282163bfd150)

The stairs do work.


<img width="606" height="619" alt="StrongDMM_Z56lgR2iRq" src="https://github.com/user-attachments/assets/153bf52e-5a5e-4e31-a9b4-f6f52c17d771" />
<img width="606" height="683" alt="StrongDMM_4dKValDL9T" src="https://github.com/user-attachments/assets/871e4fd9-a384-499a-a451-b026ff823369" />

Controversially, the trees in the yard have been replaced with pixel trees. This effectively eliminates the issue of people cutting down these stupid fucking trees every round, or else having an all-access-pass to every level of the Keep through vulnerable windows; however, they can also be hidden behind and it can be hard to see people behind these. There are still very much ways to get in, but I am open to undoing this, I just thought it was worth trying instead of having the backyard be fucking barren every round.

A bunch of wooden windows have simply been replaced with stone around the outer wall and Keep watchtowers. Still breakable, but takes longer to do so, allowing guards and knights to potentially hear it and react.


<img width="305" height="284" alt="StrongDMM_HizFo1Wdq9" src="https://github.com/user-attachments/assets/ba3d48dc-c31a-4006-b3ef-b6c583b81e9d" />

Finally, removed inexplicable wall linens.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I walked around it, realized what an empty space actually does, and fixed everything from having actually walked around and tried all the doors and windows. I even broke some of them to make sure.
<img width="328" height="309" alt="dreamseeker_e4GjfmM262" src="https://github.com/user-attachments/assets/8244436a-b19d-44db-b08f-153e1eebe968" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

There's definitely truth to the prevalent opinion that the thief's game of cat and mouse around the keep right now, without Azure Peak's restrictions, have become pretty insufferable and intolerably easy to do all game. Hopefully some _reductions_ to the ease of access throughout key infiltration areas around the keep will mitigate it. Making these areas simply _stronger variations_ rather than walling them off or something still allows for infiltration, but allows keep players more of a chance to hear it happening.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
