### PR TITLE
Grenzel Halberdier change; -1 SPD for +1 PER

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -68,8 +68,7 @@
 			H.change_stat("strength", 2) //same str, worse end, more speed - actually a good tradeoff, now.
 			H.change_stat("endurance", 2)
 			H.change_stat("constitution", 2)
-			H.change_stat("perception", -1)
-			H.change_stat("speed", 1)
+			H.change_stat("perception", 1)
 			var/weapons = list("Halberd", "Partizan")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			switch(weapon_choice)


### PR DESCRIPTION
## About The Pull Request

# Really Long Text Ahead (Not That Long)
Halberdiers my beloved. The polearm user is well known for being able to hit parts that most folks would struggle to reach! Hands, feet, eyes *(particularly feet)*. Polearms are some of the best weapons by this fact, and it isn't unusual for a wall of polearm users to be, admittedly, **unfuckable**.

So why the fuck would Halberdiers, **one of few polearm merc class**, not only lose 1 PERCEPTION but also gain 1 SPEED?
I mean I suppose you're chasing your prey if you're bounty hunting, in which case -- just go with a SPD statpack. I'unno.

This is a simple numbers change; They lose their bonus speed, they lose their perception malus. Instead, they gain 1 perception. 1 SPD = 2 points, so we turn that -1 into +1. Yay. Maths!
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It's a numbers' change dawg.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Give halberdiers a bone because not many realize that PER is tied to more things than just "damage with bows". At best you can counteract the +1 with a -1 statpack and still get average. At worst you can be a PER 14 freak and start stabbing people's eyes out.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
