### PR TITLE
Confessor gets Inquisitor combat music.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -5,7 +5,7 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/confessor
 	category_tags = list(CTAG_INQUISITION)
-	cmode_music = 'sound/music/combat_rogue.ogg'
+	cmode_music = 'sound/music/inquisitorcombat.ogg'
 
 /datum/outfit/job/roguetown/confessor
 	job_bitflag = BITFLAG_CHURCH


### PR DESCRIPTION
## About The Pull Request

Gives Confessor the [Inquisitor combat music.](https://youtu.be/q5ODUgCCUcI) Confessor is a mini-Inquisitor, so they should get the same music. Adjudicator already follows this same logic. Confessor currently uses the rogue combat music. I guess because they're vaguely rogue-ish?

## Testing Evidence

<img width="456" height="77" alt="image" src="https://github.com/user-attachments/assets/c5796892-5707-4063-8ee0-16750727c11c" />

## Why It's Good For The Game

![Untitled](https://github.com/user-attachments/assets/6fc84219-d839-4092-bc5d-b7439b2b9abe)
