### PR TITLE
aasimar knights

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -130,7 +130,6 @@
     /datum/species/human/halfelf,\
     /datum/species/demihuman,\
     /datum/species/dwarf/mountain,\
-	/datum/species/aasimar,\
 
 #define RACES_CHURCH_FAVORED \
 	/datum/species/aasimar,\

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -6,7 +6,7 @@
 	faction = "Station"
 	total_positions = 3
 	spawn_positions = 3
-	allowed_races = RACES_NOBILITY_ELIGIBLE_UP
+	allowed_races = RACES_CHURCH_FAVORED_UP
 	allowed_patrons = NON_PSYDON_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)


### PR DESCRIPTION
## About The Pull Request

Knight's racelock tag changed from
'RACES_NOBILITY_ELIGIBLE_UP'
to
'RACES_CHURCH_FAVORED_UP'
which allows aasimar to play as knights

## Testing Evidence

TBA

## Why It's Good For The Game

Aasimar are holy, revered, and several other words that mean liked. Would a squire never become a knight because they were an aasimar? Obviously not, they're aasimar. They also can already be steward and councillor, which are... nobles.