### PR TITLE
Maneater incorrect limbs delete fix

### DIFF
--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -81,12 +81,16 @@
 							limb = C.get_bodypart(zone)
 							if(limb)
 								playsound(src,'sound/misc/eat.ogg', rand(30,60), TRUE)
-								limb.dismember()
-								qdel(limb)
-								seednutrition += 20
-								if(C.mind) // eat only one limb of things with minds
-									maneater_spit_out(C)
+								if(limb.dismember())
+									limb.drop_limb()
+									qdel(limb)
+									seednutrition += 20
+									if(C.mind) // eat only one limb of things with minds
+										maneater_spit_out(C)
 									return
+								if(!limb.dismemberable) //gib goblins right away as they cant be dismembered, meaning they will be stuck in infinit loop of being snatched and not dismembered
+									C.gib()
+									seednutrition += 50
 								return
 						if(C.mind) // nugget case, just spit them out
 							maneater_spit_out(C)
@@ -94,8 +98,9 @@
 						limb = C.get_bodypart(BODY_ZONE_HEAD)
 						if(limb)
 							playsound(src,'sound/misc/eat.ogg', rand(30,60), TRUE)
-							limb.dismember()
-							qdel(limb)
+							if(limb.dismember())
+								limb.drop_limb()
+								qdel(limb)
 							return
 						limb = C.get_bodypart(BODY_ZONE_CHEST)
 						if(limb)


### PR DESCRIPTION
## About The Pull Request
Currently maneater will ALWAYS delete your limb even if it was protected or you cant be dismembered
This pr makes a proper check for dismember(), also taking in account that goblin npc cant be dismembered (we gib them right away)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I forgot to take screenshots but i made multiple tests with various possible ways for limb checks and removal ways and this one is the best
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
You will no longer loose your limb to maneater even if your armor protected you or you have TRAIT_NODISMEMBER
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
