### PR TITLE
Additional races granted access to MAA

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -4,10 +4,10 @@
 	flag = MANATARMS
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 8
-	spawn_positions = 8
+	total_positions = 10
+	spawn_positions = 10
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_races = RACES_SHUNNED_UP
+	allowed_races = RACES_NO_CONSTRUCT
 	allowed_patrons = ALL_PATRONS
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	tutorial = "Having proven yourself loyal and capable, you are entrusted to defend the town and enforce its laws. \


### PR DESCRIPTION
## About The Pull Request
Allows a good chunk of the races to granted access to MAA along with increasing the slots to 10
## Testing Evidence
<img width="519" height="129" alt="goblinpr1" src="https://github.com/user-attachments/assets/c72ac528-f0c1-41be-9354-785849659a45" />

## Why It's Good For The Game
The idea of removing race locks has been a widely contested debate supposedly, for quite a while now within the discord. This is more or less just a nudge in testing that regard in gauging whether people like it or not. Barring vocal ones that will bemoan it to begin with.