### PR TITLE
Adds the requirement for Wretches to follow the Inhuman Gods

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -1,12 +1,13 @@
 // Wretch, soft antagonists. Giving them 9 points as stat (matching mercs) on average since they're a driving antagonist on AP or assistant antagonist. 
 /datum/job/roguetown/wretch
 	title = "Wretch"
-	flag = WRETCH
+	flag = WRETCH.
 	department_flag = PEASANTS
 	faction = "Station"
 	total_positions = 10
 	spawn_positions = 10
 	allowed_races = RACES_ALL_KINDS
+	allowed_patrons = ALL_INHUMEN_PATRONS
 	tutorial = "Somewhere in your lyfe, you fell to the wrong side of civilization. Hounded by the consequences of your actions, you now threaten the peace of those who still heed the authority that condemned you."
 	outfit = null
 	outfit_female = null

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -1,7 +1,7 @@
 // Wretch, soft antagonists. Giving them 9 points as stat (matching mercs) on average since they're a driving antagonist on AP or assistant antagonist. 
 /datum/job/roguetown/wretch
 	title = "Wretch"
-	flag = WRETCH.
+	flag = WRETCH
 	department_flag = PEASANTS
 	faction = "Station"
 	total_positions = 10


### PR DESCRIPTION
## About The Pull Request
Adds the requirement for Wretches to follow the inhuman gods. If they want the powers of a heretic, they have to actually **be** a heretic.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yes
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

This closes a loophole allowing non-inhuman worshipers access to the Zizo church. We've had far too many instances of people who would immediately upon spawning in - betray their fellow inhuman wretches because they don't follow Zizo, Graggar, Matthios, or Baotha. (Looking at you psydonites). 

Non-heretics already cannot have heresiarch. Wretches are meant to be heretics, 'nuff said. This also ends the Psydonic vampire meme (undead hating god, somehow tolerates undead servants) that people have used to frag constantly..

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
