### PR TITLE
Comments out devitalized in matthios rite of armaments

### DIFF
--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -522,7 +522,7 @@ var/forgerites = list("Ritual of Blessed Reforgance")
 	spawn(20)
 		playsound(loc, 'sound/combat/hits/onmetal/grille (2).ogg', 50)
 		target.equipOutfit(/datum/outfit/job/roguetown/gildedrite)
-		target.apply_status_effect(/datum/status_effect/debuff/devitalised)
+		// target.apply_status_effect(/datum/status_effect/debuff/devitalised) // Removed: do not consume lux
 		spawn(40)
 			to_chat(target, span_cult("More to the maw, this shall help feed our greed."))
 


### PR DESCRIPTION
## About The Pull Request

Comments out the devitalized status effect for rite of armaments.

## Testing Evidence

It's a one sentence change.

## Why It's Good For The Game

Neither Zizo or Graggar has this for their version of rite of armaments so this change brings Matthios in line.
Heretics making excitement is always a good thing, rather than doing their rite and hiding for 15 minutes.