### PR TITLE
Otavan accent tweaks

### DIFF
--- a/strings/french_replacement.json
+++ b/strings/french_replacement.json
@@ -2,12 +2,6 @@
     "full": {
 		"yes": "oui",
 		"no": "non",
-		"do": "du",
-		"don't": "dun't",
-		"am": "ahm", 
-        "and": "eend",
-		"with": "weeth",
-		"it": "eet",
 		"captain": "capitaine", 
 		"cook": "cuisinier", 
 		"dad": "papa",
@@ -64,9 +58,7 @@
 		"three": "trois"
     },
     "start": {
-		"ga": "ge",
-		"th": "zh",
-		"h": "'"
+		"th": "zh"
 
     },
     "end": {

--- a/strings/french_replacement.json
+++ b/strings/french_replacement.json
@@ -46,6 +46,7 @@
 		"shit": "merde",
 		"good": "bon",
 		"my": "mon",
+		"me": "moi",
 		"please": "s’il vous plaît",
 		"goodbye": "au revoir",
 		"sorry": "pardon",

--- a/strings/french_replacement.json
+++ b/strings/french_replacement.json
@@ -49,7 +49,6 @@
 		"me": "moi",
 		"please": "s’il vous plaît",
 		"goodbye": "au revoir",
-		"sorry": "pardon",
 		"small": "petit",
 		"shop": "boutique",
 		"threesome": "ménage à trois",

--- a/strings/french_replacement.json
+++ b/strings/french_replacement.json
@@ -27,7 +27,6 @@
 		"lord": "seigneur",
 		"mister": "monsieur",
 		"sir": "monsieur",
-		"miss": "mademoiselle",
 		"ma'am": "madame",
 		"seneschal": "sénéchal",
 		"veteran": "vétéran",


### PR DESCRIPTION
## About The Pull Request
Removes H into ' (for example, helmet - 'elmet)
While I think this one is super cute, I do have to admit it sounds better spoken than it looks better written.
It also causes issues with people stuttering, maybe it completely incomprehensible.

Removes a few other examples, like "it" into "eet" and "with" into "weeth"
The PR did what it set out to do, make the french accent appear more often. But it appeared _too_ often, making it difficult to read.

## Testing Evidence
You can trust me

## Why It's Good For The Game
The goal was to make the accent appear more often, but remain reasonably understandable. But I got a little too carried away with phonetics, and failed on the latter. For people who are familiar with how the accent actually sounds, they'll be able to fill in the blanks in their mind. As it was, it got pretty difficult to read at times.