### PR TITLE
parchment, scroll recipes

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -244,6 +244,20 @@
 	verbage_simple = "put together"
 	verbage = "puts together"
 
+/datum/crafting_recipe/roguetown/survival/paper
+	name = "parchment (x3)"
+	result = list(
+		/obj/item/paper,
+		/obj/item/paper,
+		/obj/item/paper,
+		)
+	reqs = list(
+		/obj/item/grown/log/tree/small = 1,
+		/datum/reagent/water = 32,
+		)
+	structurecraft = /obj/machinery/tanningrack
+	craftdiff = 1
+
 /datum/crafting_recipe/roguetown/survival/paperscroll
 	name = "scroll of parchment (x3)"
 	result = list(
@@ -252,10 +266,9 @@
 		/obj/item/paper/scroll,
 		)
 	reqs = list(
-		/obj/item/grown/log/tree/small = 1,
-		/datum/reagent/water = 48,
+		/obj/item/paper = 3,
+		/obj/item/grown/log/tree/stick = 3,
 		)
-	structurecraft = /obj/machinery/tanningrack
 	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/survival/prosthetic/woodleftarm
@@ -290,8 +303,7 @@
 	name = "tarot deck"
 	result = list(/obj/item/toy/cards/deck/tarot)
 	reqs = list(
-		/obj/item/paper/scroll = 3,
-		/obj/item/grown/log/tree/small = 1,
+		/obj/item/paper = 6,
 		/obj/item/ash = 1,
 		)
 	skillcraft = /datum/skill/misc/reading


### PR DESCRIPTION
makes parchment craftable, changes scrolls to use sticks to match the sprite, changes tarot cards to use 6 parchment instead of scrolls and a log.

## About The Pull Request

Adds a parchment recipe, alters the recipe for scrolls and tarot cards slightly, and to make a little more sense. Craftdiffs are subject to change for balancing.

## Testing Evidence

<img width="252" height="163" alt="image_2025-08-13_233307874" src="https://github.com/user-attachments/assets/1efbe24b-0661-4581-9c50-d6c337ac75e1" />
<img width="131" height="145" alt="image_2025-08-13_233329165" src="https://github.com/user-attachments/assets/39580516-c269-46e5-955a-7ddc57cd524a" />
<img width="234" height="53" alt="image_2025-08-13_233407809" src="https://github.com/user-attachments/assets/403408f3-99d6-48f3-82e6-0661c772fba9" />
<img width="128" height="147" alt="image_2025-08-13_233419941" src="https://github.com/user-attachments/assets/32723fcc-8948-4cc9-bbb4-a099d5729ca3" />


## Why It's Good For The Game

Changes two slapcraft recipes, and adds a recipe to make parchment from a log and water with a drying rack, as it is uncraftable at the moment. (Parchment is only available from mapspawns atm. The goldface "Paper" purchase only spawns scrolls, as well.)
