### PR TITLE
Return of Duke Bad Omen + Fixes last mentions of Monarchy

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -218,13 +218,13 @@
 	var/end_reason
 
 	if(!check_for_lord())
-		end_reason = pick("Without a Monarch, they were doomed to become slaves of Zizo.",
-						"Without a Monarch, they were doomed to be eaten by nite creachers.",
-						"Without a Monarch, they were doomed to become victims of Gehenna.",
-						"Without a Monarch, they were doomed to enjoy a mass-suicide.",
-						"Without a Monarch, the Lich made them his playthings.",
-						"Without a Monarch, some jealous rival reigned in tyranny.",
-						"Without a Monarch, the town was abandoned.")
+		end_reason = pick("Without a Duke, they were doomed to become slaves of Zizo.",
+						"Without a Duke, they were doomed to be eaten by nite creachers.",
+						"Without a Duke, they were doomed to become victims of Gehenna.",
+						"Without a Duke, they were doomed to enjoy a mass-suicide.",
+						"Without a Duke, the Lich made them his playthings.",
+						"Without a Duke, some jealous rival reigned in tyranny.",
+						"Without a Duke, the town was abandoned.")
 
 	if(vampire_werewolf() == "vampire")
 		end_reason = "When the Vampires finished sucking the town dry, they moved on to the next one."

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -410,6 +410,10 @@ SUBSYSTEM_DEF(ticker)
 
 //	setup_hell()
 	SStriumphs.fire_on_PostSetup()
+	
+	// Reset the found_lords list for the new round
+	reset_found_lords()
+	
 	for(var/i in GLOB.start_landmarks_list)
 		var/obj/effect/landmark/start/S = i
 		if(istype(S))							//we can not runtime here. not in this important of a proc.

--- a/code/datums/antag_retainer.dm
+++ b/code/datums/antag_retainer.dm
@@ -50,31 +50,87 @@
 		if(!vampyr)
 			return "werewolf"
 
+
+var/global/list/found_lords = list() 
+
+/proc/reset_found_lords()
+	found_lords.Cut()
+
+/proc/cleanup_found_lords()
+	// Only clean up if we have a functional living lord (meaning the crisis is over)
+	var/has_functional_lord = FALSE
+	for(var/mob/living/carbon/human/H in GLOB.human_list)
+		if(H.mind && (H.mind.assigned_role == "Grand Duke" || H.mind.assigned_role == "Grand Duchess"))
+			if(H.stat != DEAD && !isbrain(H) && H.get_bodypart(BODY_ZONE_HEAD))
+				has_functional_lord = TRUE
+				break
+	
+	if(has_functional_lord)
+		var/list/valid_ckeys = list()
+		for(var/mob/living/carbon/human/H in GLOB.human_list)
+			if(H.ckey)
+				valid_ckeys += H.ckey
+		
+		for(var/ckey in found_lords)
+			if(ckey && !(ckey in valid_ckeys))
+				found_lords -= ckey
+
 /proc/check_for_lord(forced = FALSE)
 	if(!forced && (world.time < SSticker.next_lord_check))
 		return
 	SSticker.next_lord_check = world.time + 1 MINUTES
 	var/lord_found = FALSE
-	var/lord_dead = FALSE
+	var/living_lord_found = FALSE
+	
 	for(var/mob/living/carbon/human/H in GLOB.human_list)
-		if(H.mind)
-			if(H.job == "Monarch")
-				lord_found = TRUE
-				if(H.stat == DEAD)
-					lord_dead = TRUE
-				else
-					if(lord_dead)
-						lord_dead = FALSE
+		if(H.mind && (H.mind.assigned_role == "Grand Duke" || H.mind.assigned_role == "Grand Duchess"))
+			if(H.ckey)
+				found_lords[H.ckey] = TRUE
+			lord_found = TRUE
+			
+			// Check if the lord is actually functional (alive, not a brain, and has a head)
+			if(H.stat != DEAD && !isbrain(H) && H.get_bodypart(BODY_ZONE_HEAD))
+				living_lord_found = TRUE
+				if(hasomen(OMEN_NOLORD))
+					removeomen(OMEN_NOLORD)
+				break
+	
+	if(!living_lord_found && found_lords.len > 0 && !hasomen(OMEN_NOLORD))
+		// Check if any of our found lords are currently dead/headless in the game
+		for(var/ckey in found_lords)
+			var/mob/living/carbon/human/dead_lord = null
+			// Find the human with this ckey
+			for(var/mob/living/carbon/human/H in GLOB.human_list)
+				if(H.ckey == ckey)
+					dead_lord = H
 					break
-	if(lord_dead || !lord_found)
+			
+			// If the lord is still in the game but dead/headless, or if they're completely gone (likely dead from decapitation)
+			if(dead_lord && (dead_lord.stat == DEAD || dead_lord.stat == 3 || !dead_lord.get_bodypart(BODY_ZONE_HEAD)))
+				lord_found = TRUE
+				break
+			else if(!dead_lord)
+				// If a lord was found alive before but is now completely gone from the game,
+				// they're likely dead (from decapitation) rather than voluntarily left
+				// (Far Travel would have removed them from found_lords)
+				lord_found = TRUE
+				break
+	
+	if(lord_found && !living_lord_found)
 		if(!SSticker.missing_lord_time)
 			SSticker.missing_lord_time = world.time
-		if(world.time > SSticker.missing_lord_time + 10 MINUTES)
+		
+		if(forced || (world.time > SSticker.missing_lord_time + 10 MINUTES))
 			SSticker.missing_lord_time = world.time
 			addomen(OMEN_NOLORD)
-		return FALSE
-	else
-		return TRUE
+			//Announce the omen to players
+			var/datum/round_event_control/R = new()
+			R.badomen(OMEN_NOLORD)
+	
+	// Clean up the found_lords list at the end
+	cleanup_found_lords()
+	
+	return living_lord_found
 
 /proc/age_check(client/C)
 	if(get_remaining_days(C) == 0)

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -400,7 +400,7 @@ GLOBAL_LIST_INIT(badomens, list())
 		if(OMEN_SKELETONSIEGE)
 			used = "Unwelcome visitors!"
 		if(OMEN_NOLORD)
-			used = "The Monarch is dead! We need a new ruler."
+			used = "The Duke is dead! We need a new ruler."
 		if(OMEN_SUNSTEAL)
 			used = "The Sun, she is wounded!"
 	if(eventreason && used)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -164,7 +164,7 @@
 	if(!.)
 		return
 	switch(job)
-		if("Grand Duke")
+		if("Grand Duke", "Grand Duchess")
 			removeomen(OMEN_NOLORD)
 		if("Priest")
 			removeomen(OMEN_NOPRIEST)

--- a/modular_azurepeak/code/game/objects/structures/fartravel.dm
+++ b/modular_azurepeak/code/game/objects/structures/fartravel.dm
@@ -68,5 +68,12 @@
 		departing_mob.visible_message("<span class='notice'>[user] sends the body of [departing_mob] away. They're someone else's problem now.</span>")
 	else
 		departing_mob.visible_message("<span class='notice'>[departing_mob == user ? "Out of their own volition, " : "Ushered by [user], "][departing_mob] leaves Scarlet Reach.</span>")
+	
+	// If departure is a lord, remove them from found_lords to prevent false omen triggers
+	if(departing_mob.mind && departing_mob.ckey)
+		if(departing_mob.mind.assigned_role == "Grand Duke" || departing_mob.mind.assigned_role == "Grand Duchess")
+			if(found_lords[departing_mob.ckey])
+				found_lords -= departing_mob.ckey
+	
 	qdel(departing_mob)
 


### PR DESCRIPTION
## About The Pull Request

Bad Omen has been bugged for a while, all this time it has been checking for Monarch when in reality it should be checking for Grand Duke, so I fixed it, but then I ran into a problem that if the GD is decapped it doesn't count it to the bad omen countdown, so I fixed it, but then Far Travel was also counting towards Bad Omen, so I fixed that too.

And on the same Monarchy boat, it has been driving me up the wall that when round ends, despite there being a duke, it says one of the "Without a Monarch, they were doomed to be eaten by nite creachers." lines or something similar. So I fixed that too.
 

Bad Omen checks for dead duke every 1 minute then if a dead duke is found it starts a 10 minute timer, once it's up, it sends a message to everyone. Only way to remove it is if a new GD arrives, if the GD is revived, or if the priest coronates a new GD
## Testing Evidence

<details>
  <summary>Round end Text</summary>
**How it USED to be:**

https://github.com/user-attachments/assets/ba8697c9-cfd8-4bc1-9748-ffad4b4b9eb3


**How it is now:**

https://github.com/user-attachments/assets/70419816-4fb2-4776-aa64-ca506a95b1d8

</details>

<details>
  <summary>Bad Omen!</summary>
  
https://github.com/user-attachments/assets/ff4d0556-ed8a-4250-b1db-04da2883fefa


</details>


## Why It's Good For The Game

**DOWN WITH THE MONARCHY!!!**