### PR TITLE
Remove invalid dir override for some tables

### DIFF
--- a/_maps/map_files/dun_manor/azure_coast.dmm
+++ b/_maps/map_files/dun_manor/azure_coast.dmm
@@ -130,8 +130,7 @@
 /area/rogue/under/cave/mazedungeon)
 "aw" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
@@ -500,8 +499,7 @@
 /area/rogue/indoors/cave)
 "cr" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden{
 	pixel_x = 6;
@@ -1012,8 +1010,7 @@
 /area/rogue/outdoors/beach)
 "fL" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -1430,7 +1427,6 @@
 "iA" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
-	dir = 1
 	},
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/blocks,
@@ -1937,8 +1933,7 @@
 /area/rogue/indoors/cave)
 "mt" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
@@ -2782,8 +2777,7 @@
 /area/rogue/under/cave/orcdungeon)
 "rT" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2855,8 +2849,7 @@
 /area/rogue/under/cave/orcdungeon)
 "sv" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter)
@@ -3572,8 +3565,7 @@
 /area/rogue/under/cave/orcdungeon)
 "xr" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/roguecoin/copper/pile,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -4040,8 +4032,7 @@
 /area/rogue/outdoors/beach/forest)
 "AF" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/blocks,
@@ -5569,8 +5560,7 @@
 	dir = 4
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/bottle,
 /turf/open/floor/rogue/woodturned,
@@ -6465,8 +6455,7 @@
 /area/rogue/under/cave/dukecourt)
 "Qx" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/wood,
@@ -7450,8 +7439,7 @@
 /area/rogue/outdoors/beach)
 "Xe" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter)

--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -2400,8 +2400,7 @@
 /area/rogue/under/cave/dungeon1/gethsmane)
 "tL" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
@@ -3683,8 +3682,7 @@
 /area/rogue/under/cave/dungeon1/gethsmane)
 "DU" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/structure/vine,
 /turf/open/floor/rogue/greenstone,
@@ -3892,7 +3890,6 @@
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "FE" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/twig,
@@ -4095,8 +4092,7 @@
 /area/rogue/indoors/shelter/woods)
 "Hi" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/hexstone,
@@ -5263,8 +5259,7 @@
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Ra" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane)
@@ -5964,8 +5959,7 @@
 /area/rogue/outdoors/woods)
 "WD" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/woods)
@@ -6002,8 +5996,7 @@
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "WT" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /obj/item/reagent_containers/glass/bottle/rogue/wine,

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -3067,7 +3067,6 @@
 /obj/effect/decal/cleanable/dirt/cobweb,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
@@ -3853,7 +3852,6 @@
 /area/rogue/indoors/town)
 "cCO" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
@@ -6248,7 +6246,6 @@
 /area/rogue/under/town/sewer)
 "ejk" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/carpet/red,
@@ -6391,7 +6388,6 @@
 	dir = 1
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
@@ -6981,7 +6977,6 @@
 /area/rogue/outdoors/mountains)
 "eNa" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/woodstaff,
@@ -7224,7 +7219,6 @@
 /area/rogue/indoors/town/physician)
 "eVG" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/mace/woodclub,
@@ -8552,7 +8546,6 @@
 /area/rogue/under/town/basement/keep)
 "fUG" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/torchholder/l,
@@ -8613,7 +8606,6 @@
 /area/rogue/indoors/town)
 "fXb" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/torchholder/r,
@@ -9241,7 +9233,6 @@
 /area/rogue/indoors/town/bath)
 "gvO" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/blocks,
@@ -9460,7 +9451,6 @@
 	pixel_y = 32
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
@@ -10487,7 +10477,6 @@
 	layer = 2.81
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
@@ -10712,7 +10701,6 @@
 /area/rogue/indoors/town/manor)
 "hCc" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
@@ -11844,7 +11832,6 @@
 /area/rogue/indoors/town/vault)
 "iwd" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12916,7 +12903,6 @@
 /area/rogue/under/town/basement)
 "jiG" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -13354,7 +13340,6 @@
 /area/rogue/indoors/town)
 "jAw" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -13828,7 +13813,6 @@
 /area/rogue/indoors/town/tavern)
 "jPP" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -15316,7 +15300,6 @@
 /area/rogue/indoors/town/garrison)
 "kOv" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -15541,7 +15524,6 @@
 /area/rogue/under/town/basement/keep)
 "kUP" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -16681,7 +16663,6 @@
 	icon_state = "cobbleedge-w"
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/millstone{
@@ -19000,7 +18981,6 @@
 "noF" = (
 /obj/structure/fluff/canopy,
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter,
@@ -21257,7 +21237,6 @@
 	dir = 9
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
@@ -21315,7 +21294,6 @@
 /area/rogue/indoors/town/manor)
 "oQn" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
@@ -21559,7 +21537,6 @@
 /area/rogue/under/town/basement)
 "oZv" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
@@ -23203,7 +23180,6 @@
 /area/rogue/under/town/sewer)
 "qkE" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/bucket,
@@ -24104,7 +24080,6 @@
 /area/rogue/indoors/town/garrison)
 "qTF" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/toy/cards/deck,
@@ -24854,7 +24829,6 @@
 /area/rogue/indoors/town/church)
 "rtH" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/rogue/instrument/drum,
@@ -24946,7 +24920,6 @@
 /area/rogue/indoors/town/dwarfin)
 "rwd" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
@@ -25076,7 +25049,6 @@
 /area/rogue/indoors)
 "rBh" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/blocks,
@@ -25236,7 +25208,6 @@
 /area/rogue/indoors/town)
 "rGy" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/grass,
@@ -25387,7 +25358,6 @@
 "rLe" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/carpet,
@@ -29297,7 +29267,6 @@
 /area/rogue/indoors/town/magician)
 "uwQ" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/paper/scroll,
@@ -29774,7 +29743,6 @@
 /area/rogue/indoors/town)
 "uMM" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter,
@@ -34090,7 +34058,6 @@
 /area/rogue/indoors/town/church)
 "xOb" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/structure/rogue/trophy/deer,
@@ -34243,7 +34210,6 @@
 /area/rogue/outdoors/town/roofs)
 "xRp" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,

--- a/_maps/map_files/dun_manor/smalldecap.dmm
+++ b/_maps/map_files/dun_manor/smalldecap.dmm
@@ -657,8 +657,7 @@
 /area/rogue/outdoors/spidercave)
 "in" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/cooking/pan,
 /obj/item/reagent_containers/powder/flour,
@@ -2682,8 +2681,7 @@
 /area/rogue/under/cave/undeadmanor)
 "Ib" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/mountains/decap/stepbelow)

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -14710,12 +14710,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/fox,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/beach/forest)
-"eWU" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
 "eWV" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/dirt,
@@ -24504,14 +24498,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
-"icF" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "icG" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -27069,12 +27055,6 @@
 "iSm" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/magician)
-"iSp" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "iSu" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -42866,13 +42846,6 @@
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
-"ogQ" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town)
 "ogR" = (
 /obj/structure/fluff/clock,
 /obj/structure/fluff/walldeco/customflag{
@@ -49548,12 +49521,6 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"quQ" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/shelter/woods)
 "quT" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -50628,12 +50595,6 @@
 "qLt" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"qLM" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "qLO" = (
 /obj/machinery/light/rogue/wallfire,
 /turf/closed/wall/mineral/rogue/pipe,
@@ -52564,12 +52525,6 @@
 /obj/item/book/rogue/sword,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"rvm" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "rvn" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -230794,8 +230749,8 @@ tlX
 kbo
 pTF
 oZa
-quQ
-quQ
+gKS
+gKS
 pfw
 kbo
 ktX
@@ -231246,8 +231201,8 @@ tlX
 kbo
 kbo
 pfw
-quQ
-quQ
+gKS
+gKS
 oZa
 kbo
 jWF
@@ -231698,8 +231653,8 @@ tlX
 kbo
 kbo
 pfw
-quQ
-quQ
+gKS
+gKS
 kbo
 kbo
 ktX
@@ -240626,7 +240581,7 @@ uBc
 rUf
 sYZ
 jKv
-icF
+gGV
 naO
 uBc
 sNZ
@@ -259080,7 +259035,7 @@ uTJ
 aIu
 uBc
 mJt
-ogQ
+xUM
 hek
 cDX
 uBc
@@ -260885,7 +260840,7 @@ fpx
 exD
 exD
 exD
-qLM
+xQL
 uBc
 iLW
 xWU
@@ -261352,7 +261307,7 @@ uBc
 sYZ
 rRQ
 cDX
-eWU
+cZH
 ggq
 phl
 sns
@@ -269473,7 +269428,7 @@ pWT
 njB
 daQ
 pAl
-rvm
+ujN
 pWT
 uBc
 xol
@@ -370948,7 +370903,7 @@ aBB
 aBB
 aBB
 jWF
-iSp
+mve
 kbo
 tlX
 tlX

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -118,7 +118,6 @@
 /area/rogue/under/cave)
 "acr" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -1727,7 +1726,6 @@
 /area/rogue/outdoors/beach)
 "aCU" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/structure/rogue/trophy/deer,
@@ -2058,7 +2056,6 @@
 	layer = 2.81
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
@@ -2485,7 +2482,6 @@
 /area/rogue/indoors/town/dwarfin)
 "aPD" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/structure/vine,
@@ -2790,7 +2786,6 @@
 	dir = 4
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -2978,7 +2973,6 @@
 /area/rogue/indoors/shelter)
 "aYU" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/wallfire/candle{
@@ -3504,7 +3498,6 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "bgS" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
@@ -4972,7 +4965,6 @@
 /area/rogue/indoors/town/bath)
 "bGB" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/alch/rosa,
@@ -5955,7 +5947,6 @@
 /area/rogue/indoors/town/church/basement)
 "bWn" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/silver/lit{
@@ -9220,7 +9211,6 @@
 /area/rogue/indoors/cave)
 "dcp" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/clothing/ring/duelist{
@@ -11558,7 +11548,6 @@
 /area/rogue/under/town/basement/keep)
 "dTS" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/bucket/pot/stone,
@@ -11817,7 +11806,6 @@
 	dir = 9
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
@@ -13174,7 +13162,6 @@
 /area/rogue/under/cave/orcdungeon)
 "euO" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -13270,7 +13257,6 @@
 /area/rogue/under/cave/orcdungeon)
 "ewi" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/toy/cards/deck,
@@ -14263,7 +14249,6 @@
 /area/rogue/outdoors/mountains/decap)
 "eNu" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
@@ -14727,7 +14712,6 @@
 /area/rogue/outdoors/beach/forest)
 "eWU" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
@@ -15193,7 +15177,6 @@
 /area/rogue/indoors/town)
 "fdm" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/eora/lit,
@@ -16048,7 +16031,6 @@
 /area/rogue/indoors/shelter)
 "fqm" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/eora/lit{
@@ -16172,7 +16154,6 @@
 /area/rogue/indoors/town)
 "frN" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden{
@@ -17754,7 +17735,6 @@
 /area/rogue/outdoors/town)
 "fSU" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
@@ -18593,7 +18573,6 @@
 "giW" = (
 /obj/structure/fluff/canopy,
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter,
@@ -19196,7 +19175,6 @@
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "gth" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/millstone,
@@ -19605,7 +19583,6 @@
 /area/rogue/indoors/town/manor)
 "gzi" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/candlestick/silver/lit{
@@ -20043,7 +20020,6 @@
 /area/rogue/indoors/town)
 "gGV" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -21191,7 +21167,6 @@
 /area/rogue/outdoors/beach/forest)
 "hay" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/candlestick/silver/lit{
@@ -22239,7 +22214,6 @@
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "hqU" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -23195,7 +23169,6 @@
 	layer = 2.81
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/structure/bars/passage/shutter{
@@ -25859,7 +25832,6 @@
 "iyc" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
@@ -26763,7 +26735,6 @@
 /area/rogue/indoors/town/manor)
 "iMR" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/skull/lit{
@@ -27007,7 +26978,6 @@
 /area/rogue/under/cave/dukecourt)
 "iQu" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -27101,7 +27071,6 @@
 /area/rogue/indoors/town/magician)
 "iSp" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/twig,
@@ -28413,7 +28382,6 @@
 	dir = 4
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/elfred{
@@ -29089,7 +29057,6 @@
 /area/rogue/indoors/town)
 "jAz" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
@@ -29516,7 +29483,6 @@
 /area/rogue/indoors/town)
 "jJa" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/clothing/ring/aalloy,
@@ -29621,7 +29587,6 @@
 	dir = 10
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/toy/cards/deck,
@@ -31286,7 +31251,6 @@
 /area/rogue/under/underdark)
 "koN" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
@@ -32229,7 +32193,6 @@
 	dir = 1
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/bucket,
@@ -32431,7 +32394,6 @@
 /area/rogue/outdoors/mountains/decap)
 "kHQ" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
@@ -32747,7 +32709,6 @@
 /area/rogue/indoors/town)
 "kOg" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
@@ -34159,7 +34120,6 @@
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/hexstone,
@@ -36690,7 +36650,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "meU" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/natural/clay/clayfancyvase,
@@ -36851,7 +36810,6 @@
 	pixel_y = 9
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/herringbone,
@@ -37250,7 +37208,6 @@
 /area/rogue/outdoors/rtfield)
 "mpo" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
@@ -38479,7 +38436,6 @@
 /area/rogue/under/cave/skeletoncrypt)
 "mLt" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/candlestick/silver/single/lit{
@@ -39159,7 +39115,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "mWR" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/greenstone,
@@ -40162,7 +40117,6 @@
 	pixel_y = 32
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/clothing/ring/duelist,
@@ -40383,7 +40337,6 @@
 /area/rogue/indoors)
 "npw" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/woodstaff,
@@ -40749,7 +40702,6 @@
 /area/rogue/indoors/town)
 "nxc" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/roguestatue/clay,
@@ -44615,7 +44567,6 @@
 /area/rogue/under/cave/licharena)
 "oOc" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
@@ -45777,7 +45728,6 @@
 /area/rogue/indoors/town)
 "phn" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/carpet/royalblack,
@@ -47080,7 +47030,6 @@
 /area/rogue/indoors/shelter/mountains/decap)
 "pEa" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter,
@@ -47799,7 +47748,6 @@
 /area/rogue/outdoors/beach)
 "pQu" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
@@ -47984,7 +47932,6 @@
 /area/rogue/under/cave/dragonden)
 "pTa" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
@@ -49112,7 +49059,6 @@
 /area/rogue/indoors/town/dwarfin)
 "qmd" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
@@ -49604,7 +49550,6 @@
 /area/rogue/indoors/town)
 "quQ" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -49758,7 +49703,6 @@
 "qxh" = (
 /obj/item/rogueweapon/hammer/wood,
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -50247,7 +50191,6 @@
 /area/rogue/indoors/town/manor)
 "qFm" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/gold/lit{
@@ -50687,7 +50630,6 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "qLM" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/blocks,
@@ -50822,7 +50764,6 @@
 /area/rogue/outdoors/town)
 "qOz" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/blocks,
@@ -51423,7 +51364,6 @@
 /area/rogue/indoors)
 "qZw" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/skull/lit{
@@ -54114,7 +54054,6 @@
 /area/rogue/indoors)
 "rUW" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/aalloymug,
@@ -54849,7 +54788,6 @@
 /area/rogue/indoors/town/garrison)
 "siS" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/torchholder/r,
@@ -54993,7 +54931,6 @@
 /area/rogue/indoors/town/vault)
 "skz" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/carpet/red,
@@ -56490,7 +56427,6 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "sKh" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/paper{
@@ -56605,7 +56541,6 @@
 "sLW" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -56756,7 +56691,6 @@
 	layer = 2.81
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/structure/bars/passage/shutter{
@@ -56778,7 +56712,6 @@
 	pixel_y = 9
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -57163,14 +57096,12 @@
 /area/rogue/indoors/town/tavern)
 "sUz" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
 "sUA" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/greenstone,
@@ -57866,7 +57797,6 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "tga" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/tablecloth/silk{
@@ -58142,7 +58072,6 @@
 /area/rogue/under/cave/dukecourt)
 "tlk" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/candlestick/gold/lit{
@@ -59144,7 +59073,6 @@
 /area/rogue/indoors/town/physician)
 "tBk" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -60094,7 +60022,6 @@
 /area/rogue/indoors/town/tavern)
 "tSs" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -61010,7 +60937,6 @@
 	dir = 4
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
@@ -61163,7 +61089,6 @@
 /area/rogue/outdoors/beach/forest)
 "ujN" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/grass,
@@ -62792,7 +62717,6 @@
 /area/rogue/under/cave/dukecourt)
 "uJb" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/mace/woodclub,
@@ -62883,7 +62807,6 @@
 "uKG" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -62988,7 +62911,6 @@
 /area/rogue/indoors/town/vault)
 "uMO" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/storage/roguebag{
@@ -63363,7 +63285,6 @@
 /area/rogue/outdoors/rtfield)
 "uSZ" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/candlestick/gold/lit{
@@ -64792,7 +64713,6 @@
 /area/rogue/under/cave/dungeon1/gethsmane)
 "vsl" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/grassred,
@@ -64832,7 +64752,6 @@
 /area/rogue/indoors/town/manor)
 "vti" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/blocks/green,
@@ -65603,7 +65522,6 @@
 /area/rogue/indoors/town/church/chapel)
 "vGe" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -65789,7 +65707,6 @@
 /area/rogue/outdoors/town/roofs/keep)
 "vJj" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -65848,7 +65765,6 @@
 /area/rogue/under/cave/goblinfort)
 "vJE" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/rogue/instrument/drum,
@@ -66038,7 +65954,6 @@
 /area/rogue/outdoors/beach/forest)
 "vMV" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
@@ -67096,7 +67011,6 @@
 /area/rogue/indoors/town/manor)
 "weX" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
@@ -70326,7 +70240,6 @@
 "xgl" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/candlestick/gold/lit{
@@ -71215,7 +71128,6 @@
 	icon_state = "cobbleedge-w"
 	},
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/millstone{
@@ -71557,7 +71469,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "xCR" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/cooking/pan,
@@ -72577,7 +72488,6 @@
 /area/rogue/under/town/sewer)
 "xTe" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/wallfire/candle/floorcandle,
@@ -72628,7 +72538,6 @@
 /area/rogue/indoors/shelter)
 "xUM" = (
 /obj/structure/table/wood{
-	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -40,8 +40,7 @@
 /area/rogue/under/cavewet)
 "aak" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/roguekey/roomv{
 	name = "town house key";
@@ -3022,8 +3021,7 @@
 /area/rogue/indoors/town/shop)
 "cmB" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
@@ -3769,8 +3767,7 @@
 /area/rogue/outdoors/rtfield)
 "cWG" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -4984,8 +4981,7 @@
 /area/rogue/indoors/town/shop)
 "ejL" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "wooden_floort"
@@ -5005,8 +5001,7 @@
 /area/rogue/outdoors/town)
 "elk" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/ruinedwood{
@@ -6730,8 +6725,7 @@
 /area/rogue/indoors/town/shop)
 "gjf" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/book/rogue/playerbook,
 /obj/item/natural/feather,
@@ -8202,8 +8196,7 @@
 /area/rogue/under/town/basement)
 "hCS" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -9239,8 +9232,7 @@
 	pixel_y = 16
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
@@ -11771,8 +11763,7 @@
 /area/rogue/under/cavewet/bogcaves)
 "lFe" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/woodturned,
@@ -12171,8 +12162,7 @@
 "mdz" = (
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
@@ -14008,8 +13998,7 @@
 /area/rogue/outdoors/bog)
 "oiT" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
@@ -14340,8 +14329,7 @@
 /area/rogue/indoors)
 "oAC" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
 /obj/item/reagent_containers/glass/cup/steel,
@@ -15658,8 +15646,7 @@
 /area/rogue/indoors/town/garrison)
 "qaQ" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/rogue/instrument/flute,
 /turf/open/floor/rogue/ruinedwood,
@@ -15698,8 +15685,7 @@
 /area/rogue/outdoors/mountains)
 "qdB" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/flint{
 	pixel_x = -1
@@ -16599,8 +16585,7 @@
 /area/rogue/indoors)
 "reX" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/natural/feather,
 /obj/item/candle/yellow,
@@ -18208,8 +18193,7 @@
 /area/rogue/indoors/town/church/chapel)
 "sUe" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/clothing/under/roguetown/loincloth,
 /obj/item/clothing/under/roguetown/loincloth,
@@ -18635,8 +18619,7 @@
 /area/rogue/indoors/town/manor)
 "tnu" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/paper,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -18775,8 +18758,7 @@
 /area/rogue/indoors/town/manor)
 "twA" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -19473,8 +19455,7 @@
 /area/rogue/indoors/town/shop)
 "umw" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood,
@@ -19526,8 +19507,7 @@
 /area/rogue/indoors/town/manor)
 "uoX" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/natural/feather,
 /obj/item/candle/yellow,
@@ -19540,8 +19520,7 @@
 /area/rogue/indoors)
 "upY" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/cooking/pan,
 /obj/item/reagent_containers/powder/flour,
@@ -19782,8 +19761,7 @@
 /area/rogue/under/town/sewer)
 "uAZ" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20144,8 +20122,7 @@
 /area/rogue/indoors/town/garrison)
 "uUc" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/tile,
@@ -22632,8 +22609,7 @@
 /area/rogue/indoors)
 "xCG" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/paper,
 /obj/item/paper,
@@ -22719,8 +22695,7 @@
 "xEl" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
@@ -22906,8 +22881,7 @@
 /area/rogue/indoors/town/garrison)
 "xMM" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/toy/cards/deck,
 /turf/open/floor/rogue/wood,
@@ -23128,8 +23102,7 @@
 /area/rogue/indoors/town/manor)
 "ybh" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)

--- a/_maps/map_files/templates/sewers/sewers_topleft_3.dmm
+++ b/_maps/map_files/templates/sewers/sewers_topleft_3.dmm
@@ -30,8 +30,7 @@
 /area/rogue/under/town/sewer)
 "f" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	icon_state = "tablewood1"
 	},
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,


### PR DESCRIPTION
## About The Pull Request

There are a ton of dir overrides for woodentable1, which is not a directional icon. This removes said overrides

I have tested this briefly, but would recommend a testmerge

This is simply a mass replacement of `	dir = 1;\n	icon_state = "tablewood1"` and `	icon_state = "tablewood1";\n	dir = 1` with just 	`icon_state = "tablewood1"`