### PR TITLE
zombie voicepack added to rotcured virtue

### DIFF
--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -154,6 +154,7 @@
 	custom_text = "Colors your body a distinct, sickly green."
 	// below is functionally equivalent to dying and being resurrected via astrata T4 - yep, this is what it gives you.
 	added_traits = list(TRAIT_EASYDISMEMBER, TRAIT_NOPAIN, TRAIT_NOPAINSTUN, TRAIT_NOBREATH, TRAIT_TOXIMMUNE, TRAIT_ZOMBIE_IMMUNE, TRAIT_ROTMAN)
+	H.dna.species.soundpack_m = new /datum/voicepack/other/zombie()
 
 /datum/virtue/combat/rotcured/apply_to_human(mob/living/carbon/human/recipient)
 	recipient.update_body() // applies the rot skin tone stuff


### PR DESCRIPTION
## About The Pull Request

Adds the zombie voicepack to the rotcured virtue

## Testing Evidence

TBA

## Why It's Good For The Game

it's good for the game because it adds more uniqueness to the rotcured virtue. The zombie virtue is now more zombielike and unique.