### PR TITLE
Sleep Level-Ups for Wretch Vampires

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -66,7 +66,6 @@
 				ADD_TRAIT(H, TRAIT_NOBREATH, TRAIT_GENERIC)
 				ADD_TRAIT(H, TRAIT_NOPAIN, TRAIT_GENERIC)
 				ADD_TRAIT(H, TRAIT_INFINITE_STAMINA, TRAIT_GENERIC)
-				ADD_TRAIT(H, TRAIT_VAMP_DREAMS, TRAIT_GENERIC)
 				// Apply -1 to all stats
 				H.change_stat("strength", -1)
 				H.change_stat("perception", -1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -66,6 +66,7 @@
 				ADD_TRAIT(H, TRAIT_NOBREATH, TRAIT_GENERIC)
 				ADD_TRAIT(H, TRAIT_NOPAIN, TRAIT_GENERIC)
 				ADD_TRAIT(H, TRAIT_INFINITE_STAMINA, TRAIT_GENERIC)
+				ADD_TRAIT(H, TRAIT_VAMP_DREAMS, TRAIT_GENERIC)
 				// Apply -1 to all stats
 				H.change_stat("strength", -1)
 				H.change_stat("perception", -1)


### PR DESCRIPTION
## About The Pull Request

Adds TRAIT_VAMP_DREAMS to Wretch Vampires, making them receive a moodlet upon daybreak that allows them to trigger the sleep levelup prompt.

## Testing Evidence

<img width="1150" height="811" alt="image" src="https://github.com/user-attachments/assets/2678c4ca-9234-431d-8a38-3633c591d275" />


## Why It's Good For The Game

Enables vamps to do more interesting things than just run around naked and make people on discord cry.
