### PR TITLE
adds mentha zigs to goldface, purity, and crafting

### DIFF
--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -38,6 +38,11 @@
 	stressadd = -2
 	desc = list(span_green("A relaxing smoke."),span_green("A flavorful smoke."))
 
+/datum/stressevent/menthasmoke
+	timer = 1 MINUTES
+	stressadd = -1
+	desc = list(span_blue("A cooling feeling in my throat."))
+
 /datum/stressevent/weed
 	timer = 5 MINUTES
 	stressadd = -4

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -348,6 +348,15 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/rollie/nicotine
 	list_reagents = list(/datum/reagent/drug/nicotine = 30)
 
+/obj/item/clothing/mask/cigarette/rollie/mentha // not a subtype of nicotine for crafting reasons
+	name = "mentha zig"
+	desc = "Dried westleach carefully wrapped in fine paper. It has a particularly smooth taste with a cooling effect."
+	list_reagents = list(/datum/reagent/drug/nicotine = 30, /datum/reagent/drug/mentha = 15)
+
+/obj/item/clothing/mask/cigarette/rollie/mentha/crafted
+	name = "handmade mentha zig"
+	desc = "A rewrapped westleach zig with some alchemically extracted mentha essence."
+
 /obj/item/clothing/mask/cigarette/rollie/nicotine/cheroot
 	name = "cheroot"
 	desc = "Rich smokeleaf self-rolled into an open-clipped cigarillo. Envigorating for the enthusiast, \

--- a/code/modules/cargo/packsrogue/merchant/luxury.dm
+++ b/code/modules/cargo/packsrogue/merchant/luxury.dm
@@ -8,6 +8,11 @@
 	cost = 3
 	contains = list(/obj/item/clothing/mask/cigarette/rollie/nicotine)
 
+/datum/supply_pack/rogue/luxury/msigs
+	name = "Mentha Zig"
+	cost = 4
+	contains = list(/obj/item/clothing/mask/cigarette/rollie/mentha)
+
 /datum/supply_pack/rogue/luxury/ozium
 	name = "Ozium"
 	cost = 5

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -110,6 +110,35 @@
 	..()
 	. = 1
 
+/datum/reagent/drug/mentha // distinct from SS13 menthol, for the mentha zigs
+	name = "Mentha"
+	description = "Extract from the mentha herb. Produces a cooling sensation."
+	reagent_state = LIQUID
+	color = "#FFFFFF"
+	addiction_threshold = 999
+	taste_description = "mentha"
+	trippy = FALSE
+	overdose_threshold=999
+	metabolization_rate = 0.1 * REAGENTS_METABOLISM
+
+/datum/reagent/drug/mentha/on_mob_end_metabolize(mob/living/M)
+	..()
+
+/datum/reagent/drug/mentha/on_mob_metabolize(mob/living/M)
+	var/mob/living/carbon/V = M
+	V.add_stress(/datum/stressevent/menthasmoke)
+	..()
+
+/datum/reagent/drug/mentha/on_mob_life(mob/living/carbon/M)
+	..()
+	. = 1
+
+/datum/reagent/drug/mentha/overdose_process(mob/living/M)
+	M.adjustToxLoss(0.1*REM, 0)
+	M.adjustOxyLoss(1.1*REM, 0)
+	..()
+	. = 1
+
 /datum/reagent/drug/crank
 	name = "Crank"
 	description = "Reduces stun times by about 200%. If overdosed or addicted it will deal significant Toxin, Brute and Brain damage."

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -74,6 +74,13 @@
 	reqs = list(/obj/item/herbseed/taraxacum = 1, /obj/item/herbseed/euphrasia = 1, /obj/item/herbseed/hypericum = 1, /obj/item/herbseed/salvia = 1)
 	craftdiff = 3
 
+/datum/crafting_recipe/roguetown/alchemy/menthazig
+	name = "handmade mentha zig"
+	category = "Table"
+	result = list(/obj/item/clothing/mask/cigarette/rollie/mentha/crafted)
+	reqs = list(/obj/item/clothing/mask/cigarette/rollie/nicotine = 1, /obj/item/alch/mentha = 1)
+	craftdiff = 1
+
 //Hard to craft but feasable, will give ONE vial but that has 10 units so, enough to cure 2 people if they ration it.
 /datum/crafting_recipe/roguetown/alchemy/curerot
 	name = "rot cure potion"

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -246,6 +246,7 @@
 	held_items[/obj/item/reagent_containers/powder/ozium] = list("PRICE" = rand(6,15),"NAME" = "ozium")
 	held_items[/obj/item/reagent_containers/powder/moondust] = list("PRICE" = rand(13,25),"NAME" = "moondust")
 	held_items[/obj/item/clothing/mask/cigarette/rollie/cannabis] = list("PRICE" = rand(12,18),"NAME" = "swampweed zig")
+	held_items[/obj/item/clothing/mask/cigarette/rollie/mentha] = list("PRICE" = rand(6,11),"NAME" = "mentha zig")
 	held_items[/obj/item/clothing/mask/cigarette/rollie/nicotine] = list("PRICE" = rand(5,10),"NAME" = "zig")
 	held_items[/obj/item/reagent_containers/glass/bottle/rogue/emberwine] = list("PRICE" = rand(100,140),"NAME" = "unlabeled emberwine")
 /*	held_items[/obj/item/reagent_containers/glass/bottle/rogue/wine] = list("PRICE" = rand(35,77),"NAME" = "vino")


### PR DESCRIPTION
## About The Pull Request
there is mentha, and there are zigs, but they have never been combinable before... until now.
- mentha zigs are mostly the same as standard westleach, but contain an additional fluff chemical that provides an extra moodlet
- you can buy mentha zigs from the PURITY and from the GOLDFACE for roughly the same price as normal zigs
- lvl 1 alch lets you combine a normal zig and a mentha herb at an alchemy table
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
smoked it in game, checked goldface -> luxury and the PURITY, crafted it with level 1 alch.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
my favorite number is seven
<img width="844" height="316" alt="Screenshot from 2025-07-11 22-52-12" src="https://github.com/user-attachments/assets/6fa6a135-70c3-4611-a677-bb5a9242532c" />
<img width="396" height="216" alt="Screenshot from 2025-07-11 23-16-16" src="https://github.com/user-attachments/assets/23b9cbbf-f0f4-4993-90fe-bda39e1ae890" />

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
