### PR TITLE
MATTHIOS BANDITS

### DIFF
--- a/code/modules/antagonists/roguetown/villain/bandit.dm
+++ b/code/modules/antagonists/roguetown/villain/bandit.dm
@@ -35,8 +35,9 @@
 	ADD_TRAIT(H, TRAIT_COMMIE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_OUTLANDER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_OUTLAW, TRAIT_GENERIC)		//Just to stop them from using mesiters like Wretches.
+	H.set_patron(/datum/patron/inhumen/matthios)
 	to_chat(H, span_alertsyndie("I am a BANDIT!"))
-	to_chat(H, span_boldwarning("Long ago I did a crime worthy of my bounty being hung on the wall outside of the local inn. I live now with fellow free men in reverence to MATTHIOS whose idol grants us boons and wishes when fed the money, treasures, and metals of the civilized wretches. As a member of the free men, I worship MATTHIOS first and foremost, though I may have allegiance to other deities."))
+	to_chat(H, span_boldwarning("Long ago I did a crime worthy of my bounty being hung on the wall outside of the local inn. I live now with fellow free men in reverence to MATTHIOS whose idol grants us boons and wishes when fed the money, treasures, and metals of the civilized wretches. As a member of the free men, I worship MATTHIOS first and foremost!"))
 
 /datum/antagonist/bandit/proc/forge_objectives()
 	return


### PR DESCRIPTION
MATTHIOS MATTHIOS MATTHIOS MATTHIOS

## About The Pull Request

Forces bandits to MATTHIOS, and changes their tutorial text to match.

## Testing Evidence

<img width="447" height="72" alt="image" src="https://github.com/user-attachments/assets/2e11d3a3-8462-475e-b221-495476ef1cdb" />

This was a two line change.

## Why It's Good For The Game

Graggar bandits are just an excuse to frag.
Baotha bandits are able to abuse drugs to ridiculous extremes.
Zizo bandits literally contradict themselves. Matthios and Zizo do not mix. Why would the Freemen of Matthios support a being that wants to turn everyone into deadite slaves?

Bandits have lost much of their sense of comradery, as well as much of their identity. Everything about them screams Matthios. There's no reason to let them play other patrons, beyond playing your special Zizo sparkledog with bandit gear. If you want to be a Graggar/Baotha/Zizo bandit, just play outlaw Wretch. It's that simple.

This also helps with antags grouping up and absolutely rolling the keep. Bandits should be a third party, with their own ambitions separate from liches, vampyres, et cetera. They should not be instantly supporting Zizoids, Graggarites, and whatnot.