### PR TITLE
Reduce Shadowstep cooldown to 15 seconds

### DIFF
--- a/code/modules/spells/spell_types/wizard/misc/shadowstep.dm
+++ b/code/modules/spells/spell_types/wizard/misc/shadowstep.dm
@@ -10,7 +10,7 @@
 	overlay_state = "shadowstep"
 	chargedrain = 1
 	chargetime = 0 SECONDS
-	recharge_time = 30 SECONDS
+	recharge_time = 15 SECONDS
 	hide_charge_effect = TRUE
 	gesture_required = TRUE // Mobility spell
 	spell_tier = 2


### PR DESCRIPTION
It has a massive windup and is useless for combat, this will just lower its cooldown enough to make it actually useful for infiltration.

Provided you don't get caught.
