### PR TITLE
Cmp timer runtimes fix i hope [Test merge first]

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -258,7 +258,7 @@ SUBSYSTEM_DEF(timer)
 	if (!length(alltimers))
 		return
 
-	sortTim(alltimers, PROC_REF(cmp_timer))
+	sortTim(alltimers, /proc/cmp_timer) //Delinefortune:  Strings can't be called like procs, coz BYOND not likes it. Sorry no PROC_REF
 
 	var/datum/timedevent/head = alltimers[1]
 


### PR DESCRIPTION
## About The Pull Request

PROC_REF(cmp_timer)) -> sortTim(alltimers, /proc/cmp_timer)

## Testing Evidence

one line change what can go bad........................
<img width="1425" height="580" alt="image" src="https://github.com/user-attachments/assets/36a1248d-fd07-4813-aae7-fbbb71245e0c" />
Dont mind wildkin stuff coz is my fork from main 

## Why It's Good For The Game

an attempt to remove those guys
<img width="478" height="121" alt="image" src="https://github.com/user-attachments/assets/a5c5a1ee-69f1-40e8-aa7c-7915b6c184d1" />


