### PR TITLE
Tarot deck rename

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -442,10 +442,10 @@
 
 /obj/item/toy/cards/deck/tarot/populate_deck()
 	icon_state = "deck_[deckstyle]_full"
-	for(var/suit in list("Hearts", "Pikes", "Clovers", "Tiles"))
+	for(var/suit in list("Swords", "Wands", "Pentacles", "Cups"))
 		for(var/i in 1 to 10)
 			cards += "[i] of [suit]"
-		for(var/person in list("Valet", "Chevalier", "Dame", "Roi"))
+		for(var/person in list("Page", "Knight", "Queen", "King"))
 			cards += "[person] of [suit]"
 	for(var/trump in list("The Magician", "The High Priestess", "The Empress", "The Emperor", "The Hierophant", "The Lover", "The Chariot", "Justice", "The Hermit", "The Wheel of Fortune", "Strength", "The Hanged Man", "Death", "Temperance", "The Devil", "The Tower", "The Star", "The Moon", "The Sun", "Judgement", "The World", "The Fool"))
 		cards += trump


### PR DESCRIPTION
## About The Pull Request
Changes the suits and names on the Tarot deck to be their modern equivalents.

## Testing Evidence
I replaced some text strings with other text strings of approximately the same length. I forsee no issues.

## Why It's Good For The Game
I, and perhaps others, want to do fortune teller RP and know actual tarot reading. This will make it much easier when the deck uses the names I am used to. 
