### PR TITLE
Some runtimes fix [Test merge first]

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -216,7 +216,9 @@
  * * sig_typeor_types Signal string key or list of signal keys to stop listening to specifically
  */
 /datum/proc/UnregisterSignal(datum/target, sig_type_or_types)
-	var/list/lookup = target.comp_lookup
+	if (!target || !istype(target) || !target:comp_lookup) //Delinefortune:  If the target is null or not a valid type, we can't unregister
+		return
+	var/list/lookup = target.comp_lookup  
 	if(!signal_procs || !signal_procs[target] || !lookup)
 		return
 	if(!islist(sig_type_or_types))

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -87,9 +87,7 @@
 		/datum/body_marking_set/belly,
 		/datum/body_marking_set/bellysocks,
 		/datum/body_marking_set/tiger,
-		/datum/body_marking_set/tiger_dark,
-		/datum/body_marking/bangs,
-		/datum/body_marking/bun,
+		/datum/body_marking_set/tiger_dark,  //Delinefortune: removed TWO /datum/body_marking/ because there supposed to be /datum/body_marking_set
 	)
 	body_markings = list(
 		/datum/body_marking/flushed_cheeks,

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -157,7 +157,7 @@ There are several things that need to be remembered:
 					armdam_overlays += armdam_overlay
 			wound_overlays = list()
 			for(var/datum/wound/wound as anything in BP.wounds)
-				if(!wound.mob_overlay)
+				if(isnull(wound) || isnull(wound.mob_overlay)) //Delinefortune: If the wound is null or has no mob overlay, skip it
 					continue
 				wound_overlays |= wound.mob_overlay
 			for(var/wound_overlay in wound_overlays)


### PR DESCRIPTION
## About The Pull Request

An attempt to remove 3 sources of massive runtimes 

[[12:41:20] Runtime in code/modules/mob/living/carbon/human/species.dm, line 180: Cannot read null.body_marking_list]
[[12:51:10] Runtime in code/datums/components/_component.dm, line 219: Cannot read null.comp_lookup]
[[14:22:23] Runtime in code/modules/mob/living/carbon/human/update_icons.dm, line 160: Cannot read null.mob_overlay]

## Testing Evidence

<img width="1451" height="796" alt="image" src="https://github.com/user-attachments/assets/2b70c2e7-3e4a-4f05-895f-12a1c0776acc" />

## Why It's Good For The Game

less runtimes good