### PR TITLE
RETURN OF THE VOLF PIT but not really unless you build it - adds volfs, bears and horses as expensive import items

### DIFF
--- a/code/modules/roguetown/roguestock/import.dm
+++ b/code/modules/roguetown/roguestock/import.dm
@@ -170,6 +170,64 @@
 	. = ..()
 	new /mob/living/simple_animal/hostile/retaliate/rogue/saiga/saigabuck/tame/saddled(src)
 
+/datum/roguestock/import/volfcrate
+	name = "Volf Crate"
+	desc = "An angry, feral volf has been stuffed inside this crate. By the time it arrives, it'll likely be starving."
+	item_type = /obj/structure/closet/crate/chest/steward/volfcrate
+	export_price = 300
+	importexport_amt = 1
+
+/obj/structure/closet/crate/chest/steward/volfcrate/Initialize()
+	. = ..()
+	new /mob/living/simple_animal/hostile/retaliate/rogue/wolf(src)
+
+/datum/roguestock/import/bearcrate
+	name = "Direbear Crate"
+	desc = "A pack of lunatic fools claim to have crammed an entire, full-sized bear inside this crate. Their assurance is that it'll be angry."
+	item_type = /obj/structure/closet/crate/chest/steward/bearcrate
+	export_price = 1000
+	importexport_amt = 1
+
+/obj/structure/closet/crate/chest/steward/bearcrate/Initialize()
+	. = ..()
+	new /mob/living/simple_animal/hostile/retaliate/rogue/direbear(src)
+
+/datum/roguestock/import/horsecrate
+	name = "Horse Crate"
+	desc = "A strange and unfamiliar mount in the Scarlet Reach. Horses, unlike saigas, have uniquely uncloven, single-toed hooves."
+	item_type = /obj/structure/closet/crate/chest/steward/horsecrate
+	export_price = 500
+	importexport_amt = 1
+
+/obj/structure/closet/crate/chest/steward/horsecrate/Initialize()
+	. = ..()
+	switch(rand(1,3))
+		if(1)
+			new /mob/living/simple_animal/hostile/retaliate/rogue/horse/male/white/tame/saddled(src)
+		if(2)
+			new /mob/living/simple_animal/hostile/retaliate/rogue/horse/male/brown/tame/saddled(src)
+		if(3)
+			new /mob/living/simple_animal/hostile/retaliate/rogue/horse/male/black/tame/saddled(src)
+
+/datum/roguestock/import/ponycrate
+	name = "Miniature Pony Crate"
+	desc = "This novelty pony has been bred to be quaint of size, but more than makes up for it as a valiant steed."
+	item_type = /obj/structure/closet/crate/chest/steward/ponycrate
+	export_price = 1500
+	importexport_amt = 1
+
+/obj/structure/closet/crate/chest/steward/ponycrate/Initialize()
+	. = ..()
+	var/mob/living/simple_animal/hostile/retaliate/rogue/horse/male/pony
+	switch(rand(1,3))
+		if(1)
+			pony = new/mob/living/simple_animal/hostile/retaliate/rogue/horse/male/white/tame/saddled(src)
+		if(2)
+			pony = new/mob/living/simple_animal/hostile/retaliate/rogue/horse/male/brown/tame/saddled(src)
+		if(3)
+			pony = new/mob/living/simple_animal/hostile/retaliate/rogue/horse/male/black/tame/saddled(src)
+	pony.transform = pony.transform.Scale(0.7, 0.7)
+
 /datum/roguestock/import/cow
 	name = "Cow"
 	desc = "Farmer's best friend, reliable provider of milk and meat."


### PR DESCRIPTION
## About The Pull Request
Adds horses, direbears, volfs, and something special to the imports list.
Horses are just reskinned saigas without the slight delay on sprinting. Pretty much just a cute prestige mount.
All of the prices have been designed to be fairly high to prevent mass ordering them. If these are too low by any means, let me know. They're meant to be luxury things for fun.
Volfs - 300
Horse - 500
Direbear - 1000
By the way, there's some kind of glitch where injured mounts don't return to their previous speed once fully healed. It's not just horses. No, I don't know how to fix it.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![5678467846788](https://github.com/user-attachments/assets/d7ceb126-722d-41ea-b193-621799acde22)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
i asked santa for a pony one time and never got over not getting one
Also dukes should be able to make cool volf pits if they want them. And have an attack bear. And have it go terribly wrong.
These aren't all that dangerous mobs and if you have 1000s and 1000s of mammon, you should be enabled to spend it irresponsibly.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
