### PR TITLE
Impreg Rework: Add impregnation probability handling to sex actions and genital organs.

### DIFF
--- a/code/__DEFINES/sexcon_defines.dm
+++ b/code/__DEFINES/sexcon_defines.dm
@@ -53,6 +53,10 @@ GLOBAL_LIST_INIT(sex_actions, build_sex_actions())
 #define PAIN_MINIMUM_FOR_DAMAGE PAIN_MED_EFFECT
 #define PAIN_DAMAGE_DIVISOR 50
 
+#define IMPREG_PROB_DEFAULT 25
+#define IMPREG_PROB_INCREMENT 20
+#define IMPREG_PROB_MAX 95
+
 /proc/build_sex_actions()
 	. = list()
 	for(var/path in typesof(/datum/sex_action))

--- a/code/__DEFINES/sexcon_defines.dm
+++ b/code/__DEFINES/sexcon_defines.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_INIT(sex_actions, build_sex_actions())
 #define PAIN_DAMAGE_DIVISOR 50
 
 #define IMPREG_PROB_DEFAULT 25
-#define IMPREG_PROB_INCREMENT 20
+#define IMPREG_PROB_INCREMENT 10
 #define IMPREG_PROB_MAX 95
 
 /proc/build_sex_actions()

--- a/code/datums/sexcon/sexcon_helpers.dm
+++ b/code/datums/sexcon/sexcon_helpers.dm
@@ -69,14 +69,17 @@
 		playsound(src, pick('sound/misc/mat/guymouth (1).ogg','sound/misc/mat/guymouth (2).ogg','sound/misc/mat/guymouth (3).ogg','sound/misc/mat/guymouth (4).ogg','sound/misc/mat/guymouth (5).ogg'), 35, TRUE, ignore_walls = FALSE)
 
 /mob/living/carbon/human/proc/try_impregnate(mob/living/carbon/human/wife)
-	var/obj/item/organ/testicles/testes = getorganslot(ORGAN_SLOT_TESTICLES)
-	if(!testes)
-		return
-	var/obj/item/organ/vagina/vag = wife.getorganslot(ORGAN_SLOT_VAGINA)
-	if(!vag)
-		return
-	if(prob(25) && wife.is_fertile() && is_virile())
-		vag.be_impregnated(src)
+    var/obj/item/organ/testicles/testes = getorganslot(ORGAN_SLOT_TESTICLES)
+    if(!testes)
+        return
+    var/obj/item/organ/vagina/vag = wife.getorganslot(ORGAN_SLOT_VAGINA)
+    if(!vag)
+        return
+    if(prob(vag.impregnation_probability) && wife.is_fertile() && is_virile())
+        vag.be_impregnated(src)
+        vag.impregnation_probability = IMPREG_PROB_DEFAULT // Reset on success
+    else
+        vag.impregnation_probability = min(vag.impregnation_probability + IMPREG_PROB_INCREMENT, IMPREG_PROB_MAX)
 
 /mob/living/carbon/human/proc/get_highest_grab_state_on(mob/living/carbon/human/victim)
 	var/grabstate = null

--- a/code/modules/surgery/organs/feature_organs/genitals.dm
+++ b/code/modules/surgery/organs/feature_organs/genitals.dm
@@ -100,14 +100,16 @@
 	var/impregnation_probability = IMPREG_PROB_DEFAULT
 
 /obj/item/organ/vagina/proc/be_impregnated(mob/living/carbon/human/father)
-	if(pregnant)
-		return
-	if(!owner)
-		return
-	if(owner.stat == DEAD)
-		return
-	to_chat(owner, span_love("I feel a surge of warmth in my belly, I’m definitely pregnant!"))
-	pregnant = TRUE
+    if(!owner)
+        return
+    if(owner.stat == DEAD)
+        return
+    if(pregnant)
+        to_chat(owner, span_love("I feel a surge of warmth in my belly again..."))
+        return
+    to_chat(owner, span_love("I feel a surge of warmth in my belly, I’m definitely pregnant!"))
+    pregnant = TRUE
+	//TODO add a way to trigger lactating when pregnancy happens
 
 /obj/item/organ/breasts
 	name = "breasts"

--- a/code/modules/surgery/organs/feature_organs/genitals.dm
+++ b/code/modules/surgery/organs/feature_organs/genitals.dm
@@ -97,7 +97,7 @@
 	accessory_type = /datum/sprite_accessory/vagina/human
 	var/pregnant = FALSE
 	var/fertility = TRUE
-	var/impregnation_probability = 25
+	var/impregnation_probability = IMPREG_PROB_DEFAULT
 
 /obj/item/organ/vagina/proc/be_impregnated(mob/living/carbon/human/father)
 	if(pregnant)

--- a/code/modules/surgery/organs/feature_organs/genitals.dm
+++ b/code/modules/surgery/organs/feature_organs/genitals.dm
@@ -97,6 +97,7 @@
 	accessory_type = /datum/sprite_accessory/vagina/human
 	var/pregnant = FALSE
 	var/fertility = TRUE
+	var/impregnation_probability = 25
 
 /obj/item/organ/vagina/proc/be_impregnated(mob/living/carbon/human/father)
 	if(pregnant)


### PR DESCRIPTION
## About The Pull Request

The idea is to change how the game handles the impregnation proc to be more interactive and cumulative so players can have a bit more interaction with the probabilities to trigger it.

## Testing Evidence

I tested the changes by running a private server on Dream Daemon, granted admin on myself by moving the files from config/example to config and labeling my ckey to the required rank, I instead of using the "roguetest.dm" I waited 5 minutes and ran the standard map as I was still figuring out how this works, managed to get the Server working and spawning myself as a "Male" character stripped it and went back to lobby to respawn as a "Female" both characters with the corresponding organs to properly test it, noticed I forgot to Toggle the ERP Panel Menu, toggled it ON, did the mechanical ERP until I trigger the corresponding Proc making sure it works.
And here are the server logs on a .txt of the test.
[Debug - censured.txt](https://github.com/user-attachments/files/21478864/Debug.-.censured.txt)

Edit: I changed the file contents to be more secured with my info.



## Why It's Good For The Game

It gives more risk to the action and makes players think more carefully about the chances as it scales with every attempt.
