### PR TITLE
Reinforces merchant windows

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -34004,7 +34004,9 @@
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/shelter)
 "llx" = (
-/obj/structure/roguewindow,
+/obj/structure/roguewindow{
+	max_integrity = 500
+	},
 /obj/structure/bars/passage/shutter{
 	redstone_id = "trader_stock_shutter"
 	},
@@ -51842,7 +51844,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/orcdungeon)
 "rgz" = (
-/obj/structure/roguewindow,
+/obj/structure/roguewindow{
+	max_integrity = 500
+	},
 /obj/structure/bars/passage/shutter{
 	redstone_id = "trader_shutter"
 	},


### PR DESCRIPTION
## About The Pull Request
Title! This PR gives the merchant's windows that lead directly inside his shop the same integrity as reinforced windows, while still being transparent.
This simply reinforces the windows so it'll take some more effort to break them, hopefully giving enough time to discourage thiefs from breaking in without a plan, or assholes just throwing rocks through them.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1100" height="362" alt="image" src="https://github.com/user-attachments/assets/7156978d-6a02-45de-8b16-a6c0e2356861" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The merchant's windows are there so customers are able to see what wares there are while not having access to them. These, sadly, fail catastrophically the moment someone with a functioning arm obtains a rock. Which meant that if the merchant decided to open their shutters for a moment they were most likely going to get their windows broken and something snatched, or worse, someone jumping inside and closing the shutters to rob the merchant directly.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
