### PR TITLE
ser to sir

### DIFF
--- a/code/datums/migrants/migrant_waves/heartfelt roles.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt roles.dm
@@ -194,7 +194,7 @@
 			S.name = "knight tabard ([index])"
 		var/prev_real_name = H.real_name
 		var/prev_name = H.name
-		var/honorary = "Ser"
+		var/honorary = "Sir"
 		if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
 			honorary = "Dame"
 		H.real_name = "[honorary] [prev_real_name]"

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -51,7 +51,7 @@
 			S.name = "Captain Tabard ([index])"
 		var/prev_real_name = H.real_name
 		var/prev_name = H.name
-		var/honorary = "Ser"
+		var/honorary = "Sir"
 		if(should_wear_femme_clothes(H))
 			honorary = "Dame"
 		H.real_name = "[honorary] [prev_real_name]"

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -45,7 +45,7 @@
 			S.name = "knight's tabard ([index])"
 		var/prev_real_name = H.real_name
 		var/prev_name = H.name
-		var/honorary = "Ser"
+		var/honorary = "Sir"
 		if(should_wear_femme_clothes(H))
 			honorary = "Dame"
 		H.real_name = "[honorary] [prev_real_name]"


### PR DESCRIPTION
## About The Pull Request

turns the honoraries ser to sir for the captain, knights, and the heartfelt knight(thought I'd miss it didn't ya)

## Testing Evidence

TBA

## Why It's Good For The Game

Roguecode has a habit of making words spelled stupidly. Ser is probably the most egregious of these, so I'm removing it. The default accent doesn't even replace sir with ser, so after this change there will be no mention of ser in the code period.