### PR TITLE
Hedge mage arcyne dagger

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/hedgemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/hedgemage.dm
@@ -28,7 +28,7 @@
 	beltl = /obj/item/rogueweapon/huntingknife
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/woodstaff/ruby
-	backpack_contents = list(/obj/item/spellbook_unfinished/pre_arcyne = 1, /obj/item/roguegem/amethyst = 1, /obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/flashlight/flare/torch/lantern/prelit = 1, /obj/item/rope/chain = 1)
+	backpack_contents = list(/obj/item/spellbook_unfinished/pre_arcyne = 1, /obj/item/roguegem/amethyst = 1, /obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/flashlight/flare/torch/lantern/prelit = 1, /obj/item/rope/chain = 1, /obj/item/rogueweapon/huntingknife/idagger/silver = 1, /obj/item/rogueore/cinnabar = 1)
 	H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)


### PR DESCRIPTION
## About The Pull Request

Makes it so that hedge mages spawn with cinnabar and a silver dagger to play around with the mage loop.

## Testing Evidence

<img width="1115" height="1013" alt="Screenshot_3" src="https://github.com/user-attachments/assets/7c124114-8448-4091-8426-100cb42ed750" />

## Why It's Good For The Game

Hedge mages will be able to make runes and summon evil creatures without being forced to visit the town for cinnabar and get jumped by the keep.
