### PR TITLE
Gives Jester Master Athletics + Lets Acrobats Do Flips

### DIFF
--- a/code/game/objects/items/rogueweapons/intents/mmb/jump.dm
+++ b/code/game/objects/items/rogueweapons/intents/mmb/jump.dm
@@ -86,7 +86,7 @@
 	var/flip_direction = FLIP_DIRECTION_CLOCKWISE
 	var/prev_pixel_z = pixel_z
 	var/prev_transform = transform
-	if(get_skill_level(/datum/skill/misc/athletics) > 4)
+	if((get_skill_level(/datum/skill/misc/athletics) > 4 || HAS_TRAIT(src, TRAIT_LEAPER)) && cmode)
 		do_a_flip = TRUE
 		if((dir & SOUTH) || (dir & WEST))
 			flip_direction = FLIP_DIRECTION_ANTICLOCKWISE

--- a/code/modules/jobs/job_types/roguetown/courtier/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/jester.dm
@@ -12,7 +12,6 @@
 		You command a position of a fool, envious of the position your superiors have upon you. \
 		Your cheap tricks and illusions of intelligence will only work for so long, \
 		and someday you'll find yourself at the end of something sharper than you."
-	spells = list(/obj/effect/proc_holder/spell/self/telljoke,/obj/effect/proc_holder/spell/self/telltragedy)
 	outfit = /datum/outfit/job/roguetown/jester
 	display_order = JDO_JESTER
 	give_bank_account = TRUE
@@ -35,6 +34,7 @@
 	H.adjust_skillrank(/datum/skill/misc/sneaking, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/stealing, 5, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/athletics, 5, TRUE) //a showman like no other. you need to be fit to perform.
 	H.adjust_skillrank(/datum/skill/misc/music, rand(1,6), TRUE)
 	H.adjust_skillrank(/datum/skill/misc/lockpicking, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/cooking, rand(1,3), TRUE)


### PR DESCRIPTION
## About The Pull Request

makes it so that jesters get master athletics (they had 0 skill)
ppl with the leaper trait (from the acrobat virtue) can also do flips now
makes it so that you need to be on combat mode to do flips

problem: flips only show up for _other_ people, due to the way vision cones work in roguecode.

## Testing Evidence

breakpoint of the flip triggering under the appropriate conditions, since i can't actually get a screenshot of the flip happening on my own client
<img width="867" height="102" alt="image" src="https://github.com/user-attachments/assets/83f25048-693c-44f5-a504-956276576944" />


## Why It's Good For The Game

flip
