### PR TITLE
More Accurater Job Listings

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -77,9 +77,13 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 	dat += "</center>"
 
+	var/list/wanderers = list()
+	var/list/job_list = list()
+
 	for(var/datum/job/job in SSjob.occupations)
+		var/wanderer_job = FALSE
 		if(istype(job, /datum/job/roguetown/adventurer) || istype(job, /datum/job/roguetown/wretch) || istype(job, /datum/job/roguetown/adventurer/courtagent))
-			continue
+			wanderer_job = TRUE
 		if(!job)
 			continue
 		var/readiedas = 0
@@ -102,8 +106,12 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 										if(Lord.brohand == player.ckey)
 											thing = "*[thing]*"
 											break
-							PL += thing
-
+							if(wanderer_job)
+								wanderers += thing
+							else
+								PL += thing
+		if(wanderer_job)
+			continue
 		var/list/PL2 = list()
 		for(var/i in 1 to PL.len)
 			if(i == PL.len)
@@ -115,9 +123,18 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 		if(readiedas)
 			if(PL2.len)
-				dat += "<B>[str_job]</B> ([readiedas]) - [PL2.Join()]<br>"
+				job_list += "<B>[str_job]</B> ([readiedas]) - [PL2.Join()]<br>"
 			else
-				dat += "<B>[str_job]</B> ([readiedas])<br>"
+				job_list += "<B>[str_job]</B> ([readiedas])<br>"
+	if(length(wanderers))
+		var/wanderers_listing = "<B>Wanderers</B> ([wanderers.len]) - "
+		for(var/i in 1 to wanderers.len)
+			if(i == wanderers.len)
+				wanderers_listing += "[wanderers[i]]"
+			else
+				wanderers_listing += "[wanderers[i]], "
+		job_list.Insert(1, wanderers_listing)
+	dat += job_list
 	var/datum/browser/popup = new(src, "lobby_window", "<div align='center'>LOBBY</div>", 330, 430)
 	popup.set_window_options("can_close=1;can_minimize=0;can_maximize=0;can_resize=1;")
 	popup.set_content(dat.Join())

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -682,7 +682,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 					if(job_datum in SSjob.prioritized_jobs)
 						dat += "<a class='job[command_bold]' href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'><span class='priority'>[used_name] ([job_datum.current_positions])</span></a>"
 					else
-						dat += "<a class='job[command_bold]' href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'>[used_name] ([job_datum.current_positions])[job_datum.round_contrib_points ? " RCP: +[job_datum.round_contrib_points]" : ""]</a>"
+						dat += "<a class='job[command_bold]' href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'>[used_name] ([job_datum.current_positions]/[job_datum.total_positions])</a>"
 
 			dat += "</fieldset><br>"
 			column_counter++


### PR DESCRIPTION
## About The Pull Request

makes it so that latejoin jobs will show you the current slots _and_ the total slots available. removed the RCP part since it wasnt really too helpful.
and makes it so instead of not showing up in the readied list, adventurer, wretch and court agent will show up as "Wanderers" in the lobby

## Testing Evidence

<img width="332" height="230" alt="image" src="https://github.com/user-attachments/assets/549ffee5-31c5-4684-852b-0c68e699ea0b" />
<img width="492" height="549" alt="image" src="https://github.com/user-attachments/assets/bb97bacf-6a1b-40e2-8c8b-2a29f1798cef" />


## Why It's Good For The Game

i am a code tyrant
