### PR TITLE
Sorry Necrians I've been left with no choice (soft disables deaths door)

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -120,7 +120,7 @@
 					/obj/effect/proc_holder/spell/invoked/necras_sight			= CLERIC_T0,
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/invoked/avert					= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/deaths_door			= CLERIC_T1,
+//					/obj/effect/proc_holder/spell/invoked/deaths_door			= CLERIC_T1, //This spell is VERY busted and can RR. Soft-disabled until someone fixes the damn thing.
 					/obj/effect/proc_holder/spell/targeted/abrogation			= CLERIC_T2,
 	)
 	confess_lines = list(


### PR DESCRIPTION
## About The Pull Request
Prevents the Necrian spell ''deaths door'' from being accessible by normal means. This spell is AMAZING and I love it however it was clearly a little to ambitious for whoever created it. Its riddled with bugs including trapping players needing admin involvement or frequently round removing people.

I personally HATE to do this but the issue has been up awhile and no one has come forward with a proper fix. This will have to do for now the code all remains intact for someone smarter then I.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="637" height="652" alt="dreamseeker_6fd0Mhh0Ln" src="https://github.com/user-attachments/assets/52906e80-56ea-452a-8e94-ce0a28b39a90" />

## Why It's Good For The Game
Round removal bad.
sticky portal trapping people bad. (To be clear I am aware Necrians can remove people from portals normally. This bug goes deeper then that)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
