### PR TITLE
Bugfixes Ignition and changes Sacred Flame

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -238,7 +238,8 @@
 				var/mob/M = loc
 				M.update_inv_hands()
 			START_PROCESSING(SSobj, src)
-	..()
+			return TRUE
+	return ..()
 
 /obj/item/flashlight/flare/torch/afterattack(atom/movable/A, mob/user, proximity)
 	. = ..()

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -1,6 +1,8 @@
+
 /obj/effect/proc_holder/spell/invoked/projectile/lightningbolt/sacred_flame_rogue
 	name = "Sacred Flame"
 	overlay_state = "sacredflame"
+	sound = 'sound/magic/bless.ogg'
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	invocation = null
 	invocation_type = "shout"
@@ -9,12 +11,18 @@
 	recharge_time = 25 SECONDS
 	miracle = TRUE
 	devotion_cost = 100
-	projectile_type = /obj/projectile/magic/lightning/astratablast
+	projectile_type = /obj/projectile/magic/astratablast
 
-/obj/projectile/magic/lightning/astratablast
-	damage = 10 
+
+/obj/projectile/magic/astratablast
+	damage = 10
 	name = "ray of holy fire"
+	nodamage = FALSE
 	damage_type = BURN
+	speed = 0.3
+	muzzle_type = null
+	impact_type = null
+	hitscan = TRUE
 	flag = "magic"
 	light_color = "#a98107"
 	light_outer_range = 7
@@ -22,9 +30,8 @@
 	var/fuck_that_guy_multiplier = 2.5
 	var/biotype_we_look_for = MOB_UNDEAD
 
-/obj/projectile/magic/lightning/astratablast/on_hit(target)
+/obj/projectile/magic/astratablast/on_hit(target)
 	. = ..()
-
 	if(ismob(target))
 		var/mob/living/M = target
 		if(M.anti_magic_check())
@@ -36,7 +43,11 @@
 			damage *= fuck_that_guy_multiplier
 			M.adjust_fire_stacks(4)
 			M.IgniteMob()
-			visible_message(span_warning("[src] ignites [target] in holy flame!"))
+			visible_message(span_warning("[target] erupts in flame upon being struck by [src]!"))
+		else
+			M.adjust_fire_stacks(1)//just a little bit of burning for non-undead
+			M.IgniteMob()
+			visible_message(span_warning("[src] ignites [target]!"))
 	return FALSE
 
 /obj/effect/proc_holder/spell/invoked/ignition
@@ -59,7 +70,7 @@
 	miracle = TRUE
 	devotion_cost = 10
 
-/obj/effect/proc_holder/spell/invoked/sacred_flame_rogue/cast(list/targets, mob/user = usr)
+/obj/effect/proc_holder/spell/invoked/ignition/cast(list/targets, mob/user = usr)
 	. = ..()
 	// Spell interaction with ignitable objects (burn wooden things, light torches up)
 	if(isobj(targets[1]))


### PR DESCRIPTION
## About The Pull Request
Fixes ignition, it now works

Sacred Flame now ignites people instead of electrocuting them, non-undead will take less damage and get fewer burn stacks
also changes the SFX for sacred flame to be bless.ogg instead of the lightning bolt sfx to further differentiate the spells

Changed the torch code in flashlight.dm to return true when it lights because otherwise ignition won't function properly on them if they never actually tell the spell that they got ignited

## Testing Evidence

<img width="433" height="217" alt="image" src="https://github.com/user-attachments/assets/61961c65-eafc-4edb-aeec-9513637b0950" />

Top- ignition working on different items after selecting the spell and using middle mouse (the failure cases are on the items after they're lit, so you don't waste devotion trying to light a lantern/torch already on fire)
Middle- sacred flame on a human
Bottom- sacred flame on a skeleton, I made the text different to show that the fire is stronger

## Why It's Good For The Game

ignition's problem was a literal one-word change in its /invoked proc which was why I originally decided to make this PR in the first place
I changed sacred flame because it didn't really make sense that holy fire was electrocuting people but I'm open to balancejaks since I don't know how heavily this will effect its power in combat