### PR TITLE
Half-orcs can have feminine body sprites

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
@@ -27,9 +27,9 @@
 	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/mt_muscular.dmi'
-	limbs_icon_f = 'icons/roguetown/mob/bodies/f/ft_muscular.dmi'
+	limbs_icon_f = 'icons/roguetown/mob/bodies/f/fma.dmi'
 	dam_icon = 'icons/roguetown/mob/bodies/dam/dam_male.dmi'
-	dam_icon_f = 'icons/roguetown/mob/bodies/dam/dam_male.dmi'
+	dam_icon_f = 'icons/roguetown/mob/bodies/dam/dam_female.dmi'
 	use_m = TRUE
 	soundpack_m = /datum/voicepack/male/elf
 	soundpack_f = /datum/voicepack/female/elf


### PR DESCRIPTION
.
WIP
## Testing Evidence
.

## Why It's Good For The Game

Mandatory male sprites still carry the air of a Blackstone-era relic, but more customization is always a win. 
Nothing’s being taken away, if someone wants to run a towering, musclebound amazon, they can still choose the muscular frame and add the breasts/genitals to match.
There are slim half-orcs in popular media such as D&D and baldur's gate, mandatory beefiness is RT headcannon.