### PR TITLE
Ortho Buffs / Changes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -1,6 +1,7 @@
 /datum/advclass/confessor
 	name = "Confessor"
-	tutorial = "Church of the Ten holy hunters, unmatched in the fields of subterfuge and investigation. There is no suspect too powerful to investigate, no room too guarded to infiltrate, and no weakness too hidden to exploit."
+	tutorial = "Church of the Ten holy hunters, unmatched in the fields of subterfuge and investigation. \
+	There is no suspect too powerful to investigate, no room too guarded to infiltrate, and no weakness too hidden to exploit."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/confessor
@@ -52,11 +53,11 @@
 	var/weapon_choice = input("Choose your ranged weapon.", "TAKE UP ARMS") as anything in weapons
 	switch(weapon_choice)
 		if("Crossbow & Bolts")
-			H.adjust_skillrank(/datum/skill/combat/crossbows, 4, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 5, TRUE)
 			beltr = /obj/item/quiver/bolts
 			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 		if("Recurve Bow & Arrows")
-			H.adjust_skillrank(/datum/skill/combat/bows, 4, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/combat/bows, 5, TRUE)
 			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			beltr = /obj/item/quiver/arrows
 	H.set_blindness(0)
@@ -71,9 +72,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	mask = /obj/item/clothing/mask/rogue/facemask/psydonmask
 	head = /obj/item/clothing/head/roguetown/roguehood/psydon
-	backpack_contents = list(/obj/item/roguekey/inquisition = 1, /obj/item/lockpickring/mundane = 1, /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger/preblessed, /obj/item/grapplinghook = 1)
-	head = /obj/item/clothing/head/roguetown/puritan
-	backpack_contents = list(/obj/item/storage/keyring/orthodoxist = 1, /obj/item/lockpickring/mundane = 1, /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger, /obj/item/grapplinghook = 1)
+	backpack_contents = list(/obj/item/storage/keyring/orthodoxist = 1, /obj/item/lockpickring/mundane = 1, /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger/preblessed, /obj/item/grapplinghook = 1)
 	H.change_stat("strength", -1) // weasel
 	H.change_stat("endurance", 3)
 	H.change_stat("perception", 2)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -1,6 +1,8 @@
 /datum/advclass/disciple
 	name = "Disciple"
-	tutorial = "Monks and warscholars, trained in the martial arts. The former excels at shrugging off terrible blows while wrestling foes into submission, while the latter - often hired as mercenaries from abroad - amplify their pugilism with acryne might."
+	tutorial = "Monks and warscholars, trained in the martial arts. \
+	The former excels at shrugging off terrible blows while wrestling foes into submission. \
+	The latter - often hired as mercenaries from abroad - amplify their pugilism with acryne might."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/disciple
@@ -116,7 +118,7 @@
 			H.put_in_hands(I, TRUE)
 		if("Spear")
 			H.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
-			var/obj/item/I = new /obj/item/rogueweapon/spear/psyspear(H)
+			var/obj/item/I = new /obj/item/rogueweapon/spear(H)
 			H.put_in_hands(I, TRUE)
 		if("Sword & Shield")
 			H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
@@ -131,8 +133,6 @@
 			ADD_TRAIT(H, TRAIT_STRONGBITE, TRAIT_GENERIC)
 			var/obj/item/katar = new /obj/item/rogueweapon/katar(H)
 			H.equip_to_slot(katar, SLOT_BELT_R)
-			var/obj/item/knuckles = new /obj/item/rogueweapon/knuckles/eora(H)
-			H.equip_to_slot(knuckles, SLOT_IN_BACKPACK)
 		if("Dual Wield")
 			H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 			var/obj/item/sabre1 = new /obj/item/rogueweapon/sword/sabre/shamshir(H)
@@ -175,4 +175,4 @@
 		ADD_TRAIT(H, TRAIT_OUTLANDER, TRAIT_GENERIC)		//You're a foreigner, a guest of the realm.
 		ADD_TRAIT(H, TRAIT_ARCYNE_T1, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_SILVER_BLESSED, TRAIT_GENERIC)//Given they don't have the psyblessed silver. Puts them in line with the Inquisitor.
-		H.grant_language(/datum/language/celestial)
+		H.grant_language(/datum/language/otavan)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
@@ -1,7 +1,8 @@
 /datum/advclass/psydoniantemplar // A templar, but for the Inquisition
 	name = "Adjudicator"
-	tutorial = "Ten knights, clad in fluted chainmaille and blessed with the capacity to invoke lesser miracles. \
-	In lieu of greater miracles and rituals, they compensate through martial discipline and blessed weaponry."
+	tutorial = "Knights of the Ten, bound to the Otavan Holy See's most feared order. The Inquisition. \
+	Assigned to the Inquisitor's retinue, their loyalty is absolute. \
+	They wield a combination of miracles, martial discipline and comet-blessed weaponry for this purpose."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/psydoniantemplar
@@ -45,7 +46,6 @@
 		if(/datum/patron/divine/malum)
 			wrists = /obj/item/clothing/neck/roguetown/psicross/malum
 			cloak = /obj/item/clothing/cloak/templar/malumite
-	backr = /obj/item/rogueweapon/shield/tower/metal
 	gloves = /obj/item/clothing/gloves/roguetown/chain/psydon
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
 	pants = /obj/item/clothing/under/roguetown/chainlegs
@@ -53,28 +53,34 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	shoes = /obj/item/clothing/shoes/roguetown/boots/psydonboots
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/ornate
-	head = /obj/item/clothing/head/roguetown/helmet/heavy/psydonhelm
 	belt = /obj/item/storage/belt/rogue/leather/black
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	beltr = /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger/preblessed
 	id = /obj/item/clothing/ring/silver
-	backpack_contents = list(/obj/item/storage/keyring/orthodoxist = 1)
+
+	backpack_contents = list(
+		/obj/item/storage/keyring/orthodoxist = 1,
+		/obj/item/rope/chain = 1,
+	)
+
 	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
 	H.change_stat("strength", 2)
-	H.change_stat("constitution", 2)
+	H.change_stat("constitution", 3)
 	H.change_stat("endurance", 3)
+	H.change_stat("speed", -1)
 
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
@@ -85,7 +91,7 @@
 
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1) //Capped to T2 miracles. It's just a self-heal.
+	C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_DEVOTEE, devotion_limit = CLERIC_REQ_2) //Capped to T2 miracles. Worse regen than Templar.
 
 	var/helmets = list(
 	"Ornate Barbute" 	= /obj/item/clothing/head/roguetown/helmet/heavy/psydonbarbute,

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/spellbreaker.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/spellbreaker.dm
@@ -1,6 +1,8 @@
 /datum/advclass/spellbreaker
 	name = "Spellbreaker"
-	tutorial = "A holy warrior of the Inquisition, dedicated to crushing unholy schools of magic and proving them lesser through the purity and might of their own faith and blade."
+	tutorial = "A holy warrior of the Inquisition. \
+	Wholly dedicated to crushing unholy schools of magic and proving them lesser. \
+	Whether that be through the purity and might of their own faith, or a blade."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/spellbreaker
@@ -49,6 +51,7 @@
 		/obj/item/storage/keyring/orthodoxist = 1,
 		/obj/item/rope/chain = 1,
 	)
+
 	if(H.mind)
 		H.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
@@ -79,3 +82,4 @@
 		ADD_TRAIT(H, TRAIT_INQUISITION, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_SILVER_BLESSED, TRAIT_GENERIC)//Given they don't have the psyblessed silver cross. Puts them in line with the Inquisitor.
 		H.cmode_music = 'sound/music/inquisitorcombat.ogg'
+	H.grant_language(/datum/language/otavan)


### PR DESCRIPTION
## About The Pull Request
The Inquisitorial retinue is in a really weird place. Very, very weird.
Adjudicators don't get the buffs or benefit of being a proper Church Templar, and were objectively worse if you took away the psyblessed equipment. For a contested role that has 3 slots, and a very, very chunky set of subclasses. Of which this was, very, very frequently the worst choice.

Confessors could get roundstart legendary bows or crossbows and then, atop that, +4 in the opposite stat anyways, alongside all their other stuff. Because the guy who did that gave them +4 on top of a +4 skill spread. For some reason? I don't know. They keep the +4 in their non-chosen stat, and get +5 in the chosen weapon's category as you'll see below.

Disciples got unblessed Psyspears. And Eoran knuckles. For some reason. I fixed that. They lost the knuckles and it's a standard spear.

Just a lot of weird stuff. They could do with a proper pass, but this is primarily just a "PLEASE GOD WHY" PR so I don't have to see it anymore.

Anyhow, the stuff below.
- - -
For Adjudicator:
 - +1 wrestling, to a total of 3.
 - +2 climbing, to a total of 3.
 - +1 athletics, to a total of 4.
 - +2 knife skill. Psyblessed dagger but couldn't use it. lol
 - +1 con.
 - -1 speed.
 - 0.3(devotee) regen on devotion. Templars get 0.5. 0.3 is devotee level.
 - T2 devotion limit, as opposed to T1. They could cast T2 miracles, just didn't have the devotion cap as one might expect. Which just meant they had a smaller pool to pull from. Probably intended, but these guys aren't great compared to their contemporaries who've been numberfucked to be far better.

They also had their tutorial updated, to better reflect what they are. They weren't ever really lesser miracle restricted, and the description should help acclimate players better to what the role actually is. A knight of the Holy See, assigned to the Inquisitor. I debated giving them nobility, but that defeats the point of them being members of the clergy.

Additionally, they're still far worse than just playing Confessor, Disciple or Spellbreaker. Objectively. They don't get spells beyond the miracles. They don't get crit resist. They don't have the cracked combat skills. They can't grapple at an obscene level. They don't have the utility skills. They're just an armoured miracle caster. They couldn't even climb until I raised that, too. Given there's three slots, and it's likely only one of these slots MIGHT be an Adjudicator? I figured it was fine to buff them a little. I'd debated giving them more, but I know people are going to throw a fit over this as is. They're still not nearly as powerful as the alternatives.

For Confessors:
 - Instead of +4 on top of their already +4 skill to legendary / crossbow, they're given +1 to their respective weapon of choice. Why did it give them legendary+? I don't know. I don't care. They're still the meta choice. It gets them to +5 in total, as opposed to legendary.
 - Backpack cleaned up, removing the secondary list which existed for some reason. Alongside the other hat. This was slop coded. RAAAAA
 - Because of the backpack cleanup, they should also proper get a pre-blessed dagger now. So, a buff, I guess.

For Disciples:
 - They lost the unblessed Psyspear, instead getting a standard spear for spear selection.
 - They lost the Eoran knuckles. They still retain the katar.
 - Naledi subclass gets Otavan, instead of Cellestial.

For Spellbreaker:
 - They're given Otavan. That's it.

## Testing Evidence
It's numbers and paths.
I can test if it you really want me to, but it compiles. It should be fine, unless I've catastrophically screwed it.
## Why It's Good For The Game
Arguably explained above. Read it.