### PR TITLE
Disables round start werewolfs

### DIFF
--- a/code/modules/events/antagonist/solo/werewolf.dm
+++ b/code/modules/events/antagonist/solo/werewolf.dm
@@ -14,7 +14,7 @@
 	base_antags = 1
 	maximum_antags = 2
 	min_players = 25
-	weight = 7
+	weight = 0
 
 	earliest_start = 0 SECONDS
 


### PR DESCRIPTION
## About The Pull Request

What the title says

## Testing Evidence

Tested locally

## Why It's Good For The Game

Parity reverted the initial disabling. We're testing out other antags via admin events panel.
