### PR TITLE
Removes lux from the bandit idol

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -965,7 +965,6 @@
 		/obj/item/kitchen/spoon/silver,
 		/obj/item/candle/candlestick/gold,
 		/obj/item/candle/candlestick/silver,
-		/obj/item/reagent_containers/lux,
 		/obj/item/rogueweapon/sword/long/judgement, // various unique weapons around from a few roles follows. Don't lose your fancy toys.... 
 		/obj/item/rogueweapon/sword/long/oathkeeper,
 		/obj/item/rogueweapon/woodstaff/riddle_of_steel/magos, //bit dumb for a bandit mage to toss this toy away but whatever


### PR DESCRIPTION
## About The Pull Request
I noticed a ongoing trend of alarmingly large amounts of lux harvested, Very few lux revivals, minimal bandit interactions or with the town hearing about them or otherwise and bandits doing VERY well in the round end stats. 

With this I have concluded some players are simply not allowed nice things. This removes Lux from the Idol. I'm rather sure but not confirmed outright they have just been farming it. Still something they could do either way and I've never seen a bandit steal lux once in all my time.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiles.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->


## Why It's Good For The Game
Bandits are simply not capable of having nice things. GO **fucking** rob people.

<img width="171" height="36" alt="TIvh7myyk5" src="https://github.com/user-attachments/assets/3ccb4bcb-b8cd-4f76-9c97-6749b7ceb886" />

<img width="152" height="32" alt="5qo3ZNC62O" src="https://github.com/user-attachments/assets/b74bb474-9b37-4f42-8730-b95013402409" />

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
