### PR TITLE
Emberwine Cauldron Recipe [HOTFIX]

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipes.dm
@@ -112,4 +112,4 @@
 /datum/alch_cauldron_recipe/aphrodisiac
 	name = "Aphrodisiac Wine"
 	smells_like = "ardent sweetness"
-	output_reagents = list(/datum/reagent/consumable/ethanol/beer/emberwine = 27)
+	output_reagents = list(/datum/reagent/consumable/ethanol/beer/emberwine = 54)

--- a/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
@@ -130,7 +130,7 @@
 	name = "sinew"
 	icon_state = "sinew"
 	dropshrink = 0.9
-	major_pot = /datum/alch_cauldron_recipe/stam_poison
+	major_pot = /datum/alch_cauldron_recipe/aphrodisiac
 	med_pot = /datum/alch_cauldron_recipe/end_potion
 	minor_pot = /datum/alch_cauldron_recipe/health_potion
 
@@ -152,7 +152,7 @@
 	name = "swampweed dust"
 	icon_state = "swampdust"
 	major_pot = /datum/alch_cauldron_recipe/berrypoison
-	med_pot = /datum/alch_cauldron_recipe/big_stam_poison
+	med_pot = /datum/alch_cauldron_recipe/aphrodisiac
 	minor_pot = /datum/alch_cauldron_recipe/end_potion
 
 /obj/item/alch/tobaccodust
@@ -318,7 +318,7 @@
 	icon_state = "euphrasia"
 
 	major_pot = /datum/alch_cauldron_recipe/spd_potion
-	med_pot = /datum/alch_cauldron_recipe/stam_poison
+	med_pot = /datum/alch_cauldron_recipe/aphrodisiac
 	minor_pot = /datum/alch_cauldron_recipe/int_potion
 
 /obj/item/alch/paris
@@ -351,7 +351,7 @@
 
 	major_pot = /datum/alch_cauldron_recipe/health_potion
 	med_pot = /datum/alch_cauldron_recipe/spd_potion
-	minor_pot = /datum/alch_cauldron_recipe/stamina_potion
+	minor_pot = /datum/alch_cauldron_recipe/aphrodisiac
 
 /obj/item/alch/salvia
 	name = "salvia"
@@ -396,7 +396,7 @@
 
 	major_pot = /datum/alch_cauldron_recipe/lck_potion
 	med_pot = /datum/alch_cauldron_recipe/spd_potion
-	minor_pot = /datum/alch_cauldron_recipe/health_potion
+	minor_pot = /datum/alch_cauldron_recipe/aphrodisiac
 
 /obj/item/alch/rosa
 	name = "rosa"


### PR DESCRIPTION
## About The Pull Request
Changes around a few of the ingredient weights for cauldron recipes to enable making Emberwine poison at a cauldron.

## Testing Evidence
[https://i.gyazo.com/e6bc3c58a40f9e13ca39a47e23737903.png](url)

## Why It's Good For The Game
Someone asked me for this. Lets people without brew Emberwine in their backyards. The recipe already existed in the code, it just wasn't associated with any ingredient.
