### PR TITLE
Parry & Dodge Nerf, Other Misc Weapon Changes

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -151,7 +151,7 @@
 	smelt_bar_num = 2
 	gripped_intents = list(/datum/intent/axe/cut/battle ,/datum/intent/axe/chop/battle, /datum/intent/axe/bash, /datum/intent/sword/peel)
 	minstr = 9
-	wdefense = 4
+	wdefense = 3.5 //Slightly less than a longsword, better intents.
 
 /obj/item/rogueweapon/stoneaxe/battle/getonmobprop(tag)
 	if(tag)
@@ -186,7 +186,7 @@
 	smeltresult = /obj/item/ingot/steel
 	gripped_intents = list(/datum/intent/axe/cut/battle ,/datum/intent/axe/chop/battle, /datum/intent/axe/bash)
 	minstr = 12
-	wdefense = 5
+	wdefense = 4
 
 /obj/item/rogueweapon/stoneaxe/oath/getonmobprop(tag)
 	if(tag)
@@ -245,6 +245,7 @@
 	gripped_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop, /datum/intent/mace/warhammer/pick, /datum/intent/axe/bash)
 	smeltresult = /obj/item/ingot/steel
 	wlength = WLENGTH_NORMAL
+	wdefense = 3
 	toolspeed = 2
 
 
@@ -368,7 +369,7 @@
 	max_blade_int = 400
 	smeltresult = /obj/item/ingot/silver
 	gripped_intents = null
-	wdefense = 4
+	wdefense = 5.5
 	is_silver = TRUE
 	blade_dulling = DULLING_SHAFT_METAL
 
@@ -416,7 +417,7 @@
 	smeltresult = /obj/item/ingot/iron
 	associated_skill = /datum/skill/combat/axes
 	blade_dulling = DULLING_SHAFT_WOOD
-	wdefense = 6
+	wdefense = 4
 	pickup_sound = 'modular_helmsguard/sound/sheath_sounds/draw_greatsword.ogg'
 	sheathe_sound = 'modular_helmsguard/sound/sheath_sounds/put_back_to_leather.ogg'
 

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -65,7 +65,7 @@
 	parrysound = list('sound/combat/parry/parrygen.ogg')
 	swingsound = BLUNTWOOSH_MED
 	minstr = 7
-	wdefense = 2
+	wdefense = 3
 	wbalance = WBALANCE_HEAVY
 	blade_dulling = DULLING_SHAFT_METAL
 	intdamage_factor = 1.35
@@ -118,7 +118,7 @@
 	icon_state = "smace"
 	wbalance = WBALANCE_HEAVY
 	smeltresult = /obj/item/ingot/steel
-	wdefense = 3
+	wdefense = 4 //70% parry chance wielded, because blunt weapons are in a bad spot right now.
 	smelt_bar_num = 2
 
 /obj/item/rogueweapon/mace/steel/palloy
@@ -135,7 +135,7 @@
 	force = 24
 	gripped_intents = null
 	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash, /datum/intent/effect/daze)
-	wdefense = 4
+	wdefense = 5.5
 	smeltresult = /obj/item/ingot/silver
 	smelt_bar_num = 2
 	is_silver = TRUE
@@ -197,7 +197,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	wbalance = WBALANCE_NORMAL
 	minstr = 7
-	wdefense = 1
+	wdefense = 2
 	resistance_flags = FLAMMABLE
 	blade_dulling = DULLING_SHAFT_WOOD
 	grid_width = 32
@@ -225,7 +225,7 @@
 	blade_dulling = DULLING_SHAFT_REINFORCED
 	wbalance = WBALANCE_SWIFT
 	minstr = 7
-	wdefense = 5
+	wdefense = 4
 
 /obj/item/rogueweapon/mace/cudgel/getonmobprop(tag)
 	. = ..()
@@ -438,7 +438,7 @@
 	blade_dulling = DULLING_SHAFT_CONJURED
 
 /obj/item/rogueweapon/mace/warhammer/steel
-	force = 25
+	force = 27 //Specialized for one-handed use.
 	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/warhammer/pick, /datum/intent/mace/warhammer/stab)
 	name = "steel warhammer"
 	desc = "A fine steel warhammer, makes a satisfying sound when paired with a knight's helm."

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -259,6 +259,7 @@
 	possible_item_intents = list(/datum/intent/dagger/thrust,/datum/intent/dagger/cut, /datum/intent/dagger/thrust/pick, /datum/intent/dagger/sucker_punch)
 	force = 15
 	max_integrity = 100
+	wdefense = 4
 	name = "iron dagger"
 	desc = "This is a common dagger of iron."
 	icon_state = "idagger"
@@ -286,6 +287,7 @@
 	icon_state = "sdagger"
 	force = 20
 	max_integrity = 150
+	wdefense = 5.5
 	smeltresult = /obj/item/ingot/steel
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/holysee
@@ -313,6 +315,7 @@
 	icon_state = "stiletto"
 	force = 25
 	max_integrity = 200
+	wdefense = 6
 	smeltresult = /obj/item/ingot/steel
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/parrying //direct upgrade but more costly.
@@ -321,12 +324,12 @@
 	force = 15
 	throwforce = 15
 	icon_state = "spdagger"
-	wdefense = 6
+	wdefense = 7
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/parrying/vaquero
 	name = "sail dagger"
 	desc = "An exceptionally protective parrying dagger popular in the Etruscan Isles, this dagger features a plain metal guard in the shape of a ship's sail."
-	wdefense = 7
+	wdefense = 7.5
 	force = 17
 	throwforce = 17
 	icon_state = "sail_dagger"
@@ -425,6 +428,7 @@
 	name = "elvish dagger"
 	desc = "This beautiful dagger is of intricate, elvish design. Sharper, too."
 	force = 22
+	wdefense = 5.5
 	icon_state = "elfdagger"
 	item_state = "elfdag"
 	last_used = 0

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -205,7 +205,8 @@
 	pixel_x = -16
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
-	wdefense = 10
+	wdefense = 5.5 //This was at 10 (so 13 wielded) before for some insane reason. No, stop, wooden staffs aren't A.T. Fields. It was higher than a kite shield, get real.
+	max_integrity = 180 //It's a piece of wood. Unique staffs get higher durability.
 	bigboy = TRUE
 	gripsprite = TRUE
 	associated_skill = /datum/skill/combat/polearms
@@ -228,6 +229,7 @@
 /obj/item/rogueweapon/woodstaff/wise
 	name = "wise staff"
 	desc = "A staff for keeping the volves at bay..."
+	max_integrity = 225
 
 /obj/item/rogueweapon/woodstaff/aries
 	name = "staff of the shepherd"
@@ -236,6 +238,7 @@
 	force_wielded = 28
 	icon_state = "aries"
 	icon = 'icons/roguetown/weapons/32.dmi'
+	max_integrity = 300
 	pixel_y = 0
 	pixel_x = 0
 	inhand_x_dimension = 64
@@ -372,7 +375,8 @@
 	smeltresult = /obj/item/ingot/steel
 	max_blade_int = 200
 	minstr = 8
-	wdefense = 6
+	wdefense = 5
+	max_integrity = 325 //Sturdier than a spear, but same wdefense.
 	throwforce = 15
 
 /obj/item/rogueweapon/spear/improvisedbillhook
@@ -653,12 +657,13 @@
 	w_class = WEIGHT_CLASS_BULKY
 	minstr = 9
 	max_blade_int = 200
+	max_integrity = 275 // A little extra parry integrity, +25 compared to the spear.
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/steel
 	associated_skill = /datum/skill/combat/polearms
 	blade_dulling = DULLING_SHAFT_WOOD
 	walking_stick = TRUE
-	wdefense = 6
+	wdefense = 5.5
 	pickup_sound = 'modular_helmsguard/sound/sheath_sounds/draw_polearm.ogg'
 	sheathe_sound = 'sound/foley/equip/swordlarge1.ogg'
 
@@ -736,12 +741,12 @@
 	possible_item_intents = list(/datum/intent/spear/thrust/eaglebeak, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs
 	gripped_intents = list(/datum/intent/spear/thrust/glaive, /datum/intent/spear/cut/glaive, /datum/intent/axe/chop/scythe, SPEAR_BASH)
 	name = "glaive"
-	desc = "A curved blade on a pole, specialised in defence, but expensive to manufacture."
+	desc = "A curved blade on a pole, specialised in offense, but expensive to manufacture."
 	icon_state = "glaive"
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/steel
 	max_blade_int = 300
-	wdefense = 9
+	wdefense = 4.5 //You're sacrificing defense for a better thrust and cut here.
 
 /obj/item/rogueweapon/halberd/glaive/getonmobprop(tag)
 	. = ..()
@@ -864,7 +869,7 @@
 	smeltresult = /obj/item/ingot/steel
 	associated_skill = /datum/skill/combat/swords
 	max_blade_int = 300
-	wdefense = 5
+	wdefense = 3.5 //65% base parry chance wielded, halfway between zweihander and longsword.
 	smelt_bar_num = 3
 	pickup_sound = 'modular_helmsguard/sound/sheath_sounds/draw_greatsword.ogg'
 	sheathe_sound = 'modular_helmsguard/sound/sheath_sounds/put_back_sword2.ogg'
@@ -912,7 +917,7 @@
 	smeltresult = /obj/item/ingot/iron
 	smelt_bar_num = 3
 	max_blade_int = 200
-	wdefense = 4
+	wdefense = 3
 	force = 14
 	force_wielded = 35
 
@@ -922,6 +927,7 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 3
 	max_blade_int = 300
+	max_integrity = 300 //+50 integrity for being steel.
 	force = 14
 	force_wielded = 35
 
@@ -970,6 +976,7 @@
 	associated_skill = /datum/skill/combat/swords
 	max_blade_int = 300
 	wdefense = 5
+	max_integrity = 220 //-30 integrity compared to the greatsword to compensate for its better parry and thrusting utility.
 	smelt_bar_num = 2
 	pickup_sound = 'modular_helmsguard/sound/sheath_sounds/draw_greatsword.ogg'
 	sheathe_sound = 'modular_helmsguard/sound/sheath_sounds/put_back_sword2.ogg'
@@ -1094,7 +1101,7 @@
 	icon = 'icons/roguetown/weapons/64.dmi'
 	minstr = 10
 	max_blade_int = 200
-	wdefense = 6
+	wdefense = 5
 	throwforce = 12	//Not a throwing weapon. Too heavy!
 	blade_dulling = DULLING_SHAFT_REINFORCED
 	icon_angle_wielded = 50
@@ -1115,7 +1122,7 @@
 	icon = 'icons/roguetown/weapons/polearms64.dmi'
 	icon_state = "boarspear"
 	force_wielded = 33 // 10% base damage increase
-	wdefense = 6 // A little bit extra
+	wdefense = 5.5 // A little bit extra
 	max_blade_int = 150 // 50% more sharpness but it barely matter lol
 
 /obj/item/rogueweapon/spear/lance
@@ -1138,7 +1145,7 @@
 	name = "Naginata"
 	desc = "A traditional Kazengunese polearm, combining the reach of a spear with the cutting power of a curved blade. Due to the brittle quality of Kazengunese bladesmithing, weaponsmiths have adapted its blade to be easily replaceable when broken by a peg upon the end of the shaft."
 	force = 16
-	force_wielded = 30
+	force_wielded = 27
 	possible_item_intents = list(/datum/intent/spear/cut/naginata, SPEAR_BASH) // no stab for you little chuddy, it's a slashing weapon
 	gripped_intents = list(/datum/intent/rend/reach, /datum/intent/spear/cut/naginata, PARTIZAN_PEEL, SPEAR_BASH)
 	icon_state = "naginata"
@@ -1146,6 +1153,7 @@
 	minstr = 7
 	max_blade_int = 50 //Nippon suteeru (dogshit)
 	wdefense = 5
+	wbalance = WBALANCE_SWIFT //Lower damage, shitty blade integrity, but now its a swift weapon. Enjoy.
 	throwforce = 12	//Not a throwing weapon.
 	blade_dulling = DULLING_SHAFT_REINFORCED
 	icon_angle_wielded = 50

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -284,7 +284,7 @@
 /obj/item/rogueweapon/knuckles
 	name = "steel knuckles"
 	desc = "A mean looking pair of steel knuckles."
-	force = 22
+	force = 20
 	possible_item_intents = list(/datum/intent/knuckles/strike,/datum/intent/knuckles/smash)
 	icon = 'icons/roguetown/weapons/32.dmi'
 	icon_state = "steelknuckle"
@@ -298,7 +298,7 @@
 	swingsound = list('sound/combat/wooshes/punch/punchwoosh (1).ogg','sound/combat/wooshes/punch/punchwoosh (2).ogg','sound/combat/wooshes/punch/punchwoosh (3).ogg')
 	associated_skill = /datum/skill/combat/unarmed
 	throwforce = 12
-	wdefense = 8
+	wdefense = 6 //Unarmed classes tend to get Master unarmed so having this be too high is unhealthy.
 	wbalance = WBALANCE_HEAVY
 	blade_dulling = DULLING_SHAFT_WOOD
 	anvilrepair = /datum/skill/craft/weaponsmithing
@@ -319,7 +319,7 @@
 /obj/item/rogueweapon/knuckles/bronzeknuckles
 	name = "bronze knuckles"
 	desc = "A mean looking pair of bronze knuckles. Mildly heavier than it's steel counterpart, making it a solid defensive option, if less wieldy."
-	force = 20
+	force = 18
 	possible_item_intents = list(/datum/intent/knuckles/strike,/datum/intent/knuckles/smash)
 	icon = 'icons/roguetown/weapons/32.dmi'
 	icon_state = "bronzeknuckle"
@@ -333,7 +333,7 @@
 	swingsound = list('sound/combat/wooshes/punch/punchwoosh (1).ogg','sound/combat/wooshes/punch/punchwoosh (2).ogg','sound/combat/wooshes/punch/punchwoosh (3).ogg')
 	associated_skill = /datum/skill/combat/unarmed
 	throwforce = 12
-	wdefense = 10	//literally no clue how else to balance these
+	wdefense = 6.5
 	wbalance = WBALANCE_HEAVY
 	blade_dulling = DULLING_SHAFT_WOOD
 	anvilrepair = /datum/skill/craft/weaponsmithing
@@ -390,7 +390,7 @@
 /obj/item/rogueweapon/knuckles/eora
 	name = "close caress"
 	desc = "Some times call for a more intimate approach."
-	force = 25
+	force = 24
 	icon_state = "eoraknuckle"
 
 ///Peasantry / Militia Weapon Pack///
@@ -407,7 +407,7 @@
 	smeltresult = /obj/item/rogueore/coal
 	sharpness = IS_SHARP
 	walking_stick = TRUE
-	wdefense = 6
+	wdefense = 4
 	max_blade_int = 80
 
 /obj/item/rogueweapon/woodstaff/militia/getonmobprop(tag)
@@ -597,7 +597,7 @@
 	associated_skill = /datum/skill/combat/polearms
 	blade_dulling = DULLING_SHAFT_WOOD
 	walking_stick = TRUE
-	wdefense = 6
+	wdefense = 4.5
 	thrown_bclass = BCLASS_BLUNT
 	throwforce = 10
 	resistance_flags = FLAMMABLE
@@ -648,7 +648,7 @@
 	associated_skill = /datum/skill/combat/axes
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/steel
-	wdefense = 5
+	wdefense = 4
 	wbalance = WBALANCE_HEAVY
 
 /obj/item/rogueweapon/sword/falchion/militia

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -135,7 +135,7 @@
 	smeltresult = /obj/item/ingot/steel
 	minstr = 6
 	sellprice = 30
-	wdefense = 4.5
+	wdefense = 4.5 //75% parry chance wielded, very dependable for a seasoned swordsman - but flimsy integrity.
 	grid_width = 32
 	grid_height = 64
 	pickup_sound = 'modular_helmsguard/sound/sheath_sounds/draw_sword.ogg'
@@ -160,7 +160,7 @@
 	max_integrity = 250
 	gripped_intents = null
 	minstr = 4
-	wdefense = 6.5
+	wdefense = 6
 
 /obj/item/rogueweapon/sword/falx
 	name = "falx"
@@ -221,7 +221,7 @@
 	icon_state = "swordshort"
 	gripped_intents = null
 	minstr = 4
-	wdefense = 4.5
+	wdefense = 5
 	wlength = WLENGTH_SHORT
 	w_class = WEIGHT_CLASS_NORMAL
 	grid_width = 32
@@ -252,6 +252,8 @@
 	pickup_sound = 'sound/foley/equip/swordlarge2.ogg'
 	bigboy = 1
 	wlength = WLENGTH_LONG
+	wdefense = 4
+	max_integrity = 225
 	gripsprite = TRUE
 	pixel_y = -16
 	pixel_x = -16
@@ -288,12 +290,13 @@
 	name = "basket-hilted longsword"
 	desc = "An uncommon and elaborate type of longsword with a compound hilt like those seen on rapiers and smallswords. It has a marked unsharpened section for safe unarmored half-swording, and it's made of Calorian steel."
 	icon_state = "elongsword"
+	wdefense = 4.5 //+5% parry chance from the basket hilt.
 
 /obj/item/rogueweapon/sword/long/malumflamm
 	name = "forgefiend flamberge"
 	desc = "This sword's creation took a riddle in its own making. A great sacrifice was made for a blade of perfect quality."
 	icon_state = "malumflamberge"
-	max_integrity = 200
+	max_integrity = 300
 
 /obj/item/rogueweapon/sword/long/zizo
 	name = "darksteel longsword"
@@ -425,7 +428,7 @@
 	force = 40
 	force_wielded = 55
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel, /datum/intent/sword/strike)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/chop)
+	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel, /datum/intent/sword/chop)
 	alt_intents = list(/datum/intent/effect/daze, /datum/intent/sword/strike, /datum/intent/sword/bash)
 	icon_state = "vlord"
 	icon = 'icons/roguetown/weapons/64.dmi'
@@ -526,7 +529,7 @@
 	dropshrink = 0.75
 	minstr = 6
 	sellprice = 42
-	wdefense = 5
+	wdefense = 4.5
 	smeltresult = /obj/item/ingot/steel
 
 /obj/item/rogueweapon/sword/long/marlin/getonmobprop(tag)
@@ -686,7 +689,7 @@
 	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/axe/chop, /datum/intent/sword/peel)
 	gripped_intents = null
 	minstr = 4
-	wdefense = 2
+	wdefense = 3.5
 
 // This typepath is so buggered bruh but I am not repeating code and not dropping a massive merge conflict for now
 /obj/item/rogueweapon/sword/iron/messer/copper
@@ -709,7 +712,7 @@
 	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/axe/chop, /datum/intent/sword/peel)
 	gripped_intents = null
 	minstr = 5
-	wdefense = 4
+	wdefense = 4.5
 
 /obj/item/rogueweapon/sword/sabre
 	name = "sabre"
@@ -798,7 +801,7 @@
 		)
 	swingsound = BLADEWOOSH_SMALL
 	minstr = 6
-	wdefense = 7.5
+	wdefense = 7
 	wbalance = WBALANCE_SWIFT
 
 /obj/item/rogueweapon/sword/rapier/vaquero
@@ -807,7 +810,7 @@
 	icon = 'icons/roguetown/weapons/64.dmi'
 	max_integrity = 225
 	icon_state = "cup_hilt_rapier"
-	wdefense = 8
+	wdefense = 7.5
 	force = 25
 
 /obj/item/rogueweapon/sword/rapier/getonmobprop(tag)
@@ -910,7 +913,7 @@
 	sellprice = 300
 	max_integrity = 300
 	max_blade_int = 300
-	wdefense = 7
+	wdefense = 7.5
 
 /obj/item/rogueweapon/sword/rapier/eora
 	name = "\"Heartstring\""
@@ -920,6 +923,7 @@
 	grid_width = 32
 	grid_height = 64
 	dropshrink = 0
+	wdefense = 7.5
 	bigboy = FALSE
 
 /obj/item/rogueweapon/sword/cutlass
@@ -928,9 +932,9 @@
 	icon_state = "cutlass"
 	max_integrity = 240
 	force = 23
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/chop, /datum/intent/sword/peel)
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/chop, /datum/intent/sword/peel)
 	gripped_intents = null
-	wdefense = 6.5
+	wdefense = 6
 	wbalance = WBALANCE_SWIFT
 
 
@@ -952,7 +956,7 @@
 	force_wielded = 35
 	icon_state = "blackflamb"
 	smeltresult = /obj/item/ingot/blacksteel
-	max_integrity = 215
+	max_integrity = 300 //Blacksteel.
 
 /obj/item/rogueweapon/sword/long/blackflamb/getonmobprop(tag)
 	. = ..()
@@ -1060,7 +1064,7 @@
 	gripped_intents = list(/datum/intent/sword/cut/falx, /datum/intent/sword/strike, /datum/intent/sword/chop/falx, /datum/intent/sword/peel)
 	icon_state = "rhomphaia"
 	smeltresult = /obj/item/ingot/steel
-	max_integrity = 125
+	max_integrity = 175
 
 /obj/item/rogueweapon/sword/long/rhomphaia/getonmobprop(tag)
 	. = ..()
@@ -1165,7 +1169,7 @@
 	icon_state = "crhomphaia"
 	force = 22
 	force_wielded = 26
-	max_integrity = 100
+	max_integrity = 125
 	smeltresult = /obj/item/ingot/copper
 
 /obj/item/rogueweapon/sword/long/oathkeeper
@@ -1322,7 +1326,7 @@
 	desc = "A foreign sword used by cut-throats & thugs. There's a red tassel on the hilt."
 	icon_state = "eastsword1"
 	smeltresult = /obj/item/ingot/steel
-	wdefense = 3
+	wdefense = 4
 
 /obj/item/rogueweapon/sword/sabre/mulyeog/rumahench
 	name = "lenticular straight sword"
@@ -1332,10 +1336,10 @@
 /obj/item/rogueweapon/sword/sabre/mulyeog/rumacaptain
 	force = 30
 	name = "Heiyundao"
-	desc = "A gold-stained with cloud patterns on the groove. One of a kind."
+	desc = "A gold-stained sword with cloud patterns on the groove. One of a kind."
 	icon_state = "eastsword3"
-	max_integrity = 180
-	wdefense = 4
+	max_integrity = 225
+	wdefense = 5
 
 /obj/item/rogueweapon/sword/attack(mob/living/M, mob/living/user)
 	if(user == M && user.used_intent && user.used_intent.blade_class == BCLASS_STAB && istype(user.rmb_intent, /datum/rmb_intent/weak))

--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -26,7 +26,7 @@
 	resistance_flags = FLAMMABLE
 	can_parry = TRUE
 	associated_skill = /datum/skill/combat/shields		//Trained via blocking or attacking dummys with; makes better at parrying w/ shields.
-	wdefense = 10										//should be pretty baller
+	wdefense = 7										//should be pretty baller
 	var/coverage = 50
 	parrysound = list('sound/combat/parry/shield/towershield (1).ogg','sound/combat/parry/shield/towershield (2).ogg','sound/combat/parry/shield/towershield (3).ogg')
 	parrysound = list('sound/combat/parry/shield/towershield (1).ogg','sound/combat/parry/shield/towershield (2).ogg','sound/combat/parry/shield/towershield (3).ogg')
@@ -166,7 +166,7 @@
 	wlength = WLENGTH_NORMAL
 	resistance_flags = FLAMMABLE
 	blade_dulling = DULLING_SHAFT_REINFORCED
-	wdefense = 10
+	wdefense = 7.5
 	coverage = 40
 	parrysound = list('sound/combat/parry/shield/towershield (1).ogg','sound/combat/parry/shield/towershield (2).ogg','sound/combat/parry/shield/towershield (3).ogg')
 	max_integrity = 200
@@ -192,7 +192,7 @@
 	wlength = WLENGTH_NORMAL
 	resistance_flags = null
 	flags_1 = CONDUCT_1
-	wdefense = 11
+	wdefense = 8
 	coverage = 50
 	attacked_sound = list('sound/combat/parry/shield/metalshield (1).ogg','sound/combat/parry/shield/metalshield (2).ogg','sound/combat/parry/shield/metalshield (3).ogg')
 	parrysound = list('sound/combat/parry/shield/metalshield (1).ogg','sound/combat/parry/shield/metalshield (2).ogg','sound/combat/parry/shield/metalshield (3).ogg')
@@ -214,6 +214,8 @@
 	desc = "Protection of the Ten upon the wielder. A final, staunch line against the darkness. \
 	For it's not what is before the shield-carrier that matters, but the home behind them."
 	icon_state = "gsshield"
+	max_integrity = 350
+	wdefense = 9
 
 /obj/item/rogueweapon/shield/tower/metal/holysee/dark
 	icon_state = "gsshielddark"
@@ -222,7 +224,7 @@
 	name = "decrepit shield"
 	desc = "A decrepit, worn out shield. Aeon's grasp is upon it."
 	max_integrity = 150
-	wdefense = 9
+	wdefense = 6
 	icon_state = "ancientsh"
 	smeltresult = /obj/item/ingot/aalloy
 	blade_dulling = DULLING_SHAFT_CONJURED
@@ -241,7 +243,7 @@
 	possible_item_intents = list(SHIELD_BASH_METAL, SHIELD_BLOCK)
 	force = 25
 	throwforce = 25 //for cosplaying captain raneshen
-	wdefense = 11
+	wdefense = 8
 	max_integrity = 250 //not fully metal but not fully wood either
 
 /obj/item/rogueweapon/shield/tower/raneshen/getonmobprop(tag)
@@ -263,7 +265,7 @@
 	dropshrink = 0.8
 	resistance_flags = null
 	possible_item_intents = list(SHIELD_BASH_METAL, SHIELD_BLOCK, SHIELD_SMASH_METAL)
-	wdefense = 9
+	wdefense = 7
 	coverage = 10
 	attacked_sound = list('sound/combat/parry/shield/metalshield (1).ogg','sound/combat/parry/shield/metalshield (2).ogg','sound/combat/parry/shield/metalshield (3).ogg')
 	parrysound = list('sound/combat/parry/shield/metalshield (1).ogg','sound/combat/parry/shield/metalshield (2).ogg','sound/combat/parry/shield/metalshield (3).ogg')

--- a/code/modules/clothing/rogueclothes/scabbard.dm
+++ b/code/modules/clothing/rogueclothes/scabbard.dm
@@ -14,7 +14,7 @@
 	wlength = WLENGTH_SHORT
 	resistance_flags = FLAMMABLE
 	can_parry = TRUE
-	wdefense = 10
+	wdefense = 7
 	parrysound = "parrywood"
 	attacked_sound = "parrywood"
 	max_integrity = 150

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -561,7 +561,7 @@
 	var/mob/living/carbon/human/H
 	var/mob/living/carbon/human/UH
 	var/obj/item/I
-	var/drained = 10
+	var/drained = 5 //From 10 to 5, more in line with current parry drain
 	var/drained_npc = 5
 	if(ishuman(src))
 		H = src
@@ -573,7 +573,7 @@
 		return FALSE
 	if(L)
 		if(H?.check_dodge_skill())
-			prob2defend = prob2defend + (L.STASPD * 15)
+			prob2defend = prob2defend + (L.STASPD * 12.5) //+30% base dodge chance at Speed 15, makes it so dodge is counterable by equal speed or a large skill difference.
 		else
 			prob2defend = prob2defend + (L.STASPD * 10)
 	if(U)


### PR DESCRIPTION
## About The Pull Request
Debloats a lot of weapons and shields' wdefense, slightly buffs the wdefense of a few weapons that had completely unusable values. Reduces the impact dodge expert has on dodging from functionally +5% base dodge chance per SPD to +2.5% per SPD.

These are just value changes so as always, check the changed files for a detailed log, but a few pointers:

- Shields lose 3 points of wdefense across the board. This means a kite shield now offers a parry of 80% assuming equal shield and weapon skill. The point of shields is now to absorb blows without compromising your weapon's durability, and also offer protection against projectiles. Their parry is still good, but no longer '90% parry chance even if the opponent has higher skill' levels of good.
- Polearms lose 1 point of wdefense across the board. They are still king in parrying with a weapon, but going from 90% parry to 80% parry is still a significant nerf (twice the amount of blows going through).
- In particular the glaive had a 120% parry before. It goes down to 75% now, as it has overall better weapon intents than the spear.
- The naginata gets a small damage debuff but gains a niche as a swift polearm.
- Swords stay relatively the same, with minor nerfs in wdefense here and there. Arming swords are better at parrying than longswords, which are now better at parrying than greatswords and zweihanders. This means there is a tradeoff to using zweihanders and they are no longer strictly the best swords by virtue of having reach 2 and big peel.
- Maces also stay relatively the same, with minor buffs to parrying with maces due to blunt weapons being in a bad spot right  now.
- Daggers get decent parry chance, all the way up to 75% with the special Etruscan parrying dagger. Still not good parrying weapons but should allow the parrying daggers to actually perform their function now.
- No change to whips and flails.

As for the dodge changes:

- The weight of dodge expert was significantly reduced. This means having dodge expert is no longer a guarantee of 90% dodge chance. At 15 speed this nerf represents -30% dodge chance.
- In exchange, dodging costs 6.5 stamina, down from 10. This is still more than parrying, but should overall be less taxing for combat.

## Testing Evidence
<img width="445" height="73" alt="76283c20ae86601534db54d3caae5c2c" src="https://github.com/user-attachments/assets/5c408f7e-ea58-4f50-965a-5e72224be20d" />


## Why It's Good For The Game
Both parry and dodge chances were bloated to the point of being 80-90% in most cases. This, coupled with other issues, led to unsatisfying combats that only resolved once someone was swarmed to the point their stamina broke. This change addresses one of these issues by reducing wdefenses across the board.
