### PR TITLE
Increases all werewolf stats to 20 and gives dwielder

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -123,13 +123,13 @@
 	W.adjust_skillrank(/datum/skill/misc/climbing, 6, TRUE)
 	W.adjust_skillrank(/datum/skill/misc/swimming, 5, TRUE)
 	
-	W.STASTR = src.STASTR +5
-	W.STACON = src.STACON +5
-	W.STAEND = src.STAEND +5
-	W.STAINT = src.STAINT -3
-	W.STAPER = src.STAPER
-	W.STASPD = src.STASPD
-	W.STALUC = src.STALUC
+	W.STASTR = 20
+	W.STACON = 20
+	W.STAEND = 20
+	W.STAINT = 20
+	W.STAPER = 20
+	W.STASPD = 20
+	W.STALUC = 20
 
 
 	W.AddSpell(new /obj/effect/proc_holder/spell/self/howl/call_of_the_moon)
@@ -157,6 +157,7 @@
 	ADD_TRAIT(W, TRAIT_SPELLCOCKBLOCK, TRAIT_GENERIC)
 	ADD_TRAIT(W, TRAIT_LONGSTRIDER, TRAIT_GENERIC)
 	ADD_TRAIT(W, TRAIT_STRENGTH_UNCAPPED, TRAIT_GENERIC)
+	ADD_TRAIT(W, TRAIT_DUALWIELDER, TRAIT_GENERIC)
 
 	invisibility = oldinv
 


### PR DESCRIPTION
They were previously nerfed because of how quickly they snowballed with infections
With infection code likely to go, they should be buffed again 
This is so they're notably stronger than heretics in zizite armor who do not have daytime/silver vulnerabilities and do not lose stats (not being a werewolf/vampire is a +10 in all stats)