### PR TITLE
Fixes HUD eye displaying incorrectly

### DIFF
--- a/code/__HELPERS/customization.dm
+++ b/code/__HELPERS/customization.dm
@@ -13,7 +13,7 @@
 /mob/living/carbon/human/proc/get_eye_color()
 	var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
 	if(!eyes)
-		return "FFFFFF"
+		return "#FFFFFF"
 	return eyes.eye_color
 
 /mob/living/carbon/human/proc/get_chest_color()

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -803,7 +803,7 @@
 			iris.icon_state = "oeye_fixed"
 		else
 			iris.icon_state = "oeye"
-	iris.color = "#" + human.eye_color
+	iris.color = human.get_eye_color()
 	. += iris
 
 /atom/movable/screen/eye_intent/proc/toggle(mob/user)


### PR DESCRIPTION
## About The Pull Request

Eye color on the HUD is properly adjusted to the player's selected eye color.

## Testing Evidence
<img width="214" height="175" alt="Screenshot 2025-08-05 112243" src="https://github.com/user-attachments/assets/f914ea43-e33f-4e19-bf85-57bc1a55940f" />

## Why It's Good For The Game
Bugfixes are good.
