### PR TITLE
Longer Mindlink

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/mindlink.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mindlink.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/invoked/mindlink
 	name = "Mindlink"
-	desc = "Establish a telepathic link with an ally for one minute. Use ,y before a message to communicate telepathically."
+	desc = "Establish a telepathic link with an ally for fifteen minutes. Use ,y before a message to communicate telepathically."
 	clothes_req = FALSE
 	overlay_state = "mindlink"
 	associated_skill = /datum/skill/magic/arcane
@@ -76,7 +76,7 @@
 	to_chat(first_target, span_notice("A mindlink has been established with [second_target]! Use ,y before a message to communicate telepathically."))
 	to_chat(second_target, span_notice("A mindlink has been established with [first_target]! Use ,y before a message to communicate telepathically."))
 	
-	addtimer(CALLBACK(src, PROC_REF(break_link), link), 3 MINUTES)
+	addtimer(CALLBACK(src, PROC_REF(break_link), link), 15 MINUTES)
 	return TRUE
 
 /obj/effect/proc_holder/spell/invoked/mindlink/proc/break_link(datum/mindlink/link)


### PR DESCRIPTION
## About The Pull Request

Extends mind link to fifteen minutes.

## Testing Evidence

Works in test-environ! Just changes a description and a minute marker.

## Why It's Good For The Game

More use cases for a high-value spell slot! 
Makes it actually valuable longer-term, obviously, so higher-level spells have more kick. It's only really useful for roleplay right now, as it is- and even then, with the short duration, barely.
