### PR TITLE
Buffs MILF spawnrate

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1497,7 +1497,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 							if (AGE_ADULT)
 								to_chat(user, "You preside in your 'prime', whatever this may be, and gain no bonus nor endure any penalty for your time spent alive.")
 							if (AGE_MIDDLEAGED)
-								to_chat(user, "Muscles ache and joints begin to slow as Aeon's grasp begins to settle upon your shoulders. (-1 SPD, +1 CON)")
+								to_chat(user, "Muscles ache and joints begin to slow as Aeon's grasp begins to settle upon your shoulders. (-1 SPD, +1 CON, +1 FOR)")
 							if (AGE_OLD)
 								to_chat(user, "In a place as lethal as PSYDONIA, the elderly are all but marvels... or beneficiaries of the habitually privileged. (-1 STR, -2 SPE, -1 PER, -2 CON, +2 INT, +1 FOR)")
 						// LETHALSTONE EDIT END

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1497,7 +1497,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 							if (AGE_ADULT)
 								to_chat(user, "You preside in your 'prime', whatever this may be, and gain no bonus nor endure any penalty for your time spent alive.")
 							if (AGE_MIDDLEAGED)
-								to_chat(user, "Muscles ache and joints begin to slow as Aeon's grasp begins to settle upon your shoulders. (-1 SPD, +1 END)")
+								to_chat(user, "Muscles ache and joints begin to slow as Aeon's grasp begins to settle upon your shoulders. (-1 SPD, +1 CON)")
 							if (AGE_OLD)
 								to_chat(user, "In a place as lethal as PSYDONIA, the elderly are all but marvels... or beneficiaries of the habitually privileged. (-1 STR, -2 SPE, -1 PER, -2 CON, +2 INT, +1 FOR)")
 						// LETHALSTONE EDIT END

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -70,7 +70,7 @@
 		switch(H.age)
 			if(AGE_MIDDLEAGED)
 				change_stat("speed", -1)
-				change_stat("endurance", 1)
+				change_stat("constitution", 1)
 			if(AGE_OLD)
 				change_stat("strength", -1)
 				change_stat("speed", -2)

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -71,6 +71,7 @@
 			if(AGE_MIDDLEAGED)
 				change_stat("speed", -1)
 				change_stat("constitution", 1)
+				change_stat("fortune", 1)
 			if(AGE_OLD)
 				change_stat("strength", -1)
 				change_stat("speed", -2)


### PR DESCRIPTION
## About The Pull Request
Changes the stat modifier from being middle aged from: 
-1 Speed +1 Endurance to:
-1 Speed +1 Constitution +1 Fortune (I'm not updating the rest of the PR description, just look at anything86's comment)

This is in an effort to encourage players to make different types of characters without COMPLETELY stunting themselves.  It's still a "net negative" if you consider speed as 2 statpoints like statpacks and racestats do, but it'll be a bit less punishing towards the middle aged users.

## Testing Evidence

It's a one line change bro

## Why It's Good For The Game

<img width="120" height="81" alt="image" src="https://github.com/user-attachments/assets/c4d09612-fe93-4712-a1ce-e37cf3889096" />

I don't expect this PR to work magic, but I'm hoping it helps people feel a bit more free to make characters they enjoy without feeling like they are dropping an anvil on their foot for no trade.