### PR TITLE
Removal of Killers Ice and Emberwine favour increase for Sawbones

### DIFF
--- a/code/modules/cargo/packsrogue/Sawbones.dm
+++ b/code/modules/cargo/packsrogue/Sawbones.dm
@@ -104,11 +104,6 @@
 	cost = 20
 	contains = list(/obj/item/bomb)
 
-/datum/supply_pack/rogue/Sawbones/poison
-	name = "High-Potency poison"
-	cost = 100
-	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/poison)
-
 /datum/supply_pack/rogue/Sawbones/trustworthyhat
 	name = "Trustworthy Hat"
 	cost = 5
@@ -196,6 +191,6 @@
 
 /datum/supply_pack/rogue/Sawbones/emberwine
 	name = "Emberwine"
-	cost = 10
+	cost = 100
 	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/emberwine)
 	


### PR DESCRIPTION
## About The Pull Request

Removes Killers Ice from sawbones and ups the cost for Emberwine to be at around 100 favour.

## Testing Evidence

<img width="504" height="117" alt="image" src="https://github.com/user-attachments/assets/4c68283b-d7f4-4723-affb-5fbb89d77d95" />


## Why It's Good For The Game

With how poisons currently work, I really don't believe that sawbones should be able to buy the most potent poison in the game, nor anyone for that matter. Having someone dip their dagger in killers ice, and then swinging at you procs the poison regardless of if you missed, or failed to pen your opponents armour.

As for Emberwine, sawbones shouldn't be able to buy a drug that decreases most of your stats for a measly 10 favour. 100 is reasonable, considering all the dungeon raiding bandits do these days.
