### PR TITLE
Adds Delay To Throwing

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -249,9 +249,10 @@
 		// Admin alert for coin throws
 		if(istype(thrown_thing, /obj/item/roguecoin))
 			var/obj/item/roguecoin/coin = thrown_thing
-			var/coin_text = coin.quantity > 1 ? "[coin.quantity] [coin.name]" : coin.name
-			message_admins("[ADMIN_LOOKUPFLW(src)] has thrown [coin_text] at [target] ([AREACOORD(target)])")
-			log_admin("[key_name(src)] has thrown [coin_text] at [target] ([AREACOORD(target)])")
+			if(coin.quantity > 20) //only alert if more than the intended maximum
+				var/coin_text = coin.quantity > 1 ? "[coin.quantity] [coin.name]" : coin.name
+				message_admins("[ADMIN_LOOKUPFLW(src)] has thrown [coin_text] at [target] ([AREACOORD(target)])")
+				log_admin("[key_name(src)] has thrown [coin_text] at [target] ([AREACOORD(target)])")
 		
 		if(!thrown_speed)
 			thrown_speed = thrown_thing.throw_speed
@@ -262,6 +263,7 @@
 		log_message("has thrown [thrown_thing]", LOG_ATTACK)
 		newtonian_move(get_dir(target, src))
 		thrown_thing.safe_throw_at(target, thrown_range, thrown_speed, src, null, null, null, move_force)
+		changeNext_move(CLICK_CD_MELEE)
 		if(!used_sound)
 			used_sound = pick(PUNCHWOOSH)
 		playsound(get_turf(src), used_sound, 60, FALSE)


### PR DESCRIPTION
## About The Pull Request

makes it so that throwing. has a delay. and u cant do it again. until the delay is over.

also makes it so that the coin throw admin alert only happens if the stack contains more than 20 coins otherwise it just spams admins 4 no reason.

## Testing Evidence

<img width="256" height="140" alt="image" src="https://github.com/user-attachments/assets/51918043-23f1-42ba-ab1d-65e93595b493" />
<img width="217" height="105" alt="image" src="https://github.com/user-attachments/assets/b7c73e76-a0eb-43c9-951c-8d21b2cd3373" />


## Why It's Good For The Game

people shouldnt be able to instantly throw 14 javelins in a row, methinks
