### PR TITLE
Update warscholar.dm

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -72,7 +72,7 @@
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/haste)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/fortitude)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/forcewall/greater)
-			r_hand = /obj/item/rogueweapon/woodstaff/naledi
+			backl = /obj/item/rogueweapon/woodstaff/naledi
 
 
 			head = /obj/item/clothing/head/roguetown/roguehood/hierophant
@@ -141,7 +141,7 @@
 			H.change_stat("endurance", 2)
 			H.change_stat("intelligence", 3)
 			H.change_stat("speed", 2)
-			r_hand = /obj/item/rogueweapon/woodstaff/naledi
+			backl = /obj/item/rogueweapon/woodstaff/naledi
 			armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hierophant/grey
 			mask = /obj/item/clothing/mask/rogue/lordmask/naledi
 			belt = /obj/item/storage/belt/rogue/leather


### PR DESCRIPTION
## About The Pull Request
back at at again with another mini PR. I'm not _entirely_ sure the root of this issue but Scholars  kept dropping their staffs on spawn when spawned in hand. Causing them to outright LOSE their staff if they took the resident trait. This just moves it to their back slot. Simple as!

Detail a issue report of my guesses on why this happens and the other classes it effects shortly since..I cant fix those this way.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Confirmed they spawned with staff after changes.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Slides around a bug. Best I got idk why this happens. Bugs are bad.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
