### PR TITLE
Let heretics of same Ascendant detect each other, Matthios-style

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -870,16 +870,22 @@
 			heretic_text += "A member of Zizo's cabal."
 			if(HAS_TRAIT(examiner, TRAIT_CABAL))
 				heretic_text += " May their ambitions not interfere with mine."
+		else if(HAS_TRAIT(examiner, TRAIT_CABAL))
+			heretic_text += "Fellow scholar of Her Works!"
 	else if((HAS_TRAIT(src, TRAIT_HORDE)))
 		if(seer)
 			heretic_text += "Hardened by Graggar's Rituals."
 			if(HAS_TRAIT(examiner, TRAIT_HORDE))
 				heretic_text += " Mine were a glorious memory."
+		else if(HAS_TRAIT(examiner, TRAIT_HORDE))
+			heretic text += "Ally in slaughter!"
 	else if((HAS_TRAIT(src, TRAIT_DEPRAVED)))
 		if(seer)
 			heretic_text += "Baotha's Touched."
 			if(HAS_TRAIT(examiner, TRAIT_DEPRAVED))
 				heretic_text += " She leads us to the greatest ends."
+		else if(HAS_TRAIT(examiner, TRAIT_DEPRAVED))
+			heretic text += "Companion in pleasure!"
 	
 	return heretic_text
 


### PR DESCRIPTION
## About The Pull Request
Lets heretics of same Ascendant deity detect each other, like Matthiosites do.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
There's literally nothing that could break. It's the same code that Matthiosites use, but extended to Zizoists, Graggarites and Baothans
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Heretics already can find their allies in heart-RMB tab, so I don't know why they can't do the same on Examine. Plus, it makes it easier for heretics to find each other and cooperate inside of the town to actually conspire instead of gathering fragbands in the abandoned church and killing people outside of the town.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
