### PR TITLE
Orthodoxist gets church key + Inquis gets crypt key

### DIFF
--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -71,7 +71,7 @@
 	if(tag)
 		switch(tag)
 			if("gen")
-				return list("shrink" = 0.4,	
+				return list("shrink" = 0.4,
 "sx" = -6,
 "sy" = -3,
 "nx" = 13,
@@ -263,7 +263,10 @@
 	keys = list(/obj/item/roguekey/church, /obj/item/roguekey/graveyard)
 
 /obj/item/storage/keyring/puritan
-	keys = list(/obj/item/roguekey/puritan, /obj/item/roguekey/inquisition, /obj/item/roguekey/church)
+	keys = list(/obj/item/roguekey/puritan, /obj/item/roguekey/inquisition, /obj/item/roguekey/church, /obj/item/roguekey/graveyard)
+
+/obj/item/storage/keyring/orthodoxist
+	keys = list(/obj/item/roguekey/inquisition, /obj/item/roguekey/church)
 
 /obj/item/storage/keyring/nightman
 	keys = list(/obj/item/roguekey/nightman, /obj/item/roguekey/nightmaiden)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -70,8 +70,13 @@
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/random
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	mask = /obj/item/clothing/mask/rogue/facemask/psydonmask
+<<<<<<< Updated upstream
 	head = /obj/item/clothing/head/roguetown/roguehood/psydon
 	backpack_contents = list(/obj/item/roguekey/inquisition = 1, /obj/item/lockpickring/mundane = 1, /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger/preblessed, /obj/item/grapplinghook = 1)
+=======
+	head = /obj/item/clothing/head/roguetown/puritan
+	backpack_contents = list(/obj/item/storage/keyring/orthodoxist = 1, /obj/item/lockpickring/mundane = 1, /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger, /obj/item/grapplinghook = 1)
+>>>>>>> Stashed changes
 	H.change_stat("strength", -1) // weasel
 	H.change_stat("endurance", 3)
 	H.change_stat("perception", 2)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -70,13 +70,10 @@
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/random
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	mask = /obj/item/clothing/mask/rogue/facemask/psydonmask
-<<<<<<< Updated upstream
 	head = /obj/item/clothing/head/roguetown/roguehood/psydon
 	backpack_contents = list(/obj/item/roguekey/inquisition = 1, /obj/item/lockpickring/mundane = 1, /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger/preblessed, /obj/item/grapplinghook = 1)
-=======
 	head = /obj/item/clothing/head/roguetown/puritan
 	backpack_contents = list(/obj/item/storage/keyring/orthodoxist = 1, /obj/item/lockpickring/mundane = 1, /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger, /obj/item/grapplinghook = 1)
->>>>>>> Stashed changes
 	H.change_stat("strength", -1) // weasel
 	H.change_stat("endurance", 3)
 	H.change_stat("perception", 2)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -54,7 +54,7 @@
 	C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)	//Capped to T2 miracles. It's just a self-heal.
 
 /datum/outfit/job/roguetown/disciple/proc/brute_equip(mob/living/carbon/human/H)
-	backpack_contents = list(/obj/item/roguekey/inquisition = 1)
+	backpack_contents = list(/obj/item/storage/keyring/orthodoxist = 1)
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
@@ -58,7 +58,7 @@
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	beltr = /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger/preblessed
 	id = /obj/item/clothing/ring/silver
-	backpack_contents = list(/obj/item/roguekey/inquisition = 1)
+	backpack_contents = list(/obj/item/storage/keyring/orthodoxist = 1)
 	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/spellbreaker.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/spellbreaker.dm
@@ -77,8 +77,5 @@
 		ADD_TRAIT(H, TRAIT_MAGEARMOR, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_INQUISITION, TRAIT_GENERIC)
-<<<<<<< Updated upstream
 		ADD_TRAIT(H, TRAIT_SILVER_BLESSED, TRAIT_GENERIC)//Given they don't have the psyblessed silver cross. Puts them in line with the Inquisitor.
-=======
->>>>>>> Stashed changes
 		H.cmode_music = 'sound/music/inquisitorcombat.ogg'

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/spellbreaker.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/spellbreaker.dm
@@ -46,7 +46,7 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
 
 	backpack_contents = list(
-		/obj/item/roguekey/inquisition = 1,
+		/obj/item/storage/keyring/orthodoxist = 1,
 		/obj/item/rope/chain = 1,
 	)
 	if(H.mind)
@@ -77,5 +77,8 @@
 		ADD_TRAIT(H, TRAIT_MAGEARMOR, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_INQUISITION, TRAIT_GENERIC)
+<<<<<<< Updated upstream
 		ADD_TRAIT(H, TRAIT_SILVER_BLESSED, TRAIT_GENERIC)//Given they don't have the psyblessed silver cross. Puts them in line with the Inquisitor.
+=======
+>>>>>>> Stashed changes
 		H.cmode_music = 'sound/music/inquisitorcombat.ogg'


### PR DESCRIPTION
## About The Pull Request

I gave Orthodoxist a key to the church, and gave the Inquisitor a crypt key. I don't know why they didn't have one, honestly.

I also gave Confessor their buckled hat back. Praise the Ten.

## Testing Evidence

<img width="455" height="73" alt="image" src="https://github.com/user-attachments/assets/e70a0e7f-95cd-41b4-a286-4774b2f3ef21" />
<img width="219" height="153" alt="image" src="https://github.com/user-attachments/assets/1ac3f3c3-b00f-4cda-8dc6-51f28b8eb58e" />
<img width="147" height="84" alt="image" src="https://github.com/user-attachments/assets/648a9071-25cc-42da-8f1e-5f9376aebeae" />


## Why It's Good For The Game

It's extremely silly that Orthodoxists don't get church keys, and it's mostly just a byproduct of an earlier era. They are part of the Church, and answer to the Priest...yet they don't have keys to the front door. It gets very aggravating when playing the role. Even Churchlings get a key, and they can be Inhumen!
