### PR TITLE
Removes Ritualist Virtue

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -172,14 +172,6 @@
 /*/datum/virtue/utility/deathless/apply_to_human(mob/living/carbon/human/recipient)
 	recipient.mob_biotypes |= MOB_UNDEAD*/
 
-/datum/virtue/utility/ritualist
-	name = "Ritualist"
-	desc = "I am in tune with my god, more than others. I can perform rituals to strengthen my bond with them."
-	added_traits = list(TRAIT_RITUALIST)
-	added_stashed_items = list(
-		"Ritual Chalk" = /obj/item/ritechalk
-		)
-
 /datum/virtue/utility/blacksmith
 	name = "Blacksmith's Apprentice"
 	desc = "In my youth, I worked under a skilled blacksmith, honing my skills with an anvil."


### PR DESCRIPTION
## About The Pull Request

This PR removes Ritualist as a virtue you can choose in character creation. It is still available as a trait to every role in the game that started with it previously

## Testing Evidence

This is a really simple change and the virtue is never referenced anywhere else in the code. I can provide testing evidence on request, however

## Why It's Good For The Game

The source of 90% of complaints I have ever heard made about experiences ingame. Ritualist as a trait was never intended to be something everyone had access to, and this is demonstrated through the existence of certain things (hello darksteel/gilded fullplate/kneestinger spam).

Poorly thought out Blackmoor holdovers like this should not exist.