### PR TITLE
Gives Ordinator Inquisitor ornate half-plate and fixes satchel bug

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -165,7 +165,7 @@
 	)
 	var/shieldchoice = input("Choose your Auxiliary.", "TAKE UP SHIELD") as anything in shields
 	if(shieldchoice != "None")
-		backr = shields[shieldchoice]
+		backl = shields[shieldchoice]
 
 /obj/item/clothing/gloves/roguetown/chain/blk
 		color = CLOTHING_GREY

--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -136,7 +136,7 @@
 	ADD_TRAIT(H, TRAIT_PERFECT_TRACKER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_PURITAN, JOB_TRAIT)
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
-	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/fluted/ornate
+	armor = /obj/item/clothing/suit/roguetown/armor/plate/fluted/ornate
 	belt = /obj/item/storage/belt/rogue/leather/steel
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/chainmantle
 	shoes = /obj/item/clothing/shoes/roguetown/boots/otavan/inqboots


### PR DESCRIPTION
## About The Pull Request

At present, the Ordinator Inquisitor is a class described as a former Adjudicator (the Templar type of Orthodoxist) promoted up to Inquisitor. However, at present- they get worse armour than their actual Adjudicator underlings. They only get the silver cuirass, which is less coverage than the Adjudicator hauberk (only obtainable through adjudicator spawn.) It seems weird to me that they're running around with shitter armour than their minions, especially given that the cuirass is available for free. This gives the Ordinator Inquisitor ornate half-plate, which can be upgraded through smithing into full plate if they get blessed silver, giving them something to differentiate them as higher ranking.

Ordinator also had a bug from Carl's PR where the shield choice was overriding the satchel and deleting it. This PR fixes that.

## Testing Evidence

I changed the code and tested on my repo, and spawned with the plate.

## Why It's Good For The Game

Fleshes out the Inquisitor class in a way that doesn't really create much imbalance whatsoever. Heretics can get darksteel and such for pretty much free, so the Inquisitor having half-plate isn't going to throw balance off.
