### PR TITLE
Peel can only apply stacks if armor inegrity is below 50%

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1361,6 +1361,13 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/peel_coverage(bodypart, divisor)
 	var/coveragezone = attackzone2coveragezone(bodypart)
 	if(!(body_parts_inherent & coveragezone))
+		// Check if armor integrity is below 50% before allowing peel stacks
+		if(max_integrity != 0)
+			var/int_percent = round(((obj_integrity / max_integrity) * 100), 1)
+			if(int_percent >= 50)
+				visible_message(span_info("The armor is too intact to peel effectively!"))
+				return
+		
 		if(!last_peeled_limb || coveragezone == last_peeled_limb)
 			if(divisor >= peel_threshold)
 				peel_count += divisor ? (peel_threshold / divisor ) : 1


### PR DESCRIPTION
I have really mixed feelings about peel. I like that it's a counter to heavy armor, that’s important to have. But it’s too effective imho. You shouldn’t be able to completely ruin high-end armor like darksteel in just a few atatcks. It makes heavy armor feel pointless. A better compromise would be requiring the armor to take a certain amount of damage first before peel can be attempted.

<img width="730" height="775" alt="image" src="https://github.com/user-attachments/assets/83a414db-14e0-413f-8624-f8dc990c63d9" />
<img width="634" height="662" alt="image" src="https://github.com/user-attachments/assets/3415bab3-c114-4e92-81d4-e9dc378583fd" />
