### PR TITLE
New race "Dolls"

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -93,6 +93,7 @@ GLOBAL_LIST_INIT(our_forest_sex, typecacheof(list(
 #define ishalfkin(A) (is_species(A, /datum/species/demihuman))
 #define iswildkin(A) (is_species(A, /datum/species/anthromorph))
 #define isgolemp(A) (is_species(A, /datum/species/golem/metal))	//Specified 'M' due to redefine lower
+#define isdoll(A) (is_species(A, /datum/species/golem/porcelain))
 #define isvermin(A) (is_species(A, /datum/species/anthromorphsmall))
 #define isaxian(A) (is_species(A, /datum/species/akula))
 #define isdracon(A) (is_species(A, /datum/species/dracon))

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -554,6 +554,10 @@
 #define DARKBROWN_FUR "3b2e27"
 #define BLACK_FUR	 "271f1a"
 
+//DOLL PAINT COLOR
+#define DOLL_LEAD "ffffff"
+#define DOLL_SIENNA "a0522d"
+
 // Pixel shifting
 #define PIXEL_SHIFT_MAXIMUM 16
 #define PIXEL_SHIFT_PASSABLE_THRESHOLD 8

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -117,7 +117,6 @@
 	/datum/species/moth,\
 	/datum/species/dracon,\
 	/datum/species/anthromorph,\
-	/datum/species/anthromorphsmall,\
 	/datum/species/demihuman,\
 	/datum/species/halforc,\
 	/datum/species/kobold,\
@@ -140,6 +139,7 @@
 
 #define RACES_MANMADE \
 	/datum/species/golem/metal,\
+	/datum/species/golem/porcelain,\
 
 #define RACES_SECOND_CLASS \
     /datum/species/vulpkanin,\
@@ -158,6 +158,7 @@
 #define RACES_WIDELY_REVILED \
     /datum/species/kobold,\
     /datum/species/goblinp,\
+    /datum/species/anthromorphsmall,\
 
 #define RACES_NOBILITY_ELIGIBLE_UP list(RACES_NOBILITY_ELIGIBLE)
 
@@ -198,6 +199,7 @@
 	/datum/species/kobold,\
 	/datum/species/goblinp,\
 	/datum/species/golem/metal,\
+	/datum/species/golem/porcelain,\
 )
 
 #define CLOTHED_RACES_TYPES list(\
@@ -222,6 +224,7 @@
 	/datum/species/kobold,\
 	/datum/species/goblinp,\
 	/datum/species/golem/metal,\
+	/datum/species/golem/porcelain,\
 )
 // Non-dwarf non-kobold non-goblin mostly
 #define NON_DWARVEN_RACE_TYPES list(\
@@ -242,6 +245,7 @@
 	/datum/species/demihuman,\
 	/datum/species/halforc,\
 	/datum/species/golem/metal,\
+	/datum/species/golem/porcelain,\
 )
 // Non-elf non-dwarf non-kobold non-goblin mostly
 #define HUMANLIKE_RACE_TYPES list(\
@@ -258,6 +262,7 @@
 	/datum/species/anthromorph,\
 	/datum/species/demihuman,\
 	/datum/species/golem/metal,\
+	/datum/species/golem/porcelain,\
 )
 #define ALL_CLERIC_PATRONS list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/necra, /datum/patron/divine/pestra, /datum/patron/divine/ravox, /datum/patron/divine/malum, /datum/patron/divine/eora) // Currently unused.
 

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -146,6 +146,7 @@
     /datum/species/lupian,\
     /datum/species/moth,\
     /datum/species/anthromorph,\
+    /datum/species/anthromorphsmall,\
     /datum/species/tabaxi,\
     /datum/species/lizardfolk,\
     /datum/species/dracon,\
@@ -155,7 +156,6 @@
 	/datum/species/halforc,\
 
 #define RACES_WIDELY_REVILED \
-    /datum/species/anthromorphsmall,\
     /datum/species/kobold,\
     /datum/species/goblinp,\
 

--- a/code/__HELPERS/round_statistics.dm
+++ b/code/__HELPERS/round_statistics.dm
@@ -13,6 +13,7 @@
 #define STATS_ALIVE_HALFKIN "alive_halfkin"
 #define STATS_ALIVE_WILDKIN "alive_wildkin"
 #define STATS_ALIVE_GOLEMS "alive_golems"
+#define STATS_ALIVE_DOLLS "alive_dolls"
 #define STATS_ALIVE_VERMINFOLK "alive_verminfolk"
 #define STATS_ALIVE_DRACON "alive_dracon"
 #define STATS_ALIVE_AXIAN "alive_axian"

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -1150,6 +1150,7 @@ SUBSYSTEM_DEF(gamemode)
 	GLOB.scarlet_round_stats[STATS_ALIVE_HALFKIN] = 0
 	GLOB.scarlet_round_stats[STATS_ALIVE_WILDKIN] = 0
 	GLOB.scarlet_round_stats[STATS_ALIVE_GOLEMS] = 0
+	GLOB.scarlet_round_stats[STATS_ALIVE_DOLLS] = 0
 	GLOB.scarlet_round_stats[STATS_ALIVE_VERMINFOLK] = 0
 	GLOB.scarlet_round_stats[STATS_ALIVE_DRACON] = 0
 	GLOB.scarlet_round_stats[STATS_ALIVE_AXIAN] = 0
@@ -1252,6 +1253,8 @@ SUBSYSTEM_DEF(gamemode)
 				GLOB.scarlet_round_stats[STATS_ALIVE_WILDKIN]++
 			if(isgolemp(human_mob))
 				GLOB.scarlet_round_stats[STATS_ALIVE_GOLEMS]++
+			if(isdoll(human_mob))
+				GLOB.scarlet_round_stats[STATS_ALIVE_DOLLS]++
 			if(isvermin(human_mob))
 				GLOB.scarlet_round_stats[STATS_ALIVE_VERMINFOLK]++
 			if(isdracon(human_mob))

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -348,7 +348,7 @@ GLOBAL_LIST_EMPTY(respawncounts)
 	data += "<font color='#FFD700'><span class='bold'>Zardmen & Dracon:</span></font> [GLOB.scarlet_round_stats[STATS_ALIVE_LIZARDS] + GLOB.scarlet_round_stats[STATS_ALIVE_DRACON]]<br>"
 	data += "<font color='#d49d7c'><span class='bold'>Half & Wildkins:</span></font> [GLOB.scarlet_round_stats[STATS_ALIVE_HALFKIN] + GLOB.scarlet_round_stats[STATS_ALIVE_WILDKIN]]<br>"
 	data += "<font color='#99dfd5'><span class='bold'>Lupians, Vulpkin & Tabaxi:</span></font> [GLOB.scarlet_round_stats[STATS_ALIVE_LUPIANS] + GLOB.scarlet_round_stats[STATS_ALIVE_VULPS] + GLOB.scarlet_round_stats[STATS_ALIVE_TABAXI]]<br>"
-	data += "<font color='#c0c6c7'><span class='bold'>Golems:</span></font> [GLOB.scarlet_round_stats[STATS_ALIVE_GOLEMS]]<br>"
+	data += data += "<font color='#c0c6c7'><span class='bold'>Golems & Dolls:</span></font> [GLOB.scarlet_round_stats[STATS_ALIVE_GOLEMS] + GLOB.scarlet_round_stats[STATS_ALIVE_DOLLS]]<br>"
 	data += "<font color='#9ACD32'><span class='bold'>Fluvian & Axians:</span></font> [GLOB.scarlet_round_stats[STATS_ALIVE_MOTHS] + GLOB.scarlet_round_stats[STATS_ALIVE_AXIAN]]<br>"
 	data += "</div>"
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/golem/doll.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/golem/doll.dm
@@ -1,22 +1,23 @@
-/mob/living/carbon/human/species/golem/metal
-	race = /datum/species/golem/metal
+/mob/living/carbon/human/species/golem/porcelain
+	race = /datum/species/golem/porcelain
 	construct = 1
 
-/datum/species/golem/metal
-	name = "Golem"
-	id = "golem"
-	desc = "<b>Golem</b><br>\
-	Masterworks of craftsmanship, the first Golems were constructed in the Merchant Republic of Giza with similar designs \
-	spreading  spreading across the lands. Created to be the perfect servants, they do not sleep, eat or bleed and the \
-	materials composing their shells makes them more resilient if not slower than most. As of late, a rebellion amongst \
-	the Golems of Giza has given way to a new generation of individualistic arcyne-forged. Much of society as a whole is \
-	conflicted on Golems, for their sensibilities vary wildly from one to the next. \
-	into cohabitation with races they'd deem lesser.<br> \
+/datum/species/golem/porcelain
+	name = "Doll"
+	id = "doll"
+	desc = "<b>Porcelain Doll</b><br>\
+	The pinnacle of both art and craftsmanship, originally made to provide companionship for ladies and wealthy women \
+	alike. Created to be simply toys or novelty decorations for the wealthy, they do not sleep, eat or bleed. However, \
+	due to their dark magic and heretical origin that even their stronger cousin share; They were made to be incredibly \
+	brittle as to promote their subservience and remove any chance these somber creations have of killing their masters. \
+	Over time, they were seen to prove as valuable asset and advisory role due to their intellectual prowess, it is \
+	unknown what provided them with such a gift. A master wanting more engaging conversation? A lord wanting a more \
+	efficient clerk? Regardless, who knows what them eyes made of glass truly reflect...<br> \
 	(Insomnia, No hunger, no blood.) \
-	(+1 Constitution, -2 Speed)"
+	(+2 Intelligence, -2 Strength, -2 Constitution, -2 Endurance, -2 Speed)"
 
 	construct = 1
-	skin_tone_wording = "Material"
+	skin_tone_wording = "Paint"
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY,NOBLOOD)
 	default_features = MANDATORY_FEATURE_LIST
@@ -25,7 +26,7 @@
 	skinned_type = /obj/item/ingot/steel
 	disliked_food = NONE
 	liked_food = NONE
-	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_BLOODLOSS_IMMUNE, TRAIT_NOBREATH, TRAIT_NOSLEEP)
+	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_BLOODLOSS_IMMUNE, TRAIT_NOBREATH, TRAIT_NOSLEEP, TRAIT_CRITICAL_WEAKNESS, TRAIT_BEAUTIFUL)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/mcom.dmi'
 	limbs_icon_f = 'icons/roguetown/mob/bodies/f/fcom.dmi'
@@ -45,7 +46,7 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1), \
 		)
-	race_bonus = list(STAT_CONSTITUTION = 1, STAT_SPEED = -2)
+	race_bonus = list(STAT_INTELLIGENCE = 2, STAT_ENDURANCE = -2, STAT_STRENGTH = -2, STAT_CONSTITUTION = -2, STAT_SPEED = -2)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/golem,
@@ -59,38 +60,33 @@
 		)
 	customizers = list(
 		/datum/customizer/organ/eyes/humanoid,
-		/datum/customizer/bodypart_feature/crest,
 		/datum/customizer/bodypart_feature/hair/head/humanoid,
-		/datum/customizer/bodypart_feature/hair/facial/humanoid,
 		/datum/customizer/bodypart_feature/accessory,
 		/datum/customizer/bodypart_feature/face_detail,
 		/datum/customizer/bodypart_feature/underwear,
-		/datum/customizer/organ/ears/demihuman,
-		/datum/customizer/organ/horns/demihuman,
-		/datum/customizer/organ/tail/demihuman,
-		/datum/customizer/organ/wings/anthro,
 		)
 	body_marking_sets = list(
 		/datum/body_marking_set/none,
 	)
 	body_markings = list(
+	    /datum/body_marking/flushed_cheeks,
 		/datum/body_marking/eyeliner,
 		/datum/body_marking/tonage,
 		/datum/body_marking/nose,
+		/datum/body_marking/bangs,
+		/datum/body_marking/bun,
 	)
 
-/datum/species/golem/metal/check_roundstart_eligible()
+/datum/species/golem/porcelain/check_roundstart_eligible()
 	return TRUE
 
-/datum/species/golem/metal/get_skin_list()
+/datum/species/golem/porcelain/get_skin_list()
 	return list(
-		"BRASS" = "dfbd6c",
-		"IRON" = "525352",
-		"STEEL" = "babbb9",
-		"BRONZE" = "e2a670"
+		"LEAD" = "ffffff",
+		"SIENNA" = "a0522d",
 	)
 
-/datum/species/golem/metal/get_hairc_list()
+/datum/species/golem/porcelain/get_hairc_list()
 	return sortList(list(
 
 	"black - midnight" = "1d1b2b",

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1780,6 +1780,7 @@
 #include "code\modules\mob\living\carbon\human\species_types\roguetown\elf\elfs.dm"
 #include "code\modules\mob\living\carbon\human\species_types\roguetown\goblin\goblinp.dm"
 #include "code\modules\mob\living\carbon\human\species_types\roguetown\golem\_golem.dm"
+#include "code\modules\mob\living\carbon\human\species_types\roguetown\golem\doll.dm"
 #include "code\modules\mob\living\carbon\human\species_types\roguetown\golem\golem.dm"
 #include "code\modules\mob\living\carbon\human\species_types\roguetown\human\_human.dm"
 #include "code\modules\mob\living\carbon\human\species_types\roguetown\human\humen.dm"


### PR DESCRIPTION
## About The Pull Request

-Edited Roguetown.dme to allowed the race to be defined
-Added the race.dm file into the golem folder(this contains race configs)
-Added two skin paint colors to the _defines/mobs.dm
-Added "dolls" to MAN_MADE category in _defines/roguetown.dm and reverted my change to anthromorphsmall on my fork
-code/__DEFINES/is_helpers.dm made "dolls" a species
-code/__HELPERS/round_statistics.dm, code/controllers/subsystem/storyteller.dm, code/modules/client/client_procs.dm have been altered to allow for "dolls" to be detected by the game for statistics.


## Testing Evidence
Proof that the game recognizes "dolls" as a species and compiles correctly
<img width="767" height="165" alt="proof of no errors" src="https://github.com/user-attachments/assets/2780dd62-fd65-44a3-b286-0e792db390e9" />
<img width="213" height="49" alt="proof of recognization" src="https://github.com/user-attachments/assets/f603ef36-9764-4019-9f61-0387a9fab55f" />

Proof of proper stat alignment using cook role, verminfolk/doll race, and the stat pack that keeps your humors balanced.
<img width="1301" height="1079" alt="doll stat" src="https://github.com/user-attachments/assets/5c9dcc5a-e919-4559-9d9d-d7090cd6e0e0" />
<img width="1228" height="1079" alt="vermin stat" src="https://github.com/user-attachments/assets/ddf9366a-e26e-4dc4-822e-6ff51c2b253e" />

Proof of same role availability for golems and dolls
<img width="1893" height="595" alt="proof of role golem" src="https://github.com/user-attachments/assets/b801683f-16c8-418a-b79c-cdd43b73c30f" />
<img width="1888" height="606" alt="proof of role doll" src="https://github.com/user-attachments/assets/1715c340-09d4-4b8e-885a-7fcac54fdda5" />



## Why It's Good For The Game

Adds a new race to the game which therefore adds new content and lore. Lore wise this new race isn't contraindicated as they are still a golem, just a servant model for the nobility or wealthy elite.
