### PR TITLE
wicker cloak in the loadout

### DIFF
--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -205,6 +205,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Rapscallion's Shawl"
 	path = /obj/item/clothing/cloak/thief_cloak
 
+/datum/loadout_item/wicker_cloak
+	name = "Wicker Cloak"
+	path = /obj/item/clothing/cloak/wickercloak
+
 //SHOES
 /datum/loadout_item/darkboots
 	name = "Dark Boots"


### PR DESCRIPTION
## About The Pull Request

+ Adds wicker cloak to the loadout. That's it.

## Testing Evidence
<img width="368" height="369" alt="image" src="https://github.com/user-attachments/assets/0091dced-3dc1-4bf9-af27-e4e87a0be0c1" />
<img width="318" height="114" alt="Screenshot 2025-08-05 205237" src="https://github.com/user-attachments/assets/f811356c-f723-4a60-8aab-f121d72f5084" />


## Why It's Good For The Game
+ Genuinely do not know why it's not a part of the loadout. It has 0 storage and 0 armour rating. Price is... 1 mammon?
+ Pretty sprite
