### PR TITLE
Priest's curses do not work on bandits, wretches VL or lich

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -380,9 +380,9 @@ GLOBAL_LIST_EMPTY(heretical_players)
                     to_chat(src, span_warning("[H.real_name] is already afflicted by another curse."))
                     return
 
-                // Check if target is a bandit or wretch - silently fail for outlaws
-                if (H.mind?.assigned_role == "Bandit" || H.mind?.assigned_role == "Wretch")
-                    // Curse appears to work but has no effect on outlaws
+                // Check if target is a bandit, wretch, lich, or vampire lord - silently fail for outlaws and undead
+                if (H.mind?.assigned_role == "Bandit" || H.mind?.special_role == "Bandit" || H.mind?.assigned_role == "Wretch" || H.mind?.special_role == "Lich" || H.mind?.special_role == "Vampire Lord")
+                    // Curse appears to work but has no effect on outlaws and undead
                     priority_announce("[real_name] has cursed [H.real_name] with [curse_pick]!", title = "Judgment of the Gods", sound = 'sound/misc/excomm.ogg')
                     last_curse_time = world.time // set cooldown
                     return

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -380,6 +380,13 @@ GLOBAL_LIST_EMPTY(heretical_players)
                     to_chat(src, span_warning("[H.real_name] is already afflicted by another curse."))
                     return
 
+                // Check if target is inhuman or psydonite worshipper - silently fail for heretics
+                if (istype(H.patron, /datum/patron/inhumen) || HAS_TRAIT(H, TRAIT_PSYDONITE))
+                    // Curse appears to work but has no effect on heretics
+                    priority_announce("[real_name] has cursed [H.real_name] with [curse_pick]!", title = "Judgment of the Gods", sound = 'sound/misc/excomm.ogg')
+                    last_curse_time = world.time // set cooldown
+                    return
+
                 H.add_curse(curse_type)
                 priority_announce("[real_name] has cursed [H.real_name] with [curse_pick]!", title = "Judgment of the Gods", sound = 'sound/misc/excomm.ogg')
 

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -380,9 +380,9 @@ GLOBAL_LIST_EMPTY(heretical_players)
                     to_chat(src, span_warning("[H.real_name] is already afflicted by another curse."))
                     return
 
-                // Check if target is inhuman or psydonite worshipper - silently fail for heretics
-                if (istype(H.patron, /datum/patron/inhumen) || HAS_TRAIT(H, TRAIT_PSYDONITE))
-                    // Curse appears to work but has no effect on heretics
+                // Check if target is a bandit or wretch - silently fail for outlaws
+                if (H.mind?.assigned_role == "Bandit" || H.mind?.assigned_role == "Wretch")
+                    // Curse appears to work but has no effect on outlaws
                     priority_announce("[real_name] has cursed [H.real_name] with [curse_pick]!", title = "Judgment of the Gods", sound = 'sound/misc/excomm.ogg')
                     last_curse_time = world.time // set cooldown
                     return


### PR DESCRIPTION
## About The Pull Request

Trying to use a priest curse on bandits or wretches worshippers will do nothing but still apply the cooldown.

## Testing Evidence

<img width="2560" height="1418" alt="image" src="https://github.com/user-attachments/assets/cf941d6d-d737-4c56-8d87-781a63057719" />

## Why It's Good For The Game

Curses are a tool to punish towner roles ho defy the priest. This shouldn't be used to shut loud, known antags. 