### PR TITLE
Unapologetic salt PR

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/message.dm
+++ b/code/modules/spells/spell_types/wizard/utility/message.dm
@@ -6,7 +6,7 @@
 	releasedrain = 30
 	recharge_time = 60 SECONDS
 	warnie = "spellwarning"
-	spell_tier = 1
+	spell_tier = 2
 	associated_skill = /datum/skill/magic/arcane
 	overlay_state = "message"
 	var/identify_difficulty = 15 //the stat threshold needed to pass the identify check


### PR DESCRIPTION
Mindlink breaks if either person transforms into a Zad or is a zad
Message is made t2 so witches cannot get it
This is because of witches using zad form in combination with these spells to play like a crime reporting drone
As the person who made mindlink this was never it's intended use
<img width="2124" height="1149" alt="image" src="https://github.com/user-attachments/assets/8ef5eac5-2fe6-41f4-8bf5-fdfabefc88f8" />
<img width="2347" height="1437" alt="image" src="https://github.com/user-attachments/assets/e0c1b2e2-2858-49a0-8b58-17e7f18d49e6" />
