### PR TITLE
Handcart refactor: Refactored the code, also now you can load things like bins and chests into them, added new feedback messages for doing this and that ADDITIONALLY: refactored bins to be structures and use signals, instead, because it was necessary in the commission of handcart objectives

### DIFF
--- a/_maps/map_files/dun_manor/azure_coast.dmm
+++ b/_maps/map_files/dun_manor/azure_coast.dmm
@@ -333,7 +333,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
 "bh" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/shelter)
 "bk" = (
@@ -1717,7 +1717,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/cave)
 "kO" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
 "kP" = (
@@ -2538,7 +2538,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/orcdungeon)
 "qz" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/mazedungeon)
 "qA" = (
@@ -3209,7 +3209,7 @@
 	},
 /area/rogue/under/cave/dukecourt)
 "vf" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "vg" = (
@@ -4408,7 +4408,7 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/cave/dukecourt)
 "CP" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/orcdungeon)
 "CQ" = (
@@ -4442,7 +4442,7 @@
 /area/rogue/indoors/cave)
 "CW" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "CZ" = (
@@ -4829,7 +4829,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "FK" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
 "FP" = (

--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -965,7 +965,7 @@
 /obj/effect/decal/wood/herringbone2{
 	dir = 8
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/shelter/woods)
 "hX" = (
@@ -1420,7 +1420,7 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "lD" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
 "lF" = (
@@ -1876,7 +1876,7 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/town/basement)
 "pv" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
 "px" = (
@@ -5072,7 +5072,7 @@
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "PC" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/woods)
 "PD" = (
@@ -5823,7 +5823,7 @@
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/woods)
 "Vt" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet/bogcaves)
 "Vu" = (

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -934,7 +934,7 @@
 	dir = 8
 	},
 /obj/effect/decal/mossy,
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "aEN" = (
@@ -3259,7 +3259,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "cis" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "civ" = (
@@ -3709,7 +3709,7 @@
 /area/rogue/outdoors/town)
 "cyA" = (
 /obj/machinery/light/rogue/torchholder/l,
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "cyB" = (
@@ -4602,7 +4602,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "dcV" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -5419,7 +5419,7 @@
 	dir = 1;
 	icon_state = "borderfall"
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "dCK" = (
@@ -5887,7 +5887,7 @@
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "dVw" = (
@@ -6030,7 +6030,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "dZA" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/town)
 "dZI" = (
@@ -6124,7 +6124,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "edD" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
@@ -7738,7 +7738,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/dwarfin)
 "fnb" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "fnh" = (
@@ -8034,7 +8034,7 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
 "fzA" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
 "fzF" = (
@@ -8793,7 +8793,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/physician)
 "gdQ" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "gdU" = (
@@ -11520,7 +11520,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -11681,7 +11681,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "iqT" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "irf" = (
@@ -12757,7 +12757,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "jdd" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -12943,7 +12943,7 @@
 /turf/open/water/ocean/deep,
 /area/rogue/outdoors/beach)
 "jiX" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "jiY" = (
@@ -13515,7 +13515,7 @@
 /turf/open/water/pond,
 /area/rogue/outdoors/mountains)
 "jHo" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/physician)
@@ -14060,7 +14060,7 @@
 	},
 /area/rogue/indoors/town/physician)
 "jWq" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -14443,7 +14443,7 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
 	},
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
 "knJ" = (
@@ -14493,7 +14493,7 @@
 	},
 /area/rogue/outdoors/town)
 "koH" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "koU" = (
@@ -14651,7 +14651,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "kva" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -16005,7 +16005,7 @@
 	},
 /area/rogue/indoors/town)
 "lkl" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
 "lkr" = (
@@ -16333,7 +16333,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "lvu" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "lvL" = (
@@ -16955,7 +16955,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "lUr" = (
@@ -17798,7 +17798,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "myw" = (
@@ -18519,7 +18519,7 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/shop)
 "mXA" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "mXJ" = (
@@ -18692,7 +18692,7 @@
 /area/rogue/indoors/town/physician)
 "ndv" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "neh" = (
@@ -20075,7 +20075,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
 "nYY" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
 "nZm" = (
@@ -20367,7 +20367,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "oiO" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "oiW" = (
@@ -20889,7 +20889,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "oBK" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "oCc" = (
@@ -20985,7 +20985,7 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "oEl" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
 "oEX" = (
@@ -21180,7 +21180,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/mountains)
 "oMI" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "oMJ" = (
@@ -23167,7 +23167,7 @@
 /area/rogue/indoors/town/manor)
 "qjQ" = (
 /obj/machinery/light/rogue/torchholder/c,
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "qjR" = (
@@ -24603,7 +24603,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rjb" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "rjf" = (
@@ -25544,7 +25544,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "rSG" = (
-/obj/item/roguebin,
+/obj/structure/roguebin,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "rSH" = (
@@ -25879,7 +25879,7 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
 "sfF" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town)
 "sfP" = (
@@ -28885,7 +28885,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "uik" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
@@ -28977,7 +28977,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
 "umb" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
@@ -30790,7 +30790,7 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town/roofs)
 "vJu" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/structure/roguemachine/atm{
 	location_tag = "Keep Front Gate"
 	},
@@ -30811,7 +30811,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "vKL" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "vKT" = (
@@ -32076,7 +32076,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
 "wEc" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = -6;
 	pixel_y = 15
@@ -32464,7 +32464,7 @@
 	dir = 4
 	},
 /obj/effect/decal/wood/herringbone2,
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors)
 "wQt" = (
@@ -33727,7 +33727,7 @@
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "xFm" = (
@@ -33770,7 +33770,7 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
 "xGu" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "xGz" = (

--- a/_maps/map_files/dun_manor/smalldecap.dmm
+++ b/_maps/map_files/dun_manor/smalldecap.dmm
@@ -130,7 +130,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "cp" = (
-/obj/item/roguebin/trash,
+/obj/structure/roguebin/trash,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "cq" = (
@@ -647,7 +647,7 @@
 	},
 /area/rogue/under/cave/undeadmanor)
 "ii" = (
-/obj/item/roguebin/trash,
+/obj/structure/roguebin/trash,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "il" = (
@@ -727,7 +727,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/undeadmanor)
 "iU" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/structure/fluff/walldeco/med2{
 	pixel_y = 32
 	},
@@ -893,7 +893,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
-/obj/item/roguebin/trash,
+/obj/structure/roguebin/trash,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "lI" = (
@@ -1460,7 +1460,7 @@
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/mountains/decap)
 "tO" = (
-/obj/item/roguebin/trash,
+/obj/structure/roguebin/trash,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "tQ" = (
@@ -2099,7 +2099,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "AZ" = (
-/obj/item/roguebin/trash,
+/obj/structure/roguebin/trash,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "Ba" = (
@@ -3307,7 +3307,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
 "QT" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "QX" = (
@@ -3633,7 +3633,7 @@
 /turf/open/lava,
 /area/rogue/under/cave/undeadmanor)
 "Vw" = (
-/obj/item/roguebin/trash,
+/obj/structure/roguebin/trash,
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "VC" = (

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -320,7 +320,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "agm" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
 	},
@@ -701,7 +701,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "amN" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/dwarfin)
 "amS" = (
@@ -3455,7 +3455,7 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/cave)
 "bgr" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "bgG" = (
@@ -3697,7 +3697,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
 "blt" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -3974,7 +3974,7 @@
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/mountains)
 "bqZ" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "bra" = (
@@ -4131,7 +4131,7 @@
 /obj/effect/decal/wood/herringbone2{
 	dir = 8
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/shelter/woods)
 "btj" = (
@@ -5141,7 +5141,7 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
 "bJs" = (
-/obj/item/roguebin/water{
+/obj/structure/roguebin/water{
 	pixel_y = 5
 	},
 /turf/open/floor/rogue/metal,
@@ -5699,7 +5699,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "bSO" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/sewer)
 "bSP" = (
@@ -7307,7 +7307,7 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town)
 "cvV" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "cvX" = (
@@ -9366,7 +9366,7 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach)
 "dgu" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
 "dgv" = (
@@ -12813,7 +12813,7 @@
 /area/rogue/outdoors/beach)
 "epk" = (
 /obj/machinery/light/rogue/torchholder/l,
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "epm" = (
@@ -12866,7 +12866,7 @@
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/effect/decal/cobbleedge{
 	dir = 8;
 	pixel_y = 1
@@ -15829,7 +15829,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
 "fnZ" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "foa" = (
@@ -16600,7 +16600,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "fAz" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/fishmandungeon)
 "fAA" = (
@@ -17828,7 +17828,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "fVF" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "fVR" = (
@@ -19123,7 +19123,7 @@
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
 "gtp" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "gtt" = (
@@ -19490,7 +19490,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "gyL" = (
@@ -19936,7 +19936,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/woods)
 "gGF" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "gGL" = (
@@ -20857,7 +20857,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "gWG" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "gWI" = (
@@ -21529,7 +21529,7 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "hgP" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "hgX" = (
@@ -23176,7 +23176,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "hFF" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/shelter)
 "hFM" = (
@@ -24433,7 +24433,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
 "icU" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/mazedungeon)
 "icV" = (
@@ -24519,7 +24519,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/fishmandungeon)
 "iea" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "ieb" = (
@@ -25833,7 +25833,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/woods)
 "iAB" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
 "iAF" = (
@@ -25899,7 +25899,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church/chapel)
 "iBx" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblindungeon)
 "iBC" = (
@@ -27383,7 +27383,7 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/basement)
 "iZi" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = 11;
 	pixel_y = -2
@@ -27559,7 +27559,7 @@
 	dir = 4
 	},
 /obj/effect/decal/wood/herringbone2,
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "jcr" = (
@@ -30111,7 +30111,7 @@
 	},
 /area/rogue/indoors/town/garrison)
 "jWX" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "jXb" = (
@@ -31343,7 +31343,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "ktE" = (
@@ -32166,7 +32166,7 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "kFE" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
 "kFJ" = (
@@ -32429,7 +32429,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
 "kKL" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
@@ -32886,7 +32886,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/skeletoncrypt)
 "kUd" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
 "kUe" = (
@@ -33644,7 +33644,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "lhq" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -34620,7 +34620,7 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
 	},
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
 "lxH" = (
@@ -34726,7 +34726,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "lyI" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/sewer)
 "lyJ" = (
@@ -36170,7 +36170,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains)
 "lZM" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "lZN" = (
@@ -36602,7 +36602,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "mgk" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
 "mgq" = (
@@ -36976,7 +36976,7 @@
 /area/rogue/indoors)
 "mmJ" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "mmN" = (
@@ -37146,7 +37146,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
 "mqx" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/mountains/decap)
 "mqz" = (
@@ -37846,7 +37846,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/skeletoncrypt)
 "mDa" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
@@ -40146,7 +40146,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/dukecourt)
 "not" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach)
 "noA" = (
@@ -40403,7 +40403,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "ntR" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
 "ntX" = (
@@ -41056,7 +41056,7 @@
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
 	},
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/basement)
 "nFN" = (
@@ -44614,7 +44614,7 @@
 /area/rogue/indoors/town/manor)
 "oRu" = (
 /obj/machinery/light/rogue/torchholder/c,
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "oRv" = (
@@ -46130,7 +46130,7 @@
 	},
 /area/rogue/indoors/town)
 "psu" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "psx" = (
@@ -46215,7 +46215,7 @@
 	},
 /area/rogue/indoors/town/garrison)
 "ptF" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/dwarfin)
 "puw" = (
@@ -46474,7 +46474,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "pyL" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /obj/structure/mirror,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/magician)
@@ -46542,7 +46542,7 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/physician)
 "pzw" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -47307,7 +47307,7 @@
 	},
 /area/rogue/under/town/basement/keep)
 "pKZ" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "pLb" = (
@@ -48361,7 +48361,7 @@
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
 	},
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /obj/effect/decal/cobbleedge{
 	dir = 10;
 	icon_state = "cobbleedge-n"
@@ -49888,7 +49888,7 @@
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/effect/decal/cobbleedge{
 	dir = 9
 	},
@@ -50762,7 +50762,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "qRV" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "qRY" = (
@@ -50838,7 +50838,7 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield/eora)
 "qTk" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/cave)
 "qTl" = (
@@ -51984,7 +51984,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/basement)
 "rob" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
@@ -52123,7 +52123,7 @@
 /area/rogue/outdoors/woods)
 "rqE" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "rqI" = (
@@ -52215,7 +52215,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/sewer)
 "rsI" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/fishmandungeon)
 "rsR" = (
@@ -52465,7 +52465,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
 "rxg" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
 "rxm" = (
@@ -53780,7 +53780,7 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/town/basement/keep)
 "rTU" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "rUb" = (
@@ -54110,7 +54110,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -54621,7 +54621,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
 "sjk" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
@@ -56523,7 +56523,7 @@
 	dir = 1;
 	icon_state = "borderfall"
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "sOC" = (
@@ -56715,7 +56715,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/sewer)
 "sRm" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
 "sRn" = (
@@ -58393,7 +58393,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "ttn" = (
@@ -60325,7 +60325,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "tZJ" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
 "tZR" = (
@@ -60911,7 +60911,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "ukg" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "ukj" = (
@@ -63049,7 +63049,7 @@
 /obj/effect/decal/mossy{
 	dir = 1
 	},
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "uSC" = (
@@ -63471,7 +63471,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "uZN" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "uZQ" = (
@@ -64721,7 +64721,7 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "vvS" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/metal,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "vvU" = (
@@ -65351,7 +65351,7 @@
 /area/rogue/under/cave/scarymaze)
 "vGM" = (
 /obj/machinery/light/rogue/torchholder/c,
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "vGV" = (
@@ -65788,7 +65788,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave)
 "vNR" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "vOc" = (
@@ -66257,7 +66257,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "vWp" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet/bogcaves)
 "vWu" = (
@@ -67612,7 +67612,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "wqT" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/sewer)
 "wra" = (
@@ -69652,7 +69652,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "xaf" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/shelter/mountains/decap)
 "xai" = (
@@ -70776,7 +70776,7 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors)
 "xtp" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "xtD" = (
@@ -71824,7 +71824,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
 "xNg" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
 "xNk" = (
@@ -72490,7 +72490,7 @@
 	dir = 8
 	},
 /obj/effect/decal/mossy,
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "xYM" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -614,7 +614,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue)
 "bn" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue)
 "bo" = (
@@ -1596,7 +1596,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/inhumen)
 "hr" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/banditcamp)
 "hy" = (
@@ -3429,7 +3429,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/inhumen)
 "QX" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -3511,7 +3511,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/banditcamp)
 "TD" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/inhumen)
 "TK" = (

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1970,7 +1970,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "bbO" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "bcu" = (
@@ -2034,7 +2034,7 @@
 	},
 /area/rogue/indoors)
 "bgI" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "bgQ" = (
@@ -2073,7 +2073,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "bkd" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "bke" = (
@@ -2908,7 +2908,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
 "cfY" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/chapel)
 "cgq" = (
@@ -3559,7 +3559,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/roofs)
 "cNr" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
@@ -4122,8 +4122,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "drA" = (
-/obj/item/roguebin/water/gross,
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "dsu" = (
@@ -5029,7 +5029,7 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church)
 "emM" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
 "emX" = (
@@ -5552,7 +5552,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
 "eSc" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
 	},
@@ -6677,7 +6677,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "gfl" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
 "gfP" = (
@@ -10670,7 +10670,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/town/basement)
 "ksH" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
 "ksI" = (
@@ -11112,7 +11112,7 @@
 	},
 /area/rogue/indoors/town/shop)
 "kSh" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
@@ -12064,7 +12064,7 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves)
 "lXo" = (
-/obj/item/roguebin/trash,
+/obj/structure/roguebin/trash,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "lXJ" = (
@@ -12478,7 +12478,7 @@
 /turf/open/water/sewer,
 /area/rogue/under/cave)
 "muu" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "muz" = (
@@ -13411,7 +13411,7 @@
 "nBo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "nBz" = (
@@ -13460,7 +13460,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "nEj" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/bog)
 "nFg" = (
@@ -13791,7 +13791,7 @@
 	},
 /area/rogue/outdoors/town)
 "nYR" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 32
 	},
@@ -17100,7 +17100,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rKn" = (
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "rLm" = (
@@ -20903,7 +20903,7 @@
 /area/rogue/indoors/town/manor)
 "vKX" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/item/roguebin/water,
+/obj/structure/roguebin/water,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church)
 "vLy" = (
@@ -21490,7 +21490,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "wue" = (
-/obj/item/roguebin,
+/obj/structure/roguebin,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "wuh" = (
@@ -22324,7 +22324,7 @@
 	},
 /area/rogue/under/town/basement)
 "xoS" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "xoT" = (

--- a/_maps/map_files/roguetest/roguetest.dmm
+++ b/_maps/map_files/roguetest/roguetest.dmm
@@ -501,7 +501,7 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors)
 "rf" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "rK" = (

--- a/_maps/map_files/templates/sewers/sewers_bottomleft_2.dmm
+++ b/_maps/map_files/templates/sewers/sewers_bottomleft_2.dmm
@@ -15,7 +15,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "k" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "l" = (

--- a/_maps/map_files/templates/sewers/sewers_topleft_3.dmm
+++ b/_maps/map_files/templates/sewers/sewers_topleft_3.dmm
@@ -233,7 +233,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "S" = (
-/obj/item/roguebin/crackers,
+/obj/structure/roguebin/crackers,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)

--- a/_maps/map_files/templates/smalldungeons/smalldungeon1.dmm
+++ b/_maps/map_files/templates/smalldungeons/smalldungeon1.dmm
@@ -2137,7 +2137,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/dungeon1)
 "Wj" = (
-/obj/item/roguebin/water/gross,
+/obj/structure/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
 "Wv" = (

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -180,7 +180,13 @@
 	#define COMPONENT_NO_MOUSEDROP 1
 #define COMSIG_MOUSEDROPPED_ONTO "mousedropped_onto"			//from base of atom/MouseDrop_T: (/atom/from, /mob/user)
 
+#define COMSIG_STORAGE_MOUSEDROP "storage_mousedrop"			//from base of datum/component/storage/mousedrop_onto: (datum/component/storage/storage_datum, atom/actual_dropped_atom)
+
 #define COMSIG_CLICK_RIGHT_SHIFT "shift_right_click"
+	#define COMPONENT_RELEASE_TO_MOUSEDROPPED (1<<0)
+
+#define COMSIG_STORAGE_CAN_BE_INSERTED "can_be_inserted"		//from base of datum/component/storage/can_be_inserted: (obj/item/storing)
+	#define COMPONENT_STORAGE_BLOCK (1<<0)
 
 // /area signals
 #define COMSIG_AREA_ENTERED "area_entered" 						//from base of area/Entered(): (atom/movable/M)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -611,6 +611,9 @@
 
 	var/atom/A = parent
 	A.add_fingerprint(M)
+	if(SEND_SIGNAL(over_object, COMSIG_STORAGE_MOUSEDROP, src, parent) & COMPONENT_RELEASE_TO_MOUSEDROPPED)
+		. = NONE
+		return
 	// this must come before the screen objects only block, dunno why it wasn't before
 	if(over_object == M)
 		user_show_to_mob(M)
@@ -646,9 +649,6 @@
 			if(!L.incapacitated() && I == L.get_active_held_item())
 				if(!SEND_SIGNAL(I, COMSIG_CONTAINS_STORAGE) && can_be_inserted(I, FALSE))	//If it has storage it should be trying to dump, not insert.
 					handle_item_insertion(I, FALSE, L)
-
-/obj/item/proc/StorageBlock(obj/item/I, mob/user)
-	return FALSE
 
 /obj
 	var/component_block = FALSE
@@ -709,8 +709,6 @@
 			if(!stop_messages)
 				to_chat(M, span_warning("[IP] cannot hold [I] as it's a storage item of the same size!"))
 			return FALSE //To prevent the stacking of same sized storage items.
-		if(IP.StorageBlock(I, M))
-			return FALSE
 	if(HAS_TRAIT(I, TRAIT_NODROP)) //SHOULD be handled in unEquip, but better safe than sorry.
 		if(!stop_messages)
 			to_chat(M, span_warning("\the [I] is stuck to your hand, you can't put it in \the [host]!"))

--- a/code/game/objects/items/storage/new_storage/tetris.dm
+++ b/code/game/objects/items/storage/new_storage/tetris.dm
@@ -287,6 +287,8 @@
 		if(!stop_messages)
 			to_chat(user, span_warning("[storing] won't fit in [host], make some space!"))
 		return FALSE
+	if(SEND_SIGNAL(host, COMSIG_STORAGE_CAN_BE_INSERTED, storing, user) & COMPONENT_STORAGE_BLOCK)
+		return FALSE
 	if(isitem(host))
 		var/obj/item/host_item = host
 		var/datum/component/storage/storage_internal = storing.GetComponent(/datum/component/storage)
@@ -294,8 +296,6 @@
 			if(!stop_messages)
 				to_chat(user, span_warning("[host_item] cannot hold [storing] as it's a storage item of the same size!"))
 			return FALSE //To prevent the stacking of same sized storage items
-		if(host_item.StorageBlock(storing, user))
-			return FALSE
 	//SHOULD be handled in unEquip, but better safe than sorry
 	if(HAS_TRAIT(storing, TRAIT_NODROP))
 		if(!stop_messages)

--- a/code/game/objects/structures/roguetown/handcart.dm
+++ b/code/game/objects/structures/roguetown/handcart.dm
@@ -225,7 +225,7 @@
 		L.stop_pulling()
 
 	else if(isobj(AM))
-		if((AM.density) || AM.anchored || AM.has_buckled_mobs())
+		if(AM.anchored || AM.has_buckled_mobs())
 			return FALSE
 		else
 			if(isitem(AM))

--- a/code/game/objects/structures/roguetown/handcart.dm
+++ b/code/game/objects/structures/roguetown/handcart.dm
@@ -122,6 +122,9 @@
 	var/atom/L = drop_location()
 	for(var/atom/movable/AM in src)
 		AM.forceMove(L)
+		if(isitem(AM))
+			AM.pixel_x = rand(-8, 8)
+			AM.pixel_y = rand(-8, 8)
 
 /obj/structure/handcart/MouseDrop_T(atom/movable/mousedropping, mob/living/user)
 	if(!istype(mousedropping) || !isturf(mousedropping.loc) || istype(mousedropping, /atom/movable/screen))

--- a/code/game/objects/structures/roguetown/handcart.dm
+++ b/code/game/objects/structures/roguetown/handcart.dm
@@ -8,14 +8,11 @@
 	anchored = FALSE
 	climbable = TRUE
 
-	var/list/stuff_shit = list()
-
 	var/current_capacity = 0
-	var/maximum_capacity = 60 //arbitrary maximum amount of weight allowed in the cart before it says fuck off
+	/// Maximujm amount of weight the cart can hold
+	var/maximum_capacity = 60
 
-	var/arbitrary_living_creature_weight = 10 // The arbitrary weight for any thing of a mob and living variety
 	var/upgrade_level = 0 // This is the carts upgrade level, capacity increases with upgrade level
-	var/obj/item/cart_upgrade/upgrade = null
 	facepull = FALSE
 	throw_range = 1
 
@@ -33,16 +30,12 @@
 	desc = "A wheelbrace, skillfully cut by a woodworker that can increase the carry capacity of a wooden cart."
 	icon_state = "upgrade"
 	ulevel = 1
-	//filters = filter(type="drop_shadow", x=0, y=0, size=0.5, offset=1, color=rgb(26, 13, 150, 150))
-	//Commented out the filter effect until I or somebody else can properly fix it I guess
 
 /obj/item/cart_upgrade/level_2
 	name = "reinforced woodcutters wheelbrace"
 	desc = "A wheelbrace, expertly crafted by a woodworker that can further increase the carry capacity of a wooden cart. The first upgrade is required for this one to function."
 	icon_state = "upgrade2"
 	ulevel = 2
-	//filters = filter(type="drop_shadow", x=0, y=0, size=0.5, offset=1, color=rgb(32, 196, 218, 200))
-	//Commented out the filter effect until I or somebody else can properly fix it I guess
 
 /obj/structure/handcart/examine(mob/user)
 	. = ..()
@@ -50,143 +43,160 @@
 		. += span_notice("This cart has a <i>level 1</i> woodcutters wheelbrace instaled.")
 	else if(upgrade_level == 2)
 		. += span_notice("This cart has a <i>level 2</i> woodcutters wheelbrace instaled.")
+	. += span_notice("[span_bold("Drag")] large items such as chests or people onto this to load them in.")
+	. += span_notice("[span_bold("Lie down")] and drag yourself onto it to climb inside.")
+	. += span_notice("[span_bold("Right click")] to dump it out.")
 
-/obj/structure/handcart/proc/manage_upgrade()
-	switch(upgrade_level)
+
+/obj/structure/handcart/proc/manage_upgrade(/obj/item/cart_upgrade/upgrade, mob/living/user)
+	if(upgrade_level == upgrade.ulevel)
+		to_chat(user, span_warn("[src] already has an upgrade of that type."))
+		return
+	switch(upgrade.ulevel)
 		if(1)
 			maximum_capacity = 90
 		if(2)
 			maximum_capacity = 120
+	to_chat(user, span_notice("You install [upgrade] into [src]."))
+	qdel(upgrade)
 	update_icon()
 
 /obj/structure/handcart/Initialize(mapload)
+	RegisterSignal(src, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_EXITED), PROC_REF(contents_changed))
+	RegisterSignal(src, COMSIG_STORAGE_MOUSEDROP, PROC_REF(commandeer_mousedrop))
 	if(mapload)		// if closed, any item at the crate's loc is put in the contents
 		addtimer(CALLBACK(src, PROC_REF(take_contents)), 0)
 	. = ..()
-	update_icon()
+
+/obj/structure/handcart/Destroy()
+	UnregisterSignal(src, list(COMSIG_STORAGE_MOUSEDROP, COMSIG_ATOM_ENTERED, COMSIG_ATOM_EXITED))
+	dump_contents()
+	return ..()
+
+/obj/structure/handcart/proc/commandeer_mousedrop(datum/source, datum/component/storage/storage_datum, atom/actual_dropped_atom)
+	SIGNAL_HANDLER
+
+	if(isitem(actual_dropped_atom))
+		return NONE
+	return COMPONENT_RELEASE_TO_MOUSEDROPPED
 
 /obj/structure/handcart/container_resist(mob/living/user)
-	var/atom/L = drop_location()
-	for(var/atom/movable/AM in stuff_shit)
-		if(AM == user)
-			AM.forceMove(L)
-			stuff_shit -= AM
-			current_capacity = max(current_capacity-arbitrary_living_creature_weight, 0)
-			update_icon()
-			break
+	visible_message(span_notice("[src] rocks slightly as something inside seems to be jostling forcefully."), vision_distance = 3)
+	if(user.incapacitated())
+		// Resist logic chain will cause them to attempt to remove their cuffs regardless
+		// so they need to do that before they can escape the cart
+		return FALSE
+	to_chat(user, "You clamber out of [src].")
+	user.forceMove(drop_location())
+
+/obj/structure/handcart/proc/contents_changed(datum/source, atom/movable/atom_moving)
+	SIGNAL_HANDLER
+
+	// Don't do anything if it's not a real object
+	if(!istype(atom_moving, /obj) && !istype(atom_moving, /mob/living))
+		return NONE
+	recalculate_weight(atom_moving)
+
+/obj/structure/handcart/proc/recalculate_weight(atom/movable/moved_atom)
+	var/weight
+	var/entering = (moved_atom.loc == src)
+	if(isliving(moved_atom))
+		var/mob/living/moved_living = moved_atom
+		weight = min(moved_living.mob_size * 5, 1)
+	else if(isitem(moved_atom))
+		var/obj/item/moved_item = moved_atom
+		weight = moved_item.w_class
+	else // presumably a mobile structure or machine, assume they're all roughly twice as big as a person
+		weight = MOB_SIZE_HUMAN * 5 * 2 // 2 * 5 * 2
+	if(entering)
+		current_capacity += weight
+		if(current_capacity > maximum_capacity)
+			//shortened distance on this message to minimize the potential of it being spammed
+			visible_message(span_warn("[moved_atom] is simply too big to fit within the space remaining inside [src], and it tumbles out."), vision_distance = 1)
+			moved_atom.forceMove(drop_location())
+	else
+		current_capacity -= weight
+	update_icon()
 
 /obj/structure/handcart/dump_contents()
 	var/atom/L = drop_location()
 	for(var/atom/movable/AM in src)
 		AM.forceMove(L)
-	stuff_shit = list()
-	current_capacity = 0
 
-/obj/structure/handcart/Destroy()
-	dump_contents()
+/obj/structure/handcart/MouseDrop_T(atom/movable/mousedropping, mob/living/user)
+	if(!istype(mousedropping) || !isturf(mousedropping.loc) || istype(mousedropping, /atom/movable/screen))
+		return FALSE
+	if(!istype(user) || user.incapacitated())
+		return FALSE
+	if(!Adjacent(user) || !user.Adjacent(mousedropping))
+		return FALSE
+	if(user == mousedropping) //try to climb into or onto it
+		if(user.mobility_flags & MOBILITY_STAND)
+			return ..()
+		if(!do_after(user, 20, target = src))
+			return FALSE
+		put_in(mousedropping, user)
+		return TRUE
+	if(!insertion_allowed(mousedropping, user))
+		return FALSE
+	if(!put_in(mousedropping, user))
+		return FALSE
+	return TRUE
+			
+/obj/structure/handcart/attackby(obj/item/I, mob/user, params)
+	if(user.cmode)
+		return ..()
+	if(istype(I, /obj/item/cart_upgrade))
+		manage_upgrade(I, user)
+		return TRUE
+	if(!insertion_allowed(I, user))
+		return NONE
+	if(put_in(I, user))
+		playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
+		return TRUE
 	return ..()
 
-/obj/structure/handcart/MouseDrop_T(atom/movable/O, mob/living/user)
-	if(!istype(O) || !isturf(O.loc) || istype(O, /atom/movable/screen))
-		return
-	if(!istype(user) || user.incapacitated())
-		return
-	if(!Adjacent(user) || !user.Adjacent(O))
-		return
-	if(user == O) //try to climb into or onto it
-		if(!(user.mobility_flags & MOBILITY_STAND))
-			if(!do_after(user, 20, target = src))
-				return FALSE
-			if(put_in(O))
-				playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
-			return TRUE
-		return ..()
-	if(!insertion_allowed(O))
-		return
-	//only these intents should be able to move objects into handcarts
-	if(user.used_intent.type == INTENT_HELP || user.used_intent.type == /datum/intent/grab/move)
-		if(isliving(O))
-			var/list/targets = list(O, src)
-			if(!do_after_mob(user, targets, 20))
-				return FALSE
-		if(put_in(O))
-			playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
-		return TRUE
-
-/obj/structure/handcart/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/cart_upgrade))
-		var/obj/item/cart_upgrade/item = I
-		if(item.ulevel == 1)
-			if(upgrade_level != 0)
-				to_chat(user, "<span class='warning'>This wheelbrace is obsolete.</span>")
-				return
-			else
-				upgrade = item
-				upgrade_level = item.ulevel
-				qdel(item)
-				manage_upgrade()
-				playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
-		if(item.ulevel == 2)
-			if(upgrade_level != 1)
-				to_chat(user, "<span class='warning'>The cart needs a normal wheelbrace before this one can be used!</span>")
-				return
-			else
-				upgrade = item
-				upgrade_level = item.ulevel
-				qdel(item)
-				manage_upgrade()
-				playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
-	if(!user.cmode)
-		if(!insertion_allowed(I))
-			return
-		if(put_in(I, user))
-			playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
-		return
-	..()
-
-/obj/structure/handcart/attack_hand(mob/living/user)
-	. = ..()
-	if(.)
-		return
-	if(user.cmode)
-		return
-	var/turf/T = get_turf(user)
-	if(isturf(T))
-		user.changeNext_move(CLICK_CD_MELEE)
-		var/fou
-		for(var/obj/item/I in T)
-			if(!insertion_allowed(I))
-				continue
-			put_in(I)
-			fou = TRUE
-		if(fou)
-			playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
-
-/obj/structure/handcart/proc/put_in(atom/movable/O, mob/user)
-	var/weight = 0
-	if(isitem(O))
-		var/obj/item/I = O
-		if((current_capacity + I.w_class) > maximum_capacity)
-			return FALSE
-		weight = I.w_class
-	if(isliving(O))
-		if((current_capacity + arbitrary_living_creature_weight) > maximum_capacity)
-			return FALSE
-		weight = arbitrary_living_creature_weight
-	if(user && !user.transferItemToLoc(O, src))
+/obj/structure/handcart/interact(mob/living/user)
+	var/turf/user_turf = get_turf(user)
+	if(user_turf != user.loc)
 		return FALSE
-	else
-		O.forceMove(src)
-	current_capacity += weight
-	stuff_shit += O
-	update_icon()
+	for(var/obj/item/I in user_turf)
+		if(!insertion_allowed(I, user))
+			continue
+		put_in(I, user)
+
+/obj/structure/handcart/attack_right(mob/user)
+	if(!can_interact(user))
+		return FALSE
+	if(!length(contents))
+		to_chat(user, span_notice("But [src] is already empty."))
+		return FALSE
+	user.changeNext_move(CLICK_CD_MELEE)
+	dump_contents()
+	visible_message(span_info("[user] dumps out [src]!"))
+	playsound(loc, 'sound/foley/cartdump.ogg', 100, FALSE, -1)
+	return TRUE
+
+/obj/structure/handcart/proc/put_in(atom/movable/moved_atom, mob/user)
+	if(isitem(moved_atom))
+		if(!user.transferItemToLoc(moved_atom, src))
+			return FALSE
+		. = TRUE
+	else // we already checked if it's allowed to be moved into here
+		user.visible_message(span_notice("[user] starts moving [moved_atom] into [src]..."))
+		if(!do_after_mob(user, moved_atom, 2 SECONDS))
+			return FALSE
+		moved_atom.forceMove(src)
+		. = TRUE
+	if(.)
+		playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
 	return TRUE
 
 /obj/structure/handcart/proc/take_contents()
 	var/atom/L = drop_location()
-	for(var/atom/movable/AM in L)
-		if(AM != src && put_in(AM)) // limit reached
-			break
+	for(var/atom/movable/AM as anything in L)
+		if(AM != src && insertion_allowed(AM, null))
+			AM.forceMove(src)
 
 /obj/structure/handcart/update_icon()
 	. = ..()
@@ -196,46 +206,60 @@
 			add_overlay("ov_upgrade")
 		if(upgrade_level == 2)
 			add_overlay("ov_upgrade2")
-	if(stuff_shit.len)
+	if(length(contents))
 		icon_state = "cart-full"
 	else
 		icon_state = "cart-empty"
 
-/obj/structure/handcart/attack_right(mob/user)
-	. = ..()
-	if(.)
-		return
-	user.changeNext_move(CLICK_CD_MELEE)
-	if(stuff_shit.len)
-		dump_contents()
-		visible_message(span_info("[user] dumps out [src]!"))
-		playsound(loc, 'sound/foley/cartdump.ogg', 100, FALSE, -1)
-	update_icon()
+/obj/structure/handcart/proc/try_mob_insert(mob/living/inserted_mob, mob/living/user)
+	. = TRUE
+	var/to_user = null
+	if(!istype(inserted_mob))
+		. = FALSE
+	else if(!isliving(inserted_mob)) //let's not put ghosts or camera mobs inside closets...
+		. = FALSE
+	else if(inserted_mob.anchored)
+		to_user = span_warn("You can't seem to move [span_bold("[inserted_mob]")].")
+		. = FALSE
+	else if((inserted_mob.buckled && inserted_mob.buckled != src))
+		to_user = span_warn("Unbuckle [span_bold("[inserted_mob]")] first!")
+		. = FALSE
+	else if(inserted_mob.incorporeal_move)
+		to_user = span_warn("Your hands phase right through [span_bold("[inserted_mob]")]!")
+		. = FALSE
+	else if(inserted_mob.has_buckled_mobs())
+		to_user = span_warn("You can only move one living thing at a time into [span_bold("[src]")].")
+		. = FALSE
+	if(istype(user) && !isnull(to_user))
+		to_chat(user, to_user)
+	return .
 
-/obj/structure/handcart/proc/insertion_allowed(atom/movable/AM)
-	if(ismob(AM))
-		if(!isliving(AM)) //let's not put ghosts or camera mobs inside closets...
-			return FALSE
-		var/mob/living/L = AM
-		if(L.anchored || (L.buckled && L.buckled != src) || L.incorporeal_move || L.has_buckled_mobs())
-			return FALSE
-		if(L.mob_size > MOB_SIZE_TINY) // Tiny mobs are treated as items.
-			if(L.density)
-				return FALSE
-		L.stop_pulling()
+/obj/structure/handcart/proc/try_obj_insert(obj/inserted_object, mob/living/user)
+	. = TRUE
+	var/to_user = null
+	if(!istype(inserted_object))
+		. = FALSE
+	else if(inserted_object.anchored)
+		to_user = span_warn("You can't seem to move [span_bold("[inserted_object]")].")
+		. = FALSE
+	else if(inserted_object.has_buckled_mobs())
+		to_user = span_warn("Unbuckle everything on [span_bold("[inserted_object]")] first.")
+		. = FALSE
+	else if(isitem(inserted_object))
+		var/obj/item/inserted_item = inserted_object
+		if(HAS_TRAIT(inserted_item, TRAIT_NODROP) || inserted_item.item_flags & ABSTRACT)
+			. = FALSE
+	if(istype(user) && !isnull(to_user))
+		to_chat(user, to_user)
+	return .
 
-	else if(isobj(AM))
-		if(AM.anchored || AM.has_buckled_mobs())
-			return FALSE
-		else
-			if(isitem(AM))
-				var/obj/item/I = AM
-				if(HAS_TRAIT(I, TRAIT_NODROP) || I.item_flags & ABSTRACT)
-					return FALSE
-	else // not a mob or object
+/obj/structure/handcart/proc/insertion_allowed(atom/movable/AM, mob/living/user)
+	if(!ismovable(AM))
 		return FALSE
-
-	return TRUE
+	if(ismob(AM))
+		return try_mob_insert(AM, user)
+	if(isobj(AM))
+		return try_obj_insert(AM, user)
 
 /obj/structure/handcart/Move(atom/newloc, direct, glide_size_override)
 	. = ..()

--- a/code/game/objects/structures/roguetown/handcart.dm
+++ b/code/game/objects/structures/roguetown/handcart.dm
@@ -48,7 +48,7 @@
 	. += span_notice("[span_bold("Right click")] to dump it out.")
 
 
-/obj/structure/handcart/proc/manage_upgrade(/obj/item/cart_upgrade/upgrade, mob/living/user)
+/obj/structure/handcart/proc/manage_upgrade(obj/item/cart_upgrade/upgrade, mob/living/user)
 	if(upgrade_level == upgrade.ulevel)
 		to_chat(user, span_warn("[src] already has an upgrade of that type."))
 		return
@@ -100,11 +100,13 @@
 /obj/structure/handcart/proc/recalculate_weight(atom/movable/moved_atom)
 	var/weight
 	var/entering = (moved_atom.loc == src)
+	var/mob/living/moved_living = null
+	var/obj/item/moved_item = null
 	if(isliving(moved_atom))
-		var/mob/living/moved_living = moved_atom
+		moved_living = moved_atom
 		weight = min(moved_living.mob_size * 5, 1)
 	else if(isitem(moved_atom))
-		var/obj/item/moved_item = moved_atom
+		moved_item = moved_atom
 		weight = moved_item.w_class
 	else // presumably a mobile structure or machine, assume they're all roughly twice as big as a person
 		weight = MOB_SIZE_HUMAN * 5 * 2 // 2 * 5 * 2
@@ -114,6 +116,7 @@
 			//shortened distance on this message to minimize the potential of it being spammed
 			visible_message(span_warn("[moved_atom] is simply too big to fit within the space remaining inside [src], and it tumbles out."), vision_distance = 1)
 			moved_atom.forceMove(drop_location())
+			moved_item?.after_throw()	
 	else
 		current_capacity -= weight
 	update_icon()
@@ -123,8 +126,8 @@
 	for(var/atom/movable/AM in src)
 		AM.forceMove(L)
 		if(isitem(AM))
-			AM.pixel_x = rand(-8, 8)
-			AM.pixel_y = rand(-8, 8)
+			var/obj/item/moved_item = AM
+			moved_item.after_throw()
 
 /obj/structure/handcart/MouseDrop_T(atom/movable/mousedropping, mob/living/user)
 	if(!istype(mousedropping) || !isturf(mousedropping.loc) || istype(mousedropping, /atom/movable/screen))

--- a/code/game/objects/structures/roguetown/handcart.dm
+++ b/code/game/objects/structures/roguetown/handcart.dm
@@ -133,8 +133,6 @@
 	if(user == mousedropping) //try to climb into or onto it
 		if(user.mobility_flags & MOBILITY_STAND)
 			return ..()
-		if(!do_after(user, 20, target = src))
-			return FALSE
 		put_in(mousedropping, user)
 		return TRUE
 	if(!insertion_allowed(mousedropping, user))
@@ -152,7 +150,6 @@
 	if(!insertion_allowed(I, user))
 		return NONE
 	if(put_in(I, user))
-		playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
 		return TRUE
 	return ..()
 
@@ -178,7 +175,12 @@
 	return TRUE
 
 /obj/structure/handcart/proc/put_in(atom/movable/moved_atom, mob/user)
-	if(isitem(moved_atom))
+	if(moved_atom == user)
+		user.visible_message(span_notice("[user] starts shimmying up inside of [src]..."))
+		if(!do_after(user, 2 SECONDS))
+			return FALSE
+		. = TRUE
+	else if(isitem(moved_atom))
 		if(!user.transferItemToLoc(moved_atom, src))
 			return FALSE
 		. = TRUE
@@ -186,10 +188,10 @@
 		user.visible_message(span_notice("[user] starts moving [moved_atom] into [src]..."))
 		if(!do_after_mob(user, moved_atom, 2 SECONDS))
 			return FALSE
-		moved_atom.forceMove(src)
 		. = TRUE
 	if(.)
 		playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
+		moved_atom.forceMove(src)
 	return TRUE
 
 /obj/structure/handcart/proc/take_contents()

--- a/code/modules/admin/verbs/beakerpanel.dm
+++ b/code/modules/admin/verbs/beakerpanel.dm
@@ -8,7 +8,7 @@
 
 /proc/beakersforbeakers()
 	. = list()
-	for(var/t in subtypesof(/obj/item/reagent_containers) + list(/obj/structure/fermentation_keg, /obj/item/roguebin))
+	for(var/t in subtypesof(/obj/item/reagent_containers) + list(/obj/structure/fermentation_keg, /obj/structure/roguebin))
 		var/obj/item/reagent_containers/C = t
 		. += list(list("id" = t, "text" = initial(C.name), "volume" = initial(C.volume)))
 

--- a/code/modules/farming/big_liquid_containers.dm
+++ b/code/modules/farming/big_liquid_containers.dm
@@ -1,12 +1,12 @@
 // For storing roguebin and fermenting barrel or something
 
 // Bin
-/obj/item/roguebin/water/Initialize()
+/obj/structure/roguebin/water/Initialize()
 	. = ..()
 	reagents.add_reagent(/datum/reagent/water,500)
 	update_icon()
 
-/obj/item/roguebin/water/gross/Initialize()
+/obj/structure/roguebin/water/gross/Initialize()
 	. = ..()
 	reagents.add_reagent(/datum/reagent/water/gross,500)
 	update_icon()

--- a/code/modules/farming/bin.dm
+++ b/code/modules/farming/bin.dm
@@ -1,4 +1,4 @@
-/obj/item/roguebin
+/obj/structure/roguebin
 	name = "wood bin"
 	desc = "A washbin, a trashbin, a bloodbin... Your choices are limitless."
 	icon = 'icons/roguetown/misc/structure.dmi'
@@ -8,7 +8,6 @@
 	opacity = FALSE
 	anchored = FALSE
 	max_integrity = 300
-	w_class = WEIGHT_CLASS_GIGANTIC
 	var/kover = FALSE
 	drag_slowdown = 2
 	throw_speed = 1
@@ -16,11 +15,11 @@
 	blade_dulling = DULLING_BASHCHOP
 	obj_flags = CAN_BE_HIT
 
-/obj/item/roguebin/weather_trigger(W)
+/obj/structure/roguebin/weather_trigger(W)
 	if(W==/datum/weather/rain)
 		START_PROCESSING(SSweather,src)
 
-/obj/item/roguebin/Initialize()
+/obj/structure/roguebin/Initialize()
 	if(!base_state)
 		create_reagents(600, DRAINABLE | AMOUNT_VISIBLE | REFILLABLE)
 		icon_state = "washbin[rand(1,2)]"
@@ -30,8 +29,9 @@
 	pixel_x = 0
 	pixel_y = 0
 	update_icon()
+	RegisterSignal(src, COMSIG_STORAGE_CAN_BE_INSERTED, PROC_REF(storage_block))
 
-/obj/item/roguebin/Destroy()
+/obj/structure/roguebin/Destroy()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	if(STR)
 		var/list/things = STR.contents()
@@ -40,7 +40,7 @@
 	return ..()
 
 
-/obj/item/roguebin/update_icon()
+/obj/structure/roguebin/update_icon()
 	if(kover)
 		icon_state = "[base_state]over"
 	else
@@ -53,7 +53,7 @@
 			filling.alpha = mix_alpha_from_reagents(reagents.reagent_list)
 			add_overlay(filling)
 
-/obj/item/roguebin/onkick(mob/user)
+/obj/structure/roguebin/onkick(mob/user)
 	if(isliving(user))
 		var/mob/living/L = user
 		if(kover)
@@ -78,13 +78,13 @@
 			user.visible_message(span_warning("[user] kicks [src]!"), \
 				span_warning("I kick [src]!"))
 
-/obj/item/roguebin/attack_hand(mob/user)
+/obj/structure/roguebin/attack_hand(mob/user)
 	var/datum/component/storage/CP = GetComponent(/datum/component/storage)
 	if(CP)
 		CP.rmb_show(user)
 		return TRUE
 
-/obj/item/roguebin/attack_right(mob/user)
+/obj/structure/roguebin/attack_right(mob/user)
 	. = ..()
 	if(.)
 		return
@@ -131,18 +131,18 @@
 					reagents.add_reagent(/datum/reagent/water/gross, amount_to_dirty)
 			return
 
-//We need to use this or the object will be put in storage instead of attacking it
-/obj/item/roguebin/StorageBlock(obj/item/I, mob/user)
-	if(user.used_intent)
-		if(user.used_intent.type in list(/datum/intent/fill,/datum/intent/pour,/datum/intent/splash))
-			return TRUE
+/obj/structure/roguebin/proc/storage_block(datum/source, obj/item/I, mob/user)
+	SIGNAL_HANDLER
+
+	if(user.used_intent?.type in list(/datum/intent/fill,/datum/intent/pour,/datum/intent/splash))
+		return COMPONENT_STORAGE_BLOCK
 	if(istype(I, /obj/item/rogueweapon/tongs))
 		var/obj/item/rogueweapon/tongs/T = I
 		if(T.hingot && istype(T.hingot))
-			return TRUE
-	return FALSE
+			return COMPONENT_STORAGE_BLOCK
+	return NONE
 
-/obj/item/roguebin/attackby(obj/item/I, mob/user, params)
+/obj/structure/roguebin/attackby(obj/item/I, mob/user, params)
 	if(!reagents || !reagents.maximum_volume) //trash
 		return ..()
 	if(istype(I, /obj/item/rogueweapon/tongs))
@@ -228,11 +228,12 @@
 			return
 	. = ..()
 
-/obj/item/roguebin/trash
+/obj/structure/roguebin/trash
 	name = "trash bin"
 	desc = "An eyesore that is meant to make things look cleaner."
 	icon_state = "trashbin"
 	base_state = "trashbin"
 
-/obj/item/roguebin/trash/StorageBlock(obj/item/I, mob/user)
-	return FALSE
+/obj/structure/roguebin/trash/Initialize(mapload)
+	. = ..()
+	UnregisterSignal(src, COMSIG_STORAGE_CAN_BE_INSERTED) //everything will be inserted

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -220,8 +220,8 @@
 		O.visible_message(span_notice("The <font color=[O.color]>paint</font> on [O] washes away!"))
 		O.color = initial(O.color)
 
-	if(istype(O, /obj/item/roguebin))
-		var/obj/item/roguebin/RB = O
+	if(istype(O, /obj/structure/roguebin))
+		var/obj/structure/roguebin/RB = O
 		if(!RB.kover)
 			if(RB.reagents)
 				RB.reagents.add_reagent(src.type, reac_volume)

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -179,7 +179,7 @@
 
 /datum/crafting_recipe/roguetown/roguebin
 	name = "wooden bin"
-	result = /obj/item/roguebin
+	result = /obj/structure/roguebin
 	reqs = list(/obj/item/grown/log/tree/small = 2)
 	verbage_simple = "make"
 	verbage = "makes"

--- a/code/modules/roguetown/roguestock/import.dm
+++ b/code/modules/roguetown/roguestock/import.dm
@@ -5,11 +5,11 @@
 /datum/roguestock/import/crackers
 	name = "Bin of Rations"
 	desc = "Low moisture bread that keeps well."
-	item_type = /obj/item/roguebin/crackers
+	item_type = /obj/structure/roguebin/crackers
 	export_price = 100
 	importexport_amt = 1
 
-/obj/item/roguebin/crackers/Initialize()
+/obj/structure/roguebin/crackers/Initialize()
 	. = ..()
 	new /obj/item/reagent_containers/food/snacks/rogue/crackerscooked(src)
 	new /obj/item/reagent_containers/food/snacks/rogue/crackerscooked(src)
@@ -321,7 +321,7 @@
 	new /obj/item/natural/stone(src)
 	new /obj/item/natural/stone(src)
 	new /obj/item/natural/stone(src)
-	new /obj/item/roguebin(src)
+	new /obj/structure/roguebin(src)
 	new /obj/item/reagent_containers/glass/bucket(src)
 
 /datum/roguestock/import/craftsman


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

This refactors the code on handcarts, as well as giving them the ability to load things like barrels, chests, crates, and so on. As well, I added some feedback messages for why something can't be loaded, or if the cart is too full, and so on.

As well, though it wasn't the primary objective, bins are now refactored to be structures instead of items; they use signals to handle the special considerations necessary for not putting a bucket inside the bin when you meant to dump it in, and so on.

Finally, it adds some extra meat to the description of handcarts so people know.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->


https://github.com/user-attachments/assets/53db7940-2153-4a22-a815-43ef1b27596d


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Handcarts are a cool little thing and this makes them more robust for carrying things like bins and chests, which they are currently unable to do. The changes to bins clean the code up so there isn't a random proc defined on the absolute base /obj/item to handle their work, and instead uses signals, which are cool.