### PR TITLE
[TM ONLY] The scom costs copper to use and is delayed

### DIFF
--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -443,10 +443,8 @@
 		to_chat(user, span_warning("I need to insert a copper coin into the scomstone first!"))
 		return
 	
-	// Check if user has noble trait for free sending
-	if(!HAS_TRAIT(user, TRAIT_NOBLE))
-		// Remove the coin since it was used
-		ready_to_send = FALSE
+	// Remove the coin since it was used
+	ready_to_send = FALSE
 	
 	var/usedcolor = user.voice_color
 	if(user.voicecolor_override)
@@ -947,10 +945,8 @@
 		to_chat(user, span_warning("I need to insert a copper coin into the garrison scomstone first!"))
 		return
 	
-	// Check if user has noble trait for free sending
-	if(!HAS_TRAIT(user, TRAIT_NOBLE))
-		// Remove the coin since it was used
-		ready_to_send = FALSE
+	// Remove the coin since it was used
+	ready_to_send = FALSE
 	
 	var/usedcolor = user.voice_color
 	if(user.voicecolor_override)


### PR DESCRIPTION
<img width="872" height="234" alt="image" src="https://github.com/user-attachments/assets/81a0b0a0-9689-420c-98d9-149b44908e64" />

Each scom message now costs one (1) copper.
There is a delay of 30 seconds from you sending the message to it being broadcast. 
This is so an antag can murder you if you snitch without the entire town descending on your location.

You ready a scom for use by inserting coin:
<img width="932" height="319" alt="image" src="https://github.com/user-attachments/assets/d8dbf4f5-ee33-437d-a2b9-037a84de4178" />
<img width="943" height="383" alt="image" src="https://github.com/user-attachments/assets/30a67c9b-baea-4b47-9c42-cf227010384b" />

This is a very big change and there may be a few bugs I did not catch in testing, please TM.