### PR TITLE
full-coif doesn't cover chest

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -212,7 +212,7 @@
 	max_integrity = 275
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	resistance_flags = FIRE_PROOF
-	body_parts_covered = NECK|MOUTH|NOSE|HAIR|EARS|HEAD|CHEST
+	body_parts_covered = NECK|MOUTH|NOSE|HAIR|EARS|HEAD
 	adjustable = CAN_CADJUST
 	smeltresult = /obj/item/ingot/iron
 	smelt_bar_num = 2


### PR DESCRIPTION
## About The Pull Request

the steel and iron full chain coif no longer covers the chest

## Testing Evidence

<img width="365" height="244" alt="image_2025-08-06_205805302" src="https://github.com/user-attachments/assets/3056fabc-b4f6-42f9-96b7-7a65dcd652e5" />


## Why It's Good For The Game

It's a better fit for the sprite because it doesn't cover the chest. Also a buff to the neck armor because it will not be broken by errant strikes. I.E. a skeleton hits you in the chest a bunch like a dummy and breaks your neck armor, letting a player five seconds later to chop off your neck.