### PR TITLE
[FIX] Savefile update for racial changes

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -7,7 +7,7 @@
 //	where you would want the updater procs below to run
 
 //	This also works with decimals.
-#define SAVEFILE_VERSION_MAX	31
+#define SAVEFILE_VERSION_MAX	32
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -133,6 +133,24 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			S["facial_style_name"]	>> facial_hairstyle
 	if(current_version < 30)
 		S["voice_color"]		>> voice_color
+	if(current_version < 32) // Update races
+		var/species_name
+		S["species"] >> species_name
+		testing("Save version < 32, updating [species_name].")
+		if(species_name)
+			var/newtype = GLOB.species_list[species_name]
+			if(!newtype)
+				if(species_name == "Sissean")
+					testing("Updating to Saurian.")
+					species_name = "Saurian"
+				else if(species_name == "Constructb")
+					testing("Updating to Golemb.")
+					species_name = "Golemb"
+				else if(findtext(species_name, "Metal Construct"))
+					testing("Updating to Golem.")
+					species_name = "Golem"
+
+		_load_species(S, species_name)
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)
@@ -327,10 +345,11 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	return TRUE
 
 
-/datum/preferences/proc/_load_species(S)
-	var/species_name
+/datum/preferences/proc/_load_species(S, species_name = null)
 	testing("begin _load_species()")
-	S["species"] >> species_name
+	if(!species_name)
+		S["species"] >> species_name
+
 	if(species_name)
 		var/newtype = GLOB.species_list[species_name]
 		if(newtype)


### PR DESCRIPTION
## About The Pull Request

-Updates proc `load_species` to accept species override.
-Update proc `update_character` to convert old species names to new species names
`Sissean` -> `Saurian`
`Constructb` -> `Golemb`
`Metal Construct` -> `Golem`
Which then calls `load_species` with the new species name as an override.

## Testing Evidence
From my testing it maintains the appearance from an old save file, if that's not the case feel free to ping me on Discord.
If it still doesn't work, make sure you **DON'T** save your broken character.

https://github.com/user-attachments/assets/b42fa60f-cb1b-4298-af28-d530440ad093

## Why It's Good For The Game

Transfers savefiles made before PR #309
Fix so players don't lose the customization made for their characters.