### PR TITLE
Inquisitor Ordinator Fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -130,7 +130,7 @@
 	H.verbs |= /mob/living/carbon/human/proc/faith_test
 	H.verbs |= /mob/living/carbon/human/proc/torture_victim
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_SILVER_BLESSED, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_INQUISITION, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_PERFECT_TRACKER, TRAIT_GENERIC)
@@ -143,12 +143,29 @@
 	pants = /obj/item/clothing/under/roguetown/chainlegs/kilt
 	cloak = /obj/item/clothing/cloak/cape/puritan
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	backl = /obj/item/rogueweapon/shield/tower/metal
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
-	head = /obj/item/clothing/head/roguetown/helmet/heavy/psydonhelm
 	gloves = /obj/item/clothing/gloves/roguetown/otavan/inqgloves
-	beltl = /obj/item/rogueweapon/sword/long/psysword
+	beltl = /obj/item/rogueweapon/sword/long/psysword/preblessed
 	backpack_contents = list(/obj/item/storage/keyring/puritan = 1, /obj/item/lockpickring/mundane = 1, /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger/preblessed, /obj/item/grapplinghook = 1, /obj/item/storage/belt/rogue/pouch/coins/rich = 1)
+
+	var/helmets = list(
+	"Ornate Barbute" 	= /obj/item/clothing/head/roguetown/helmet/heavy/psydonbarbute,
+	"Ornate Armet" 		= /obj/item/clothing/head/roguetown/helmet/heavy/psydonhelm,
+	"None"
+	)
+	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+	if(helmchoice != "None")
+		head = helmets[helmchoice]
+
+	var/shields = list(
+	"Holy Shield (Light)" 	= /obj/item/rogueweapon/shield/tower/metal/holysee,
+	"Holy Shield (Dark)" 	= /obj/item/rogueweapon/shield/tower/metal/holysee/dark,
+	"Weapon Strap" 			=/obj/item/gwstrap,
+	"None"
+	)
+	var/shieldchoice = input("Choose your Auxiliary.", "TAKE UP SHIELD") as anything in shields
+	if(shieldchoice != "None")
+		backr = shields[shieldchoice]
 
 /obj/item/clothing/gloves/roguetown/chain/blk
 		color = CLOTHING_GREY


### PR DESCRIPTION
## About The Pull Request
Allows him to actually use his armour, and provides him with the appropriate pre-blessed weapon. As was intended, but I missed it. Somehow noticed the dagger but not the blade. If he was a Psydonite, he'd auto get the trait to wear his armour, but in this server's infinite wisdom, it was decided that they shouldn't be. For whatever reason.

Additionally, this provides them with the helmet and back selection of the Adjudicator, too.

## Testing Evidence
I did not test this.
## Why It's Good For The Game
Literal oversight fix.
Also, selection of fluff items or a GWS isn't a big deal.