### PR TITLE
War scholar god choice

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -13,7 +13,6 @@
 
 /datum/outfit/job/roguetown/mercenary/warscholar
 	var/detailcolor
-	allowed_patrons = list(/datum/patron/old_god)
 
 /datum/outfit/job/roguetown/mercenary/warscholar/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
## About The Pull Request
It gives the choice for the war scholars on which god to pick.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1295" height="1059" alt="image" src="https://github.com/user-attachments/assets/7d7f5781-da1a-4fe2-b71f-5b9e8ffb7bdc" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Changed the warscholar to be able to pick their religion like they can with the Orthodoxist.

The mercenary was left alone when the changes were made. I am not sure if it was because they forgot. But, from what I gather, many people would prefer the option to choose their deity to worship for the role. I am sure that someone can code in some kind of benefit if they pick Psydon in the future. This is a simple code change to give the players a bit more of a choice.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
