### PR TITLE
Empowers Baotha rituals but gives them all shout invokes

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -208,6 +208,37 @@
 	owner.cmode_music = originalcmode
 	. = ..()
 
+/datum/status_effect/buff/divine_protection
+	id = "divine_protection"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/divine_protection
+	duration = 1 MINUTES
+
+/datum/status_effect/buff/divine_protection/on_apply()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_BLOODLOSS_IMMUNE, TRAIT_MIRACLE)
+	ADD_TRAIT(owner, TRAIT_STUNIMMUNE, TRAIT_MIRACLE)
+	ADD_TRAIT(owner, TRAIT_NODEATH, TRAIT_MIRACLE)
+	ADD_TRAIT(owner, TRAIT_INFINITE_STAMINA, TRAIT_MIRACLE)
+	ADD_TRAIT(owner, TRAIT_NOPAIN, TRAIT_MIRACLE)
+	ADD_TRAIT(owner, TRAIT_NOPAINSTUN, TRAIT_MIRACLE)
+
+/datum/status_effect/buff/divine_protection/on_remove()
+	REMOVE_TRAIT(owner, TRAIT_BLOODLOSS_IMMUNE, TRAIT_MIRACLE)
+	REMOVE_TRAIT(owner, TRAIT_STUNIMMUNE, TRAIT_MIRACLE)
+	REMOVE_TRAIT(owner, TRAIT_NODEATH, TRAIT_MIRACLE)
+	REMOVE_TRAIT(owner, TRAIT_INFINITE_STAMINA, TRAIT_MIRACLE)
+	REMOVE_TRAIT(owner, TRAIT_NOPAIN, TRAIT_MIRACLE)
+	REMOVE_TRAIT(owner, TRAIT_NOPAINSTUN, TRAIT_MIRACLE)
+	
+	
+	to_chat(owner, span_warning("Baotha's divine protection fades away... I am vulnerable once more."))
+	. = ..()
+
+/atom/movable/screen/alert/status_effect/buff/divine_protection
+	name = "Divine Protection"
+	desc = "Baotha's grace protects me from all harm."
+	icon_state = "divine_protection"
+
 /datum/status_effect/buff/weed
 	id = "weed"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/weed


### PR DESCRIPTION
.

## About The Pull Request

Baotha’s miracles have long offered little more than flavor. This proposed revision serves two purposes: First, to make the miracle set meaningful, given that Baothan clerics are valids unlike Ten clerics. Second, to prevent them from hiding too easily.

The changes significantly enhance the impact of Baotha’s miracles, but balance this power by requiring them to be invoked aloud, as shouts. 


-Baotha's blessing now heals fatigue and nourishes you. Nothing too crazy.
-Enrapturing powder applies emberwine and drunk walking for a few seconds.
-Painkiller is where it gets wacky. No fatigue, no death and no pain is applied for a minute. This means the only way you can die is with a beheading. To be subdued you have to be crit into submission.



## Testing Evidence

<img width="927" height="369" alt="image" src="https://github.com/user-attachments/assets/605e507f-ad4c-46ca-b39e-e481aa859317" />
<img width="955" height="1069" alt="image" src="https://github.com/user-attachments/assets/b5301bab-35d0-437d-a6bc-fa80f29a1471" />
<img width="2241" height="1433" alt="image" src="https://github.com/user-attachments/assets/881e6fee-b96c-4ef2-bca8-a2bd53f7474b" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/5da58abe-21cd-4778-8d9d-004b35b5f15b" />

## Why It's Good For The Game

Baotha's a cool concept. It’d be awesome to see more solid representation for her, something that actually holds up mechanically that isn't just flavor.
