### PR TITLE
Entry whitelist overhaul

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,12 +1,27 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.10; The query to update the schema revision table is:
+The latest database version is 5.11; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 10);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 11);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 10);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 11);
 
 In any query remember to add a prefix to the table names if you use one.
+
+-----------------------------------------------------
+Version 5.11, 12 July 2025, by ComradeNiobe
+Added a new table for DB-based whitelisting to replace the bunker bypass system and perhaps other file-based whitelists in the future.
+
+```sql
+CREATE TABLE `whitelists` (
+  `ckey` varchar(32) NOT NULL,
+  `type` enum('entry','agevet') NOT NULL,
+  `added_by` varchar(32) NOT NULL,
+  `timestamp` datetime NOT NULL,
+  `round_id` int(11) unsigned NOT NULL,
+  PRIMARY KEY (`ckey`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+```
 
 -----------------------------------------------------
 Version 5.10, 08 January 2024, by useroth

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -565,6 +565,22 @@ CREATE TABLE `ticket` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+--
+-- Table structure for table `whitelists`.
+--
+DROP TABLE IF EXISTS `whitelists`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `whitelists` (
+  `ckey` varchar(32) NOT NULL,
+  `type` enum('entry','agevet') NOT NULL,
+  `added_by` varchar(32) NOT NULL,
+  `timestamp` datetime NOT NULL,
+  `round_id` int(11) unsigned NOT NULL,
+  PRIMARY KEY (`ckey`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
 DELIMITER $$
 CREATE PROCEDURE `set_poll_deleted`(
 	IN `poll_id` INT

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1118,7 +1118,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		qdel(query_client_in_db)
 		return
 	if(!query_client_in_db.NextRow())
-		if (CONFIG_GET(flag/panic_bunker) && !holder && !GLOB.deadmins[ckey] && !bunker_bypass_check())
+		if (CONFIG_GET(flag/panic_bunker) && !holder && !GLOB.deadmins[ckey] && !entry_whitelist_check())
 			log_access("Failed Login: [key] - New account attempting to connect during panic bunker")
 			message_admins(span_adminnotice("Failed Login: [key] - New account attempting to connect during panic bunker"))
 			to_chat(src, CONFIG_GET(string/panic_bunker_message))

--- a/modular/code/modules/admin/bunker_bypass.dm
+++ b/modular/code/modules/admin/bunker_bypass.dm
@@ -1,9 +1,7 @@
-GLOBAL_LIST_INIT(bunker_bypasses, load_bypasses_from_file())
+GLOBAL_LIST_INIT(entry_whitelists, load_entry_whitelists())
 
-/client/proc/bunker_bypass_check()
-	if (ckey in GLOB.bunker_bypasses)
-		GLOB.bunker_bypasses -= ckey
-		save_bypasses_to_file()
+/client/proc/entry_whitelist_check()
+	if (ckey in GLOB.entry_whitelists)
 		return TRUE
 	return FALSE
 
@@ -16,13 +14,13 @@ GLOBAL_LIST_INIT(bunker_bypasses, load_bypasses_from_file())
 
 	var/selection = input("Who would you like to let in?", "CKEY", "") as text|null
 	if(selection)
-		if(ckey in GLOB.bunker_bypasses)
+		if(ckey in GLOB.entry_whitelists)
 			to_chat(src, span_warning("Player with ckey [ckey] is already on the list."))
 			return
 		if(alert("Confirm: allow ckey [selection] to connect?", "", "Yes!", "No") == "Yes!")
-			add_bunker_bypass(selection, ckey)
+			add_entry_whitelist(selection, ckey)
 
-/proc/add_bunker_bypass(target_ckey, admin_ckey = "SYSTEM")
+/proc/add_entry_whitelist(target_ckey, admin_ckey = "SYSTEM")
 	if(!target_ckey)
 		return
 
@@ -30,24 +28,34 @@ GLOBAL_LIST_INIT(bunker_bypasses, load_bypasses_from_file())
 		return
 
 	target_ckey = ckey(target_ckey)
-	GLOB.bunker_bypasses |= target_ckey
+	GLOB.entry_whitelists |= target_ckey
 	message_admins("BUNKER BYPASS: Added [target_ckey] to the bypass list[admin_ckey? " by [admin_ckey]":""]")
 	log_admin("BUNKER BYPASS: Added [target_ckey] to the bypass list[admin_ckey? " by [admin_ckey]":""]")
-	save_bypasses_to_file()
 
-/proc/load_bypasses_from_file()
-	var/json_file = file("data/whitelist.json")
-	if(fexists(json_file))
-		var/list/json = json_decode(file2text(json_file))
-		return json["data"]
-	else
-		return list()
+	var/datum/DBQuery/query_add_entry_whitelist = SSdbcore.NewQuery({"
+		INSERT INTO [format_table_name("whitelists")] (ckey, type, added_by, timestamp, round_id)
+		VALUES (:ckey, :type, :added_by, :timestamp, :round_id)
+	"}, list(
+		"ckey" = target_ckey,
+		"type" = "entry",
+		"added_by" = admin_ckey,
+		"timestamp" = SQLtime(),
+		"round_id" = GLOB.round_id,
+	))
+	if(!query_add_entry_whitelist.Execute())
+		message_admins("Failed to add entry whitelist for [key_name_admin(target_ckey)] to the database!")
+		log_admin("Failed to add entry whitelist for [key_name_admin(target_ckey)] to the database!")
+		qdel(query_add_entry_whitelist)
+		return
 
+/proc/load_entry_whitelists()
+	RETURN_TYPE(/list)
 
-/proc/save_bypasses_to_file()
-	var/json_file = file("data/whitelist.json")
-	var/list/file_data = list()
-	file_data["data"] = GLOB.bunker_bypasses
-	fdel(json_file)
-	WRITE_FILE(json_file,json_encode(file_data))
-
+	var/datum/DBQuery/query_load_entry_whitelists = SSdbcore.NewQuery("SELECT ckey FROM [format_table_name("whitelists")] WHERE type = 'entry'")
+	if(!query_load_entry_whitelists.Execute())
+		qdel(query_load_entry_whitelists)
+		return
+	var/list/ckeys = list()
+	while(query_load_entry_whitelists.NextRow())
+		ckeys |= query_load_entry_whitelists.item[1]
+	return ckeys


### PR DESCRIPTION
## About The Pull Request

This PR overhauls entry whitelisting to be done via database instead of a temporary JSON file. Theoretically, this could be used for agevet whitelists as well, but that's outside the scope of this PR (even tho I added support for it).

## Testing Evidence

To Be Added

## Why It's Good For The Game

There's little reason to reinvent the wheel by using a JSON file as a temporary database when you can just use the actual database. It's easier, not reliant on filesystem shenanigans, and fool-proof.