### PR TITLE
make crab cake not take an entire crab

### DIFF
--- a/modular/Neu_Food/code/raw/raw_shellfish.dm
+++ b/modular/Neu_Food/code/raw/raw_shellfish.dm
@@ -10,7 +10,7 @@
 	slice_path = /obj/item/reagent_containers/food/snacks/rogue/meat/crab
 	cooked_smell = /datum/pollutant/food/fried_crab
 
-/obj/item/reagent_containers/food/snacks/fish/crab/attackby(obj/item/I, mob/living/user, params)
+/obj/item/reagent_containers/food/snacks/rogue/meat/crab/attackby(obj/item/I, mob/living/user, params)
 	var/found_table = locate(/obj/structure/table) in (loc)
 	if(istype(I, /obj/item/reagent_containers/food/snacks/rogue/butterdoughslice))
 		if(isturf(loc)&& (found_table))


### PR DESCRIPTION
## About The Pull Request

why does the crab cake recipie take an entire crab. that shouldn't be the case. this makes it not the case

## Testing Evidence

slapped some butterdough slice on the raw crab meat on a table and it worked

## Why It's Good For The Game

i'll admit cooking doesnt take a whole lot of presence in this game but it's important to ME. i NEED to be able to make every recipie available and nobody ever brings the crab whole to a cook anyways. please merge this i beg of you
