### PR TITLE
VerminFolk get same roles as WildKin

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -146,6 +146,7 @@
     /datum/species/lupian,\
     /datum/species/moth,\
     /datum/species/anthromorph,\
+    /datum/species/anthromorphsmall,\
     /datum/species/tabaxi,\
     /datum/species/lizardfolk,\
     /datum/species/dracon,\
@@ -155,7 +156,6 @@
 	/datum/species/halforc,\
 
 #define RACES_WIDELY_REVILED \
-    /datum/species/anthromorphsmall,\
     /datum/species/kobold,\
     /datum/species/goblinp,\
 


### PR DESCRIPTION
## About The Pull Request

Seen someone make some fair points so I pushed the PR, tested it so it shouldn't blow up the server. I edited the roguetown.dm file in _DEFINES to allow for VerminFolk to receive the same roles as their larger kin.

## Testing Evidence

<img width="1919" height="1079" alt="Test 1" src="https://github.com/user-attachments/assets/27696e4b-a913-4b46-bb5f-fa7f7cc43795" />
<img width="1919" height="1079" alt="Test 2" src="https://github.com/user-attachments/assets/97105d9c-99aa-4c14-93d3-199c06518d31" />
<img width="1919" height="1079" alt="Test 3" src="https://github.com/user-attachments/assets/a2e35c87-3511-4f68-9d8e-5ce81ee444e7" />


## Why It's Good For The Game

"Wildkin existing already makes the fact that vermin aren't tolerated in those roles very silly. We already have rat people in the garrison, we have rat people as priests, hell some of the zardmen have been even more ridiculous than some of the rats. As long as wildkin exists, they will be better rats than normal rats if you want to be multiple jobs. Also, verminvolk doesn't even necessarily mean rat people. It can be gnomes, bunnies like karmen, and other non-rat races. We had them as councilors and such before with little issue"
