### PR TITLE
Buffs werewolf claw

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -167,11 +167,11 @@
 	icon = 'icons/roguetown/weapons/32.dmi'
 	max_blade_int = 900
 	max_integrity = 900
-	force = 25
+	force = 35
 	block_chance = 0
-	wdefense = 2
+	wdefense = 10
 	blade_dulling = DULLING_SHAFT_GRAND
-	armor_penetration = 15
+	armor_penetration = 30
 	associated_skill = /datum/skill/combat/unarmed
 	wlength = WLENGTH_NORMAL
 	wbalance = WBALANCE_HEAVY


### PR DESCRIPTION
With infection code gone they've had to adapt as lone wolves 
Old wolves were definitely on the weaker side imho, their defense/force/AP is really low, this buffs it.
These lonewolves are not ones you should want to 1v1
