### PR TITLE
Mild Maneater nerf

### DIFF
--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -11,7 +11,7 @@
 
 /obj/structure/flora/roguegrass/maneater/real
 	var/aggroed = 0
-	max_integrity = 20
+	max_integrity = 30
 	integrity_failure = 0.15
 	attacked_sound = list('sound/vo/mobs/plant/pain (1).ogg','sound/vo/mobs/plant/pain (2).ogg','sound/vo/mobs/plant/pain (3).ogg','sound/vo/mobs/plant/pain (4).ogg')
 	var/list/eatablez = list(/obj/item/bodypart, /obj/item/organ, /obj/item/reagent_containers/food/snacks/rogue/meat)
@@ -247,7 +247,7 @@
 	desc = "Green and vivid. This one seems smaller than usual."
 	icon = 'icons/roguetown/mob/monster/maneater.dmi'
 	icon_state = "maneater-hidden"
-	max_integrity = 10
+	max_integrity = 15
 	seednutrition = 0
 	max_seednutrition = 50
 	var/growth_stage = 1


### PR DESCRIPTION
## About The Pull Request
Adjusts the maneater+ variants overall health
## Testing Evidence

Will add momentarily.

## Why It's Good For The Game
There's currently a bug affecting maneaters at the moment where they'll outright bypass any bracers you're equipped with. Or, in another case outright lose a limb despite the bracers saying they've blocked the attack. This PR adjusts their health as a band-aid fix for the time being, to at least **try** and alleviate some of the problems making maneaters significantly weaker allowing for an easier escape via fighting. 