### PR TITLE
Fixes RCP [Hotfix]

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -147,7 +147,7 @@
 		if(H.stat != DEAD)
 			if(H.get_triumphs() < 0)
 				H.adjust_triumphs(1)
-		if(GLOB.round_join_times[H.ckey] && H.job && H.allmig_reward)
+		if(GLOB.round_join_times[H.ckey] && H.job)
 			if((GLOB.round_join_times[H.ckey] + 45 MINUTES) < world.time)
 				var/datum/job/job = SSjob.GetJob(H.job)
 				if(job && job.round_contrib_points)


### PR DESCRIPTION
rcp was not being added

this was because of the order of the procs cleared the 'nights slept' thing before checking to see if any nights were slept
this just kinda removes the nights slept requirement. being there 45 mins before the round end is already enough for a hotfix

i tested it it worked