### PR TITLE
Revive while target spirit is not body fix

### DIFF
--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -126,6 +126,13 @@
 				return FALSE
 			}
 		}
+		var/mob/dead/observer/spirit = target.get_spirit()
+		//GET OVER HERE!
+		if(spirit)
+			var/mob/dead/observer/ghost = spirit.ghostize()
+			qdel(spirit)
+			ghost.mind.transfer_to(target, TRUE)
+		target.grab_ghost(force = FALSE)
 		if(!target.mind)
 			revert_cast()
 			return FALSE
@@ -134,7 +141,7 @@
 			revert_cast()
 			return FALSE
 		if(!target.mind.active)
-			to_chat(user, "Astrata is not done with [target], yet.")
+			to_chat(user, "[target] will not return from afterlife.")
 			revert_cast()
 			return FALSE
 		if(target == user)
@@ -152,22 +159,12 @@
 			target.visible_message(span_danger("[target] is unmade by holy light!"), span_userdanger("I'm unmade by holy light!"))
 			target.gib()
 			return TRUE
-		if(alert(target, "They are calling for you. Are you ready?", "Revival", "I need to wake up", "Don't let me go") != "I need to wake up")
-			target.visible_message(span_notice("Nothing happens. They are not being let go."))
-			return FALSE
 		target.adjustOxyLoss(-target.getOxyLoss()) //Ye Olde CPR
 		if(!target.revive(full_heal = FALSE))
 			to_chat(user, span_warning("Nothing happens."))
 			revert_cast()
 			return FALSE
 		testing("revived2")
-		var/mob/living/carbon/spirit/underworld_spirit = target.get_spirit()
-		//GET OVER HERE!
-		if(underworld_spirit)
-			var/mob/dead/observer/ghost = underworld_spirit.ghostize()
-			qdel(underworld_spirit)
-			ghost.mind.transfer_to(target, TRUE)
-		target.grab_ghost(force = TRUE) // even suicides
 		target.emote("breathgasp")
 		target.Jitter(100)
 		GLOB.scarlet_round_stats[STATS_ASTRATA_REVIVALS]++


### PR DESCRIPTION
## About The Pull Request
Makes anastasis force your spirit back into your body on revive if you ghosted after death but not yet respawned, rather then just cancel revive.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="560" height="154" alt="image" src="https://github.com/user-attachments/assets/25ab114b-da8b-4c2e-ac69-8f4a3c21565a" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Most revives right now gets failed because players are flying aroung as ghost, waiting for their revive which will never occure because there is check for you to be in your body.
If you dont want to be revived so much then respawn and go into observer again.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
