### PR TITLE
Fixes silver half-plate bug

### DIFF
--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -987,25 +987,6 @@
 
 	max_integrity = 400
 
-	/// Whether the user has the Heavy Armour Trait prior to donning.
-	var/traited = FALSE
-
-/obj/item/clothing/suit/roguetown/armor/plate/fluted/ornate/equipped(mob/living/user, slot)
-	..()
-	if(slot != SLOT_ARMOR)
-		return
-	if (!HAS_TRAIT(user, TRAIT_MEDIUMARMOR))
-		return
-	ADD_TRAIT(user, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	to_chat(user, span_notice("Endure til' inevitability."))
-
-/obj/item/clothing/suit/roguetown/armor/plate/fluted/ornate/dropped(mob/living/user)
-	..()
-	if (traited)
-		return
-	REMOVE_TRAIT(user, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	to_chat(user, span_notice("Trust in thyself."))
-
 /obj/item/clothing/suit/roguetown/armor/plate/full
 	name = "plate armor"
 	desc = "Full plate. Slow to don and doff without the aid of a good squire."


### PR DESCRIPTION
There was an unforseen bug with giving the silver half-plate to Ordinator Inquisitor. It had a weird proc where it would grant heavy armour training to anyone who equipped it with medium armour training, then remove it when unequipped. Given that the Ordinator only has heavy armour training, it just removed it entirely and left them perkless for the rest of the round.

This is a pretty silly proc to have, so I just removed it.
