### PR TITLE
Adds a surgeon's bag to the merchant's GOLDFACE

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/tools.dm
+++ b/code/modules/cargo/packsrogue/merchant/tools.dm
@@ -219,3 +219,8 @@
 	name = "Shovel"
 	cost = 20
 	contains = list(/obj/item/rogueweapon/shovel)
+
+/datum/supply_pack/rogue/tools/surgeon_bag
+	name = "Surgeon's Bag, Full"
+	cost = 80
+	contains = list(/obj/item/storage/belt/rogue/surgery_bag)


### PR DESCRIPTION
## About The Pull Request

+ Adds a filled out surgeon's bag to merchant's GOLDFACE for 80 zennies, baseline cost

For some reason this change did not come through from my previous surgeon's bag PR where I added it to the crafting menu AND merchant's Goldface

## Testing Evidence

<img width="600" height="450" alt="image" src="https://github.com/user-attachments/assets/759e7e48-cc12-478f-a6e3-1f6f3e5e577c" />

## Why It's Good For The Game

i dont want to stand in line for 20 minutes waiting for a smith to finish smithing
