### PR TITLE
*READY* COMBAT MUSIC OVERRIDE (Prefs + Options Verb)

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -68,9 +68,14 @@
 		var/datum/loadout_item/loadout_item = new path()
 		GLOB.loadout_items[path] = loadout_item
 
+	// Combat Music Overrides
 	for (var/path in subtypesof(/datum/combat_music))
 		var/datum/combat_music/combat_music = new path()
-		GLOB.cmode_tracks_list[path] = combat_music
+		GLOB.cmode_tracks_by_type[path] = combat_music
+
+	for (var/path in GLOB.cmode_tracks_by_type)
+		var/datum/combat_music/trackref = GLOB.cmode_tracks_by_type[path]
+		cmode_track_to_namelist(trackref)
 
 //creates every subtype of prototype (excluding prototype) and adds it to list L.
 //if no list/L is provided, one is created.

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -68,6 +68,10 @@
 		var/datum/loadout_item/loadout_item = new path()
 		GLOB.loadout_items[path] = loadout_item
 
+	for (var/path in subtypesof(/datum/combat_music))
+		var/datum/combat_music/combat_music = new path()
+		GLOB.cmode_tracks_list[path] = combat_music
+
 //creates every subtype of prototype (excluding prototype) and adds it to list L.
 //if no list/L is provided, one is created.
 /proc/init_subtypes(prototype, list/L)

--- a/code/datums/combat_music.dm
+++ b/code/datums/combat_music.dm
@@ -1,0 +1,494 @@
+/*
+	Combat Mode Music Track Datums
+	---
+	Currently only used for overriding the default combat music that comes with your job or antagonist.
+	As of writing they are never directly applied to mobs themselves, only the name and musicpath are.
+	Deleting these datums or renaming subtypes will not break preferences; invalid saves get redirected to /default.
+	When adding new songs, add a shortname around ~12 characters for the game preferences menu.
+	
+	IMPORTANT! Be careful about adding songs to this list that aren't used anywhere else, lest you needlessly inflate the RSC.
+*/
+
+GLOBAL_LIST_EMPTY(cmode_tracks_list)
+
+/datum/combat_music
+	var/name = "An Error"
+	var/desc = "You should not be seeing this."
+	var/shortname
+	var/credits
+	var/musicpath = list()
+
+/datum/combat_music/default
+	name = "Default"
+	desc = "I let my current status sing for itself; its song will change dynamically."
+	shortname = "Default"
+	musicpath = list()
+
+/datum/combat_music/adjudicator
+	name = "Adjudicator"
+	desc = ""
+	shortname = "Adjudicator"
+	credits = "Chivalry 2 OST: Duty and Honor II (with Ryan Patrick Buckley)"
+	musicpath = list('sound/music/templarofpsydonia.ogg')
+
+/datum/combat_music/ascended
+	name = "Ascended"
+	desc = "No mortal could ever comprehend the heights to which I've risen."
+	shortname = "Ascended"
+	credits = "TO PIERCE THE BLACK SKY /// ENVY INTERLUDE - UNFORTUNATE DEVELOPMENT"
+	musicpath = list('sound/music/combat_ascended.ogg')
+
+/datum/combat_music/astratan_zeal
+	name = "Astratan Zeal"
+	desc = ""
+	shortname = "Astratan"
+	credits = "Jesper Kyd - Light of the Imperium"
+	musicpath = list('sound/music/combat_holy.ogg')
+
+/datum/combat_music/bandit_soldier
+	name = "Bandit - Soldier"
+	desc = "Noble swine, they've found us! Dispatch them!"
+	shortname = "Bandit Sold."
+	credits = "Deus Ex - Battery Park Combat"
+	musicpath = list('sound/music/combat_bandit.ogg')
+
+/datum/combat_music/bandit_rogue
+	name = "Bandit - Rogue"
+	desc = "Your visors and plates are no match for the tip of my blade. Approach me!"
+	shortname = "Bandit Rogue"
+	credits = "Evanora Unlimited - Mithlond (Instrumental)"
+	musicpath = list('sound/music/combat_bandit2.ogg')
+
+/datum/combat_music/bandit_brigand
+	name = "Bandit - Brute"
+	desc = "I don't care if I'm one against five. They're not breaking through."
+	shortname = "Bandit Brut."
+	credits = "Silent Scream - Lateralis"
+	musicpath = list('sound/music/combat_bandit_brigand.ogg')
+
+// Bandit Rogue Mage track can be found down at /mage since it's generic.
+
+/datum/combat_music/barbarian
+	name = "Barbarian"
+	desc = ""
+	shortname = "Barbarian"
+	musicpath = list('sound/music/combat_gronn.ogg')
+
+/datum/combat_music/bard
+	name = "Bard"
+	desc = ""
+	shortname = "Bard"
+	musicpath = list('sound/music/combat_bard.ogg')
+
+/datum/combat_music/berserker
+	name = "Berserker"
+	desc = ""
+	shortname = "Berserker"
+	credits = "Mikolai Stroinski - Eyes of the Wolf"
+	musicpath = list('sound/music/combat_berserker.ogg')
+
+/datum/combat_music/blackoak
+	name = "Black Oak's Guardian"
+	desc = ""
+	shortname = "Black Oak"
+	musicpath = list('sound/music/combat_blackoak.ogg')
+
+/datum/combat_music/beggar
+	name = "Beggar"
+	desc = ""
+	shortname = "Beggar"
+	credits = "Pathologic (Classic) - Most Combat Theme"
+	musicpath = list('sound/music/combat_bum.ogg')
+
+/datum/combat_music/conddottiero
+	name = "Condottiero Guildsman"
+	desc = ""
+	shortname = "Condottiero"
+	musicpath = list('sound/music/combat_condottiero.ogg')
+
+/datum/combat_music/cultic
+	name = "Cultic Witchcraft"
+	desc = ""
+	shortname = "Cultic"
+	credits = "Igor Kornelyuk - Воланд (\"Voland\")"
+	musicpath = list('sound/music/combat_cult.ogg')
+
+/datum/combat_music/combat
+	name = "Combat Classic (Adventurer)"
+	desc = ""
+	shortname = "Combt Classic"
+	musicpath = list('sound/music/combat.ogg')
+
+/datum/combat_music/combat_old
+	name = "Combat Old (Town Elder)"
+	desc = ""
+	shortname = "Combt Old"
+	musicpath = list('sound/music/combat_old.ogg')
+
+/* Unused
+/datum/combat_music/combat_old_2
+	name = "Combat Old 2"
+	desc = ""
+	shortname = "Combat Old 2"
+	musicpath = list('sound/music/combat2.ogg')
+*/
+
+/datum/combat_music/deadite
+	name = "Deadite"
+	desc = ""
+	shortname = "Deadite"
+	musicpath = list('sound/music/combat_weird.ogg')
+
+/datum/combat_music/desertrider
+	name = "Desert Rider Mercenary"
+	desc = ""
+	shortname = "Desert Rider"
+	credits = "Two Fingers - You Ain't Down"
+	musicpath = list('sound/music/combat_desertrider.ogg')
+
+/datum/combat_music/druid
+	name = "Druid (Verewolf)"
+	desc = ""
+	shortname = "Druid"
+	credits = "The Witcher 3: Wild Hunt - Hunt or Be Hunted"
+	musicpath = list('sound/music/combat_druid.ogg')
+
+/datum/combat_music/duelist
+	name = "Duelist"
+	desc = ""
+	shortname = "Duelist"
+	credits = "Medieval Total War 2 OST: Spanish Battle Theme"
+	musicpath = list('sound/music/combat_duelist.ogg')
+
+/datum/combat_music/dungeoneer
+	name = "Dungeoneer"
+	desc = ""
+	shortname = "Dungeoneer"
+	credits = "T87-Sulfurhead - RATEATER (https://www.youtube.com/@T87-Sulfurhead)"
+	musicpath = list('sound/music/combat_dungeoneer.ogg')
+
+/datum/combat_music/dwarf
+	name = "Dwarven Grudgebearer"
+	desc = ""
+	shortname = "Dwarf"
+	musicpath = list('sound/music/combat_dwarf.ogg')
+
+/datum/combat_music/forlorn
+	name = "Forlorn Hope Mercenary"
+	desc = ""
+	shortname = "Forlorn Hope"
+	musicpath = list('sound/music/combat_blackstar.ogg')
+
+/datum/combat_music/grenzelhoft
+	name = "Grenzelhoft Mercenary"
+	desc = ""
+	shortname = "Grenzelhoft"
+	credits = "Helbrede - Sons of Tyr"
+	musicpath = list('sound/music/combat_grenzelhoft.ogg')
+
+/* Unused
+/datum/combat_music/guard_song_1
+	name = "Guard Song 1"
+	desc = ""
+	shortname = "Guard Song 1"
+	musicpath = list('sound/music/combat_bog.ogg')
+*/
+
+/* Unused
+/datum/combat_music/guard_song_2
+	name = "Guard Song 2"
+	desc = ""
+	shortname = "Guard Song 2"
+	credits = "Deus Ex The Conspiracy (PS2) / Deus Ex Revision - UNATCO HQ Combat Theme"
+	musicpath = list('sound/music/combat_guard_bog.ogg')
+*/
+
+/* Unused
+/datum/combat_music/guard_song_3
+	name = "Guard Song 3"
+	desc = ""
+	shortname = "Guard 3"
+	credits = "Deus Ex The Conspiracy (PS2) / Deus Ex Revision - UNATCO Combat Theme"
+	musicpath = list('sound/music/combat_guard3.ogg')
+*/
+
+/* Unused
+/datum/combat_music/guard_song_4
+	name = "Guard Song 4"
+	desc = ""
+	shortname = "Guard 4"
+	credits = "Deus Ex The Conspiracy (PS2) / Deus Ex Revision - NYC Combat Theme"
+	musicpath = list('sound/music/combat_guard4.ogg')
+*/
+
+/datum/combat_music/heretic_zizo
+	name = "Heretic - Zizo (Lich)"
+	desc = ""
+	shortname = "Zizo"
+	credits = "T87-Sulfurhead - DEMESNE (https://www.youtube.com/@T87-Sulfurhead)"
+	musicpath = list('sound/music/combat_heretic.ogg')
+
+/datum/combat_music/heretic_matthios
+	name = "Heretic - Matthios"
+	desc = ""
+	shortname = "Matthios"
+	credits = "T87-Sulfurhead - Amontillado (https://www.youtube.com/@T87-Sulfurhead)"
+	musicpath = list('sound/music/combat_matthios.ogg')
+
+/datum/combat_music/heretic_graggar
+	name = "Heretic - Graggar"
+	desc = ""
+	shortname = "Graggar"
+	credits = "T87-Sulfurhead - Black Powder (https://www.youtube.com/@T87-Sulfurhead)"
+	musicpath = list('sound/music/combat_graggar.ogg')
+
+/datum/combat_music/heretic_baotha
+	name = "Heretic - Baotha"
+	desc = ""
+	shortname = "Baotha"
+	credits = "T87-Sulfurhead - Love Within You (Rough Mix) (https://www.youtube.com/@T87-Sulfurhead)"
+	musicpath = list('sound/music/combat_baotha.ogg')
+
+/datum/combat_music/iconoclast
+	name = "Iconoclast"
+	desc = ""
+	shortname = "Iconoclast"
+	credits = "Valley of Judgement- Lateralis"
+	musicpath = list('sound/music/Iconoclast.ogg')
+
+/datum/combat_music/inquisitor
+	name = "Inquisitor (Monster Hunter/Spellbreaker)"
+	desc = ""
+	shortname = "Inquisitor"
+	credits = "Hellsing OST RAID Track 15: Survival on the Street of Insincerity"
+	musicpath = list('sound/music/inquisitorcombat.ogg')
+
+/datum/combat_music/inquis_ordinator
+	name = "Inquisitor - Ordinator"
+	desc = ""
+	shortname = "Ordinator"
+	musicpath = list('sound/music/combat_inqordinator.ogg')
+
+/datum/combat_music/jester
+	name = "Jester"
+	desc = ""
+	shortname = "Jester"
+	credits = "Alias Conrad Coldwood - Pepper Steak (OFF OST)"
+	musicpath = list('sound/music/combat_jester.ogg')
+
+/datum/combat_music/kazengite
+	name = "Kazengite"
+	desc = ""
+	shortname = "Kazengite"
+	musicpath = list('sound/music/combat_kazengite.ogg')
+
+/datum/combat_music/knight
+	name = "Knight (Noble)"
+	desc = ""
+	shortname = "Knight"
+	credits = "T87-Sulfurhead - Durandal (https://www.youtube.com/@T87-Sulfurhead)"
+	musicpath = list('sound/music/combat_knight.ogg')
+
+/datum/combat_music/man_at_arms
+	name = "Man at Arms (Sergeant)"
+	desc = ""
+	shortname = ""
+	credits = "T87-Sulfurhead - Ready or Not (https://www.youtube.com/@T87-Sulfurhead)"
+	musicpath = list('sound/music/combat_ManAtArms.ogg')
+
+/datum/combat_music/mage
+	name = "Magician (Rogue Mage)"
+	desc = ""
+	shortname = "Magician"
+	credits = "Timestopper Tactics - corru.works"
+	musicpath = list('sound/music/combat_bandit_mage.ogg')
+
+// Maniac code has this track uncommented so this is free. And tbh it should remain here. Banger.
+/datum/combat_music/maniac
+	name = "Maniac"
+	desc = ""
+	shortname = "Maniac"
+	credits = "Thomas Bangalter - Stress"
+	musicpath = list('sound/music/combat_maniac2.ogg')
+
+/* Unused
+/datum/combat_music/maniac_old
+	name = "Maniac (Old)"
+	desc = ""
+	shortname = "Maniac Old"
+	musicpath = list('sound/music/combat_maniac.ogg')
+*/
+
+/datum/combat_music/martyr
+	name = "Martyr"
+	desc = ""
+	shortname = "Martyr"
+	musicpath = list('sound/music/combat_martyrsafe.ogg')
+
+// The two Martyr Vengeance combat tracks are intentionally left out of this. Look how they're used.
+
+/datum/combat_music/noble
+	name = "Noble (Merchant/Freifechter)"
+	desc = ""
+	shortname = "Noble"
+	musicpath = list('sound/music/combat_noble.ogg')
+
+/datum/combat_music/ozium
+	name = "Ozium Abuse (loud!)"
+	desc = ""
+	shortname = "Ozium"
+	credits = "Light Club - FAHKEET"
+	musicpath = list('sound/music/combat_ozium.ogg')
+
+/datum/combat_music/physician
+	name = "Physician (Sawbones)"
+	desc = ""
+	shortname = "Physician"
+	credits = "Michael Anthony - Klaus Schwab Rap (Instrumental)"
+	musicpath = list('sound/music/combat_physician.ogg')
+
+/datum/combat_music/poacher
+	name = "Poacher Wretch"
+	desc = ""
+	shortname = "Poacher"
+	musicpath = list('sound/music/combat_poacher.ogg')
+
+/datum/combat_music/rogue
+	name = "Rogue (Veteran Scout)"
+	desc = ""
+	shortname = "Rogue"
+	musicpath = list('sound/music/combat_rogue.ogg')
+
+/datum/combat_music/routier
+	name = "Routier, Otavan"
+	desc = ""
+	shortname = "Rogue"
+	musicpath = list('sound/music/combat_routier.ogg')
+
+/datum/combat_music/shaman
+	name = "Shaman, Atgervi"
+	desc = ""
+	shortname = "Shaman"
+	credits = "Heilung - Elddansurin"
+	musicpath = list('sound/music/combat_shaman2.ogg')
+
+/* Unused
+/datum/combat_music/shaman_old
+	name = "Shaman, Atgervi (Old)"
+	desc = ""
+	shortname = "Shaman Old"
+	musicpath = list('sound/music/combat_shaman.ogg')
+*/
+
+/datum/combat_music/soilson
+	name = "Soilson"
+	desc = ""
+	shortname = "Soilson"
+	credits = "Jeremy Soule - TESIV Oblivion - Death Knell"
+	musicpath = list('sound/music/combat_soilson.ogg')
+
+/datum/combat_music/squire
+	name = "Squire"
+	desc = ""
+	shortname = "Squire"
+	credits = "Dragon's Dogma OST: Tense Combat"
+	musicpath = list('sound/music/combat_squire.ogg')
+
+/datum/combat_music/starsugar
+	name = "Starsugar Abuse (loud!)"
+	desc = ""
+	shortname = "Starsugar"
+	credits = "FEMTANYL - DOGMATICA"
+	musicpath = list('sound/music/combat_starsugar.ogg')
+
+/datum/combat_music/steppe
+	name = "Steppesman"
+	desc = ""
+	shortname = "Steppe"
+	credits = "Tatar Theme (Hellish Quart OST)"
+	musicpath = list('sound/music/combat_steppe.ogg')
+
+/datum/combat_music/towner
+	name = "Towner"
+	desc = ""
+	shortname = "Towner"
+	credits = "Jeremy Soule - TESIV Oblivion - Daedra in Flight"
+	musicpath = list('sound/music/combat_towner.ogg')
+
+/datum/combat_music/treasure_hunter
+	name = "Treasure Hunter"
+	desc = ""
+	shortname = "Treasure"
+	credits = "Henry Jackman - Cut To The Chase"
+	musicpath = list('sound/music/combat_treasurehunter.ogg')
+
+/datum/combat_music/varangian
+	name = "Varangian"
+	desc = ""
+	shortname = "Varangian"
+	musicpath = list('sound/music/combat_vagarian.ogg')
+
+/datum/combat_music/vampire
+	name = "Vampire"
+	desc = ""
+	shortname = "Vampire"
+	credits = "Filmmaker - Mystic Circles"
+	musicpath = list('sound/music/combat_vamp2.ogg')
+
+/* Unused
+/datum/combat_music/vampire_old
+	name = "Vampire (Old)"
+	desc = ""
+	shortname = "Vampire Old"
+	musicpath = list('sound/music/combat_vamp.ogg')
+*/
+
+/datum/combat_music/vaquero
+	name = "Vaquero (Cutpurse)"
+	desc = ""
+	shortname = "Vaquero"
+	musicpath = list('sound/music/combat_vaquero.ogg')
+
+/datum/combat_music/veteran
+	name = "Veteran"
+	desc = ""
+	shortname = "Veteran"
+	credits = "T87-Sulfurhead - Good Men Die Young (https://www.youtube.com/@T87-Sulfurhead)"
+	musicpath = list('sound/music/combat_veteran.ogg')
+
+/datum/combat_music/watchman
+	name = "Watchman (Bailiff)"
+	desc = ""
+	shortname = "Watchman"
+	credits = "Deus Ex The Conspiracy (PS2) / Deus Ex Revision - Hong Kong Canal Combat Theme"
+	musicpath = list('sound/music/combat_guard.ogg')
+
+/datum/combat_music/warden
+	name = "Warden"
+	desc = "At the end of the road, we meet again."
+	shortname = "Warden"
+	credits = "T87-Sulfurhead - Metamorphosis (https://www.youtube.com/@T87-Sulfurhead)"
+	musicpath = list('sound/music/combat_warden.ogg')
+
+/datum/combat_music/warscholar
+	name = "Warscholar, Naledi"
+	desc = ""
+	shortname = "Warscholar"
+	credits = "Butcher's Boulevard - Kristjan Thomas Haaristo"
+	musicpath = list('sound/music/warscholar.ogg')
+
+/* Unused. I love Filmmaker but this one ain't worth it.
+/datum/combat_music/werewolf_old
+	name = "Werewolf (Old)"
+	desc = ""
+	shortname = "Werewolf Old"
+	credits = "Filmmaker - Federal Bestiary"
+	musicpath = list('sound/music/combat_werewolf.ogg')
+*/
+
+/datum/combat_music/zybantine
+	name = "Zybantine Slavers"
+	desc = ""
+	shortname = "Zybantine"
+	credits = "Hakan Glante - Crusader Kings 3 Fate of Iberia OST - War \"Short\""
+	musicpath = list('sound/music/combat_zybantine.ogg')

--- a/code/datums/combat_music.dm
+++ b/code/datums/combat_music.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_EMPTY(cmode_tracks_list)
 	var/credits
 	var/musicpath = list()
 
+// Shit WILL break if you change /default's typepath. Don't do it.
 /datum/combat_music/default
 	name = "Default"
 	desc = "I let my current status sing for itself; its song will change dynamically."

--- a/code/datums/combat_music.dm
+++ b/code/datums/combat_music.dm
@@ -24,6 +24,7 @@ GLOBAL_LIST_EMPTY(cmode_tracks_by_name)
 		LAZYREMOVE(GLOB.cmode_tracks_by_type, track.type)
 		CRASH("CMODE MUSIC: type [track.type] has duplicate name \"[track.name]\"!")
 	GLOB.cmode_tracks_by_name[track.name] = track
+	return
 
 /datum/combat_music
 	var/name

--- a/code/datums/combat_music.dm
+++ b/code/datums/combat_music.dm
@@ -9,11 +9,25 @@
 	IMPORTANT! Be careful about adding songs to this list that aren't used anywhere else, lest you needlessly inflate the RSC.
 */
 
-GLOBAL_LIST_EMPTY(cmode_tracks_list)
+// Admins: please don't molest my lists. You can't add new types at runtime anyways. Kisses! - Zoktiik
+GLOBAL_LIST_EMPTY(cmode_tracks_by_type)
+GLOBAL_LIST_EMPTY(cmode_tracks_by_name)
+
+// People make mistakes. This should help catch when that happens.
+/proc/cmode_track_to_namelist(var/datum/combat_music/track)
+	if(!track)
+		return
+	if(!track.name)
+		LAZYREMOVE(GLOB.cmode_tracks_by_type, track.type)
+		CRASH("CMODE MUSIC: type [track.type] has no name!") 
+	if(GLOB.cmode_tracks_by_name[track.name])
+		LAZYREMOVE(GLOB.cmode_tracks_by_type, track.type)
+		CRASH("CMODE MUSIC: type [track.type] has duplicate name \"[track.name]\"!")
+	GLOB.cmode_tracks_by_name[track.name] = track
 
 /datum/combat_music
-	var/name = "An Error"
-	var/desc = "You should not be seeing this."
+	var/name
+	var/desc
 	var/shortname
 	var/credits
 	var/musicpath = list()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -505,6 +505,9 @@
 		GLOB.chosen_names -= M.real_name
 		LAZYREMOVE(GLOB.actors_list, M.mobid)
 		LAZYREMOVE(GLOB.roleplay_ads, M.mobid)
+		SSdroning.kill_droning(M.client)
+		SSdroning.kill_loop(M.client)
+		SSdroning.kill_rain(M.client)
 
 		var/mob/dead/new_player/NP = new()
 		NP.ckey = M.ckey

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -106,6 +106,8 @@
 	W.stored_language.copy_known_languages_from(src)
 	W.stored_skills = ensure_skills().known_skills.Copy()
 	W.stored_experience = ensure_skills().skill_experience.Copy()
+	W.cmode_music_override = cmode_music_override
+	W.cmode_music_override_name = cmode_music_override_name
 	mind.transfer_to(W)
 	skills?.known_skills = list()
 	skills?.skill_experience = list()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -151,7 +151,8 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/highlight_color = "#FF0000"
 	var/datum/charflaw/charflaw
 
-
+	var/datum/combat_music/combat_music
+	var/combat_music_helptext_shown = FALSE
 
 	var/crt = FALSE
 	var/grain = TRUE
@@ -395,6 +396,9 @@ GLOBAL_LIST_EMPTY(chosen_names)
 
 
 			dat += "<b>Dominance:</b> <a href='?_src_=prefs;preference=domhand'>[domhand == 1 ? "Left-handed" : "Right-handed"]</a><BR>"
+
+			var/musicname = (combat_music.shortname ? combat_music.shortname : combat_music.name)
+			dat += "<b>Combat Music:</b> <a href='?_src_=prefs;preference=combat_music;task=input'>[musicname || "FUCK!"]</a><BR>"
 
 /*
 			dat += "<br><br><b>Special Names:</b><BR>"
@@ -1563,6 +1567,28 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						to_chat(user, "Background: [selected_patron.desc]")
 						to_chat(user, "<font color='red'>Likely Worshippers: [selected_patron.worshippers]</font>")
 
+				if("combat_music") // if u change shit here look at /client/verb/combat_music() too
+					if(!combat_music_helptext_shown)
+						to_chat(user, span_notice("<span class='bold'>Combat Music Override</span>\n") + \
+						"Options other than \"Default\" override whatever the game dynamically sets for you, \
+						which is influenced by your job class, villain status, or certain events.\n\
+						You can change this later through \"Combat Mode Music\" in the Options tab.\"</span>")
+						combat_music_helptext_shown = TRUE
+					var/list/tracks_by_name = list()
+					for(var/path as anything in GLOB.cmode_tracks_list)
+						var/datum/combat_music/track = GLOB.cmode_tracks_list[path]
+						if(!track.name || tracks_by_name[track.name]) // containing damage from inevitable cockups
+							continue
+						tracks_by_name[track.name] = track
+					var/track_select = input(user, "Set a track to be your combat music.", "Combat Music", combat_music?.name) as null|anything in tracks_by_name
+					if(track_select)
+						combat_music = tracks_by_name[track_select]
+						to_chat(user, span_notice("Selected track: <b>[track_select]</b>."))
+						if(combat_music.desc)
+							to_chat(user, "<i>[combat_music.desc]</i>")
+						if(combat_music.credits)
+							to_chat(user, span_info("Song name: <b>[combat_music.credits]</b>"))
+
 				if("bdetail")
 					var/list/loly = list("Not yet.","Work in progress.","Don't click me.","Stop clicking this.","Nope.","Be patient.","Sooner or later.")
 					to_chat(user, "<font color='red'>[pick(loly)]</font>")
@@ -2430,6 +2456,8 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 	character.name = character.real_name
 
 	character.domhand = domhand
+	character.cmode_music_override = combat_music.musicpath
+	character.cmode_music_override_name = combat_music.name
 	character.highlight_color = highlight_color
 	character.nickname = nickname
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -151,6 +151,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/highlight_color = "#FF0000"
 	var/datum/charflaw/charflaw
 
+	var/static/default_cmusic_type = /datum/combat_music/default
 	var/datum/combat_music/combat_music
 	var/combat_music_helptext_shown = FALSE
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -220,6 +220,8 @@ GLOBAL_LIST_EMPTY(chosen_names)
 		charflaw = new charflaw()
 	if(!selected_patron)
 		selected_patron = GLOB.patronlist[default_patron]
+	if(!combat_music)
+		combat_music = GLOB.cmode_tracks_by_type[default_cmusic_type]
 	key_bindings = deepCopyList(GLOB.hotkey_keybinding_list_by_key) // give them default keybinds and update their movement keys
 	C.update_movement_keys()
 	if(!loaded_preferences_successfully)
@@ -1575,15 +1577,10 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						which is influenced by your job class, villain status, or certain events.\n\
 						You can change this later through \"Combat Mode Music\" in the Options tab.\"</span>")
 						combat_music_helptext_shown = TRUE
-					var/list/tracks_by_name = list()
-					for(var/path as anything in GLOB.cmode_tracks_list)
-						var/datum/combat_music/track = GLOB.cmode_tracks_list[path]
-						if(!track.name || tracks_by_name[track.name]) // containing damage from inevitable cockups
-							continue
-						tracks_by_name[track.name] = track
-					var/track_select = input(user, "Set a track to be your combat music.", "Combat Music", combat_music?.name) as null|anything in tracks_by_name
+					var/track_select = input(user, "Set a track to be your combat music.", "Combat Music", combat_music?.name)\
+											as null|anything in GLOB.cmode_tracks_by_name
 					if(track_select)
-						combat_music = tracks_by_name[track_select]
+						combat_music = GLOB.cmode_tracks_by_name[track_select]
 						to_chat(user, span_notice("Selected track: <b>[track_select]</b>."))
 						if(combat_music.desc)
 							to_chat(user, "<i>[combat_music.desc]</i>")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -427,6 +427,14 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if (preview_height)
 		preview_height = new preview_height()
 
+/datum/preferences/proc/_load_combat_music(S)
+	var/combat_music_type
+	S["combat_music"] >> combat_music_type
+	if (GLOB.cmode_tracks_list[combat_music_type])
+		combat_music = new combat_music_type()
+	else
+		combat_music = new /datum/combat_music/default()
+
 /datum/preferences/proc/_load_appearence(S)
 	S["real_name"]			>> real_name
 	S["gender"]				>> gender
@@ -492,6 +500,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	_load_loadout(S)
 	_load_loadout2(S)
 	_load_loadout3(S)
+
+	_load_combat_music(S)
 
 	if(!S["features["mcolor"]"] || S["features["mcolor"]"] == "#000")
 		WRITE_FILE(S["features["mcolor"]"]	, "#FFF")
@@ -717,6 +727,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["statpack"] , statpack.type)
 	WRITE_FILE(S["virtue"] , virtue.type)
 	WRITE_FILE(S["virtuetwo"], virtuetwo.type)
+	WRITE_FILE(S["combat_music"], combat_music.type)
 	WRITE_FILE(S["body_size"] , features["body_size"])
 	if(loadout)
 		WRITE_FILE(S["loadout"] , loadout.type)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -431,7 +431,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	var/combat_music_type
 	S["combat_music"] >> combat_music_type
 	if (GLOB.cmode_tracks_list[combat_music_type])
-		combat_music = new combat_music_type()
+		combat_music = GLOB.cmode_tracks_list[combat_music_type]
 	else
 		combat_music = new /datum/combat_music/default()
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -433,7 +433,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if (GLOB.cmode_tracks_list[combat_music_type])
 		combat_music = GLOB.cmode_tracks_list[combat_music_type]
 	else
-		combat_music = new /datum/combat_music/default()
+		combat_music = GLOB.cmode_tracks_list[default_cmusic_type]
 
 /datum/preferences/proc/_load_appearence(S)
 	S["real_name"]			>> real_name

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -430,10 +430,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 /datum/preferences/proc/_load_combat_music(S)
 	var/combat_music_type
 	S["combat_music"] >> combat_music_type
-	if (GLOB.cmode_tracks_list[combat_music_type])
-		combat_music = GLOB.cmode_tracks_list[combat_music_type]
+	if (GLOB.cmode_tracks_by_type[combat_music_type])
+		combat_music = GLOB.cmode_tracks_by_type[combat_music_type]
 	else
-		combat_music = GLOB.cmode_tracks_list[default_cmusic_type]
+		combat_music = GLOB.cmode_tracks_by_type[default_cmusic_type]
 
 /datum/preferences/proc/_load_appearence(S)
 	S["real_name"]			>> real_name

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -595,6 +595,47 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	else
 		to_chat(usr, "Running changed (turning)")
 
+/client/verb/combat_music() // if you touch this, touch the option in game preferences too
+	set name = "Combat Mode Music"
+	set category = "Options"
+	set desc = ""
+	if(!isliving(mob))
+		to_chat(src, span_warning("You're not alive yet. Set this in your Game Preferences instead."))
+		return
+	var/mob/living/L = mob
+	var/list/tracks_by_name = list()
+	for(var/path as anything in GLOB.cmode_tracks_list)
+		var/datum/combat_music/track = GLOB.cmode_tracks_list[path]
+		if(!track.name || tracks_by_name[track.name]) // containing damage from inevitable cockups
+			continue
+		tracks_by_name[track.name] = track
+	var/track_select = input(src, "Choose a combat music track to use TEMPORARILY.\n\
+									You can set this permanently in Game Preferences.\
+									", "Combat Music", L.cmode_music_override_name) as null|anything in tracks_by_name
+	if(track_select)
+		if(!isliving(mob)) // mob might've changed between then and now
+			return
+		L = mob
+		var/datum/combat_music/combat_music
+		combat_music = tracks_by_name[track_select]
+		to_chat(src, span_notice("Selected track: <b>[track_select]</b>."))
+		if(combat_music.desc)
+			to_chat(src, "<i>[combat_music.desc]</i>")
+		if(combat_music.credits)
+			to_chat(src, span_info("Song name: <b>[combat_music.credits]</b>"))
+		// also change it for Werewolf & Wildshape transformations, else it'd be annoying to keep changing this (lol)
+		var/mob/living/carbon/human/H
+		var/mob/living/S
+		if(ishuman(mob))
+			H = mob
+			if(isliving(H.stored_mob))
+				S = H.stored_mob
+		L.cmode_music_override = combat_music.musicpath
+		L.cmode_music_override_name = combat_music.name
+		if(S)
+			S.cmode_music_override = combat_music.musicpath
+			S.cmode_music_override_name = combat_music.name
+	return
 
 /client/verb/policy()
 	set name = "Show Policy"
@@ -609,6 +650,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	var/header = get_policy(POLICY_VERB_HEADER)
 	var/list/policytext = list(header,"<hr>")
 	var/anything = FALSE
+
 	for(var/keyword in keywords)
 		var/p = get_policy(keyword)
 		if(p)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -603,21 +603,16 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		to_chat(src, span_warning("You're not alive yet. Set this in your Game Preferences instead."))
 		return
 	var/mob/living/L = mob
-	var/list/tracks_by_name = list()
-	for(var/path as anything in GLOB.cmode_tracks_list)
-		var/datum/combat_music/track = GLOB.cmode_tracks_list[path]
-		if(!track.name || tracks_by_name[track.name]) // containing damage from inevitable cockups
-			continue
-		tracks_by_name[track.name] = track
 	var/track_select = input(src, "Choose a combat music track to use TEMPORARILY.\n\
 									You can set this permanently in Game Preferences.\
-									", "Combat Music", L.cmode_music_override_name) as null|anything in tracks_by_name
+									", "Combat Music", L.cmode_music_override_name)\
+									as null|anything in GLOB.cmode_tracks_by_name
 	if(track_select)
 		if(!isliving(mob)) // mob might've changed between then and now
 			return
 		L = mob
 		var/datum/combat_music/combat_music
-		combat_music = tracks_by_name[track_select]
+		combat_music = GLOB.cmode_tracks_by_name[track_select]
 		to_chat(src, span_notice("Selected track: <b>[track_select]</b>."))
 		if(combat_music.desc)
 			to_chat(src, "<i>[combat_music.desc]</i>")

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
@@ -35,6 +35,8 @@
 	W.stored_experience = ensure_skills().skill_experience.Copy()
 	W.stored_spells = mind.spell_list.Copy()
 	W.voice_color = voice_color
+	W.cmode_music_override = cmode_music_override
+	W.cmode_music_override_name = cmode_music_override_name
 	mind.transfer_to(W)
 	skills?.known_skills = list()
 	skills?.skill_experience = list()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -181,3 +181,6 @@
 	var/voice_pitch = 1
 
 	var/domhand = 0
+
+	var/cmode_music_override = list() // set by prefs or the verb, ignored if empty
+	var/cmode_music_override_name // solely for autoselecting as a spawned-in mob

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -581,7 +581,9 @@
 	else
 		cmode = TRUE
 		playsound_local(src, 'sound/misc/combon.ogg', 100)
-		if(L.cmode_music)
+		if(length(L.cmode_music_override))
+			SSdroning.play_combat_music(L.cmode_music_override, client)
+		else if(L.cmode_music)
 			SSdroning.play_combat_music(L.cmode_music, client)
 		if(client && HAS_TRAIT(src, TRAIT_SCHIZO_AMBIENCE))
 			animate(client, pixel_y = 1, time = 1, loop = -1, flags = ANIMATION_RELATIVE)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -395,6 +395,7 @@
 #include "code\datums\callback.dm"
 #include "code\datums\chatmessage.dm"
 #include "code\datums\cinematic.dm"
+#include "code\datums\combat_music.dm"
 #include "code\datums\datacore.dm"
 #include "code\datums\datum.dm"
 #include "code\datums\datumvars.dm"


### PR DESCRIPTION
## About The Pull Request
With huge thanks to Lukas/leggydog for motivation with this project.
- Allows you to set combat music in preferences (permanent, saves/loads) and from a verb (temporary to mob)
- Adds new `combat_music` singleton datums with metadata for each song. Just define a new one and it'll be added.
  - Don't make a datum for a song that's unpopular and otherwise unused. That will just make the RSC larger for no reason.
- Adds a new global list ~~`cmode_tracks_list`~~ `cmode_tracks_by_type` of these singleton datums. Typepath goes in, reference to the instance comes out.
- Persists the override through Verewolf and Wildshape transformations. Transforming copies your override to the new mob. Setting a new track while transformed will also set it for your original mob. The result is seamless transition.
- Admins can now simply just modify a living mob's `cmode_music_override` with varedit to get a similar, more consistent effect instead of `cmode_music` directly.
  - The tradeoff is that the plebs can now override your varedit using the verb.
  - You can't really add a new song to the list because you can't generate a new type out of thin air.
  - Enabling this (adminbus) is part of why I don't apply datum typepath or reference to the mobs.
- Unrelated: "Send to Lobby" in Admins' Player Panel now stops background music (for living mobs)

- **New:** Global list of tracks by name `cmode_tracks_by_name`, allowing us to use significantly less resources when selecting a track. Preferences and the verb both use this list now. The type-to-ref list is sticking around for loading saves.
- **New:** Error-checking proc. If you mess up with names when adding a track, or you use a duplicate name by accident, you get a free runtime error for your effort. Should help with maintaining the music list.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- I can set my track to anything in prefs or the verb, and my currently selected track will always autoselect in the list
- My override consistently plays pretty much no matter what lmao
- Transforming into a verewolf kept my override, turning back kept my override
- No runtimes aside from already existing werewolf runtimes lol
- Varediting the override allowed me to play whatever music I want
- Send to Lobby button properly terminated the background music 
<img width="578" height="168" alt="image" src="https://github.com/user-attachments/assets/01333476-3d9a-4417-a603-3132c4abdb93" />
<img width="302" height="240" alt="image" src="https://github.com/user-attachments/assets/5317d77b-1187-42fb-a932-f2546579ef0b" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It's nice to be able to pick your own music sometimes.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
