### PR TITLE
(Technically a bugfix) It is now possible to consult with the actors button in the title screen and politely ask it to tell you what species someone is.

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -239,10 +239,17 @@
 			var/mob/living/carbon/human/Hu = H
 			GLOB.actors_list[H.mobid] = "[H.real_name] as the [Hu.dna.species.name] [H.mind.assigned_role]<BR>"
 	if (!hidden_job)
-		if (obsfuscated_job)
-			GLOB.actors_list[H.mobid] = "[H.real_name] as Adventurer<BR>"
+		var/mob/living/carbon/human/Hu = H 
+		if (istype(H, /mob/living/carbon/human))
+			if (obsfuscated_job)
+				GLOB.actors_list[H.mobid] = "[H.real_name] as the [Hu.dna.species.name] Adventurer<BR>"
+			else
+				GLOB.actors_list[H.mobid] = "[H.real_name] as the [Hu.dna.species.name] [H.mind.assigned_role]<BR>"
 		else
-			GLOB.actors_list[H.mobid] = "[H.real_name] as [H.mind.assigned_role]<BR>"
+			if (obsfuscated_job)
+				GLOB.actors_list[H.mobid] = "[H.real_name] as Adventurer<BR>"
+			else
+				GLOB.actors_list[H.mobid] = "[H.real_name] as [H.mind.assigned_role]<BR>"
 
 /client/verb/set_mugshot()
 	set category = "OOC"


### PR DESCRIPTION
## About The Pull Request

Imagine a world where you could click on the Actors menu, and you could _see_ what species other characters were, not just a name that sounds vaguely lizard like. This may sound like an impossible dream, but it is not, for I have returned the feature to Scarlet Reach.

(You can click the actors list and see the species of characters on it. That's all this PR does.)

## Testing Evidence

Despite this being a teeny change, I am a diligant individual who did, indeed, test it. 

It worked.

<img width="378" height="130" alt="image" src="https://github.com/user-attachments/assets/936ccc37-06c7-40d9-b244-400cbc3627db" />

## Why It's Good For The Game

Sometimes it's nice to know what species' a certain character is - particularly if you're an heir trying to match species with the Duke, or you wish to hit on the tavern keeper for a while, but would die inside if you approached them and they turned out to be a disgusting elf.

People also liked the suggestion on Discord, and this is actually less an _addition_ to the game and more a bugfix, as the features were there, but had stopped working due to some new code that spawned in.
