### PR TITLE
Even more wretch changes

### DIFF
--- a/code/modules/antagonists/roguetown/villain/vampire.dm
+++ b/code/modules/antagonists/roguetown/villain/vampire.dm
@@ -329,7 +329,7 @@
 	}
 	// Restore original appearance to visible organs
 	for(var/obj/item/organ/O in internal_organs)
-		if(istype(O, /obj/item/organ/tail) || istype(O, /obj/item/organ/wings) || istype(O, /obj/item/organ/ears) || istype(O, /obj/item/organ/snout) || istype(O, /obj/item/organ/horns) || istype(O, /obj/item/organ/frills) || istype(O, /obj/item/organ/penis) || istype(O, /obj/item/organ/breasts)) {
+		if(istype(O, /obj/item/organ/tail) || istype(O, /obj/item/organ/tail_feature) || istype(O, /obj/item/organ/wings) || istype(O, /obj/item/organ/ears) || istype(O, /obj/item/organ/snout) || istype(O, /obj/item/organ/horns) || istype(O, /obj/item/organ/frills) || istype(O, /obj/item/organ/penis) || istype(O, /obj/item/organ/breasts)) {
 			if(islist(VD.original_organ_icons) && (O in VD.original_organ_icons)) O.icon = VD.original_organ_icons[O]
 			if(islist(VD.original_organ_icon_states) && (O in VD.original_organ_icon_states)) O.icon_state = VD.original_organ_icon_states[O]
 			if(islist(VD.original_organ_colors) && (O in VD.original_organ_colors)) O.color = VD.original_organ_colors[O]

--- a/code/modules/antagonists/roguetown/villain/vampire.dm
+++ b/code/modules/antagonists/roguetown/villain/vampire.dm
@@ -329,7 +329,7 @@
 	}
 	// Restore original appearance to visible organs
 	for(var/obj/item/organ/O in internal_organs)
-		if(istype(O, /obj/item/organ/tail) || istype(O, /obj/item/organ/wings) || istype(O, /obj/item/organ/ears) || istype(O, /obj/item/organ/snout) || istype(O, /obj/item/organ/horns) || istype(O, /obj/item/organ/frills)) {
+		if(istype(O, /obj/item/organ/tail) || istype(O, /obj/item/organ/wings) || istype(O, /obj/item/organ/ears) || istype(O, /obj/item/organ/snout) || istype(O, /obj/item/organ/horns) || istype(O, /obj/item/organ/frills) || istype(O, /obj/item/organ/penis) || istype(O, /obj/item/organ/breasts)) {
 			if(islist(VD.original_organ_icons) && (O in VD.original_organ_icons)) O.icon = VD.original_organ_icons[O]
 			if(islist(VD.original_organ_icon_states) && (O in VD.original_organ_icon_states)) O.icon_state = VD.original_organ_icon_states[O]
 			if(islist(VD.original_organ_colors) && (O in VD.original_organ_colors)) O.color = VD.original_organ_colors[O]

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/werewolf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/werewolf.dm
@@ -33,7 +33,8 @@
 		TRAIT_HARDDISMEMBER, //Decapping Volfs causes them to bug out, badly, and need admin intervention to fix. Bandaid fix.
 		TRAIT_PIERCEIMMUNE, //Prevents weapon dusting and caltrop effects due to them transforming when killed/stepping on shards.
 		TRAIT_IGNORESLOWDOWN,
-		TRAIT_LONGSTRIDER
+		TRAIT_LONGSTRIDER,
+		TRAIT_ZOMBIE_IMMUNE
 	)
 	inherent_biotypes = MOB_HUMANOID
 	armor = 30


### PR DESCRIPTION
-Vampires and werewolves both get zombie immunity
-Vampires get no sleep trait so they cannot eaisly recover from damage (pay to use regen or find someone to heal you) 
-Vampire disguise now changes all organ colours when disguising and undisguising rather than just your skin tone

Shown by this disgusting sparkledog that should be KOS'd
<img width="318" height="224" alt="image" src="https://github.com/user-attachments/assets/8442659f-4fcf-47ab-b526-e2092fe40ba7" />
<img width="1888" height="1066" alt="image" src="https://github.com/user-attachments/assets/71f616a6-e2f2-4040-bb6c-60dad30da45e" />
