### PR TITLE
Bandits can spawn even if there's less than the "desired" amount

### DIFF
--- a/code/modules/events/antagonist/solo/bandits.dm
+++ b/code/modules/events/antagonist/solo/bandits.dm
@@ -51,6 +51,18 @@
 	typepath = /datum/round_event/antagonist/solo/bandits
 	antag_datum = /datum/antagonist/bandit
 
+/datum/round_event_control/antagonist/solo/bandits/canSpawnEvent(players_amt, gamemode, fake_check)
+	. = ..()
+	if(!.)
+		return
+	var/list/candidates = get_candidates()
+	
+	// Allow the event to run if there's at least 1 candidate, even if fewer than desired
+	if(length(candidates) < 1)
+		return FALSE
+	
+	return TRUE
+
 /datum/round_event/antagonist/solo/bandits
 	var/leader = FALSE
 


### PR DESCRIPTION


There's a quirk with the CanSpawnEvent that I found on my Thieves' guild PR Essentially, if there's not enough people readied up for bandit, no one can be a bandit. This PR will make it so bandits will always spawn as long as 1 person has readied up:

Solo bandit on local host 
<img width="2558" height="1439" alt="image" src="https://github.com/user-attachments/assets/405a2247-690f-4b45-ab0d-445562dc8399" />
