### PR TITLE
Hedge Mage Revert

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/hedgemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/hedgemage.dm
@@ -6,7 +6,7 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/wretch/hedgemage
 	category_tags = list(CTAG_WRETCH)
-	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_OUTLANDER, TRAIT_MAGEARMOR, TRAIT_DODGEEXPERT, TRAIT_OUTLAW, TRAIT_ARCYNE_T3, TRAIT_HERESIARCH)
+	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_OUTLANDER, TRAIT_MAGEARMOR, TRAIT_OUTLAW, TRAIT_ARCYNE_T3, TRAIT_HERESIARCH)
 
 // Hedge Mage on purpose has nearly the same fit as a Adv Mage / Mage Associate who cast conjure armor roundstart. Call it meta disguise.
 /datum/outfit/job/roguetown/wretch/hedgemage/pre_equip(mob/living/carbon/human/H)
@@ -48,5 +48,5 @@
 	H.change_stat("speed", 1)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-	H?.mind.adjust_spellpoints(21)
+	H?.mind.adjust_spellpoints(27) // Unlike Rogue Mage, who gets 6 but DExpert, this one don't have DExpert but have more spell points than anyone but the CM.
 	wretch_select_bounty(H)


### PR DESCRIPTION
## About The Pull Request
Simply returns Hedge Mage to 27 spell points and removes dodge expert.
Why would you gut six spellpoints?
Dodge Expert doesn't help.
They don't have access to the hoardmaster.
The stat spread isn't nearly as impressive as rogue mage. There was no reason for the nerf to put them on par with rogue mage, but significantly worse. You already contend with people who stripmine the Wretch spawn roundstart and sprint off with everything. This is just making a potentially solo antag significantly more unbearable, and having played with it, that's my exact thought.

This was also done in a direct push. WHY? RAAAAAA!!!!!!!

## Testing Evidence
It's a number change and datum removal.
## Why It's Good For The Game
See above. Let me go back to running a nothing-but-buffs build. Thanks.