### PR TITLE
Step_Action() Runtime Squishing

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -323,7 +323,7 @@
 #define COMSIG_ITEM_WEARERCROSSED "wearer_crossed"                //called on item when crossed by something (): (/atom/movable, mob/living/crossed)
 
 // /obj/item/clothing signals
-#define COMSIG_CLOTHING_STEP_ACTION "clothing_step_action"			//from base of obj/item/clothing/shoes/proc/step_action(): ()
+#define COMSIG_CLOTHING_STEP_ACTION "clothing_step_action"			//from base of obj/item/proc/step_action(): ()
 
 // /obj/item/rogueweapon signals
 #define COMSIG_ROGUEWEAPON_OBJFIX "rogueweapon_fix"				//from base of obj/item/rogueweapon/obj_fix()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1458,3 +1458,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			str += "<b>Sewing</b> and a needle."
 		str = span_info(str)
 		. += str
+
+/obj/item/proc/step_action() //this was made to rewrite clown shoes squeaking, moved here to avoid throwing runtimes with non-/clothing wearables
+	SEND_SIGNAL(src, COMSIG_CLOTHING_STEP_ACTION)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -516,6 +516,3 @@ BLIND     // can't see anything
 		if(!user.incapacitated())
 			return 1
 	return 0
-
-/obj/item/clothing/proc/step_action() //this was made to rewrite clown shoes squeaking
-	SEND_SIGNAL(src, COMSIG_CLOTHING_STEP_ACTION)


### PR DESCRIPTION
## About The Pull Request

This fixes the runtime on step_action() calls caused by the weird inheritance we have with item/storage being wearable despite not being in item/clothing, forgor this bug existed when I fixed up the port, soh, now it's proper fixed.

## Testing Evidence

<img width="901" height="522" alt="Screenshot 2025-07-29 143209" src="https://github.com/user-attachments/assets/0f881fbf-99f8-401d-b6b6-b4b7340dbe0a" />
<img width="838" height="502" alt="Screenshot 2025-07-29 143301" src="https://github.com/user-attachments/assets/b8b910cc-6305-4b6a-ab8f-0f73b17ea8ff" />
<img width="1186" height="475" alt="Screenshot 2025-07-29 143350" src="https://github.com/user-attachments/assets/2b0e068e-91b6-4f43-a2e1-c573d3b7150c" />


## Why It's Good For The Game

Runtimes bad. Runtime fixing good.
