### PR TITLE
Typing Indicator Shows Up Over Blindspots

### DIFF
--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_EMPTY(typing_indicator_overlays)
 	if(ispath(state))
 		var/atom/thing = new state(null)
 		var/mutable_appearance/generated = new(thing)
+		generated.plane = FULLSCREEN_PLANE
 		return generated
 	else
 		CRASH("Unsupported typing indicator state: [state]")
@@ -57,5 +58,6 @@ GLOBAL_LIST_EMPTY(typing_indicator_overlays)
 	icon = 'icons/mob/typing_indicator.dmi'
 	icon_state = "default0"
 	appearance_flags = RESET_COLOR | TILE_BOUND | PIXEL_SCALE
-	layer = 5.1 // ABOVE_FLY_LAYER
+	layer = HUD_LAYER
+	plane = FULLSCREEN_PLANE
 	alpha = 175


### PR DESCRIPTION
## About The Pull Request

other ppl's typing indicators will show up even if they'reb ehind u.

typing indicator will also show up over everything else, so  if ur pixelshifted under someone it'll still appear

## Testing Evidence
<img width="230" height="241" alt="image" src="https://github.com/user-attachments/assets/cb751432-fc7f-43c3-b00e-14992515e5d1" />


<img width="249" height="186" alt="image" src="https://github.com/user-attachments/assets/47301b31-0cd8-4b7d-a26c-433e2c7e8a21" />

<img width="167" height="134" alt="image" src="https://github.com/user-attachments/assets/f22fd32d-676c-4b66-9750-7283b29e8f37" />


## Why It's Good For The Game

I am a code tyrant.
