### PR TITLE
Fixes and improves marriage code

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1081,7 +1081,7 @@
 
 /obj/structure/fluff/psycross/attackby(obj/item/W, mob/user, params)
 	if(user.mind)
-		if(user.mind.assigned_role == "Priest")
+		if(user.mind.assigned_role == "Priest" || user.mind.assigned_role == "Priestess")
 			if(istype(W, /obj/item/reagent_containers/food/snacks/grown/apple))
 				if(!istype(get_area(user), /area/rogue/indoors/town/church/chapel))
 					to_chat(user, span_warning("I need to do this in the chapel."))


### PR DESCRIPTION
The biggest difference is it now actually works
However, this no longer randomly assigns you a surname. The priest assigns one upon completing the ceremony:
It also blocks excommunicated from being married
<img width="1615" height="1343" alt="image" src="https://github.com/user-attachments/assets/6f233104-baf2-4742-8155-de47421b9589" />
<img width="635" height="895" alt="image" src="https://github.com/user-attachments/assets/c3990059-50d5-4b9b-b0ac-66fb421056bb" />
