### PR TITLE
Decapitation/Dismemberment Changes

### DIFF
--- a/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
+++ b/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
@@ -32,10 +32,18 @@
 		if(!HAS_TRAIT(C, TRAIT_CRITICAL_WEAKNESS) && !HAS_TRAIT(C, TRAIT_EASYDISMEMBER))	//People with these traits can be decapped standing, or buckled, or however.
 			if(!isnull(C.mind) && (C.mobility_flags & MOBILITY_STAND) && !C.buckled) //Only allows upright decapitations if it's not a player. Unless they're buckled.
 				return FALSE
+			if(!istype(user.rmb_intent, /datum/rmb_intent/strong))
+				return FALSE //Only allow decapitations on Strong stance, unless they have crit weakness/easy dismemberment.
 	if(C.status_flags & GODMODE)
 		return FALSE
 	if(HAS_TRAIT(C, TRAIT_NODISMEMBER))
 		return FALSE
+	if(user)
+		if(zone_precise in list(BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND))
+			return FALSE //No dismemberment on hand/feet.
+		if(!istype(user.rmb_intent, /datum/rmb_intent/strong) && !HAS_TRAIT(C, TRAIT_CRITICAL_WEAKNESS) && !HAS_TRAIT(C, TRAIT_EASYDISMEMBER))
+			if(!prob(10))
+				return FALSE //Only 10% chance of dismembering if not on Strong stance (after the limb is capped out on damage, as per the preceding proc).
 
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner

--- a/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
+++ b/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
@@ -41,9 +41,6 @@
 	if(user)
 		if(zone_precise in list(BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND))
 			return FALSE //No dismemberment on hand/feet.
-		if(!istype(user.rmb_intent, /datum/rmb_intent/strong) && !HAS_TRAIT(C, TRAIT_CRITICAL_WEAKNESS) && !HAS_TRAIT(C, TRAIT_EASYDISMEMBER))
-			if(!prob(10))
-				return FALSE //Only 10% chance of dismembering if not on Strong stance (after the limb is capped out on damage, as per the preceding proc).
 
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner


### PR DESCRIPTION
## About The Pull Request

- Makes decapitations only occur on Strong stance (unless the target has one of two relevant traits).
- Disables dismemberment on hands/feet.
- If not on Strong stance, limb dismemberment is now only a 10% chance after hitting the limb damage threshold (again, negated by crit weakness/easy dismemberment).

## Testing Evidence

<img width="440" height="68" alt="image" src="https://github.com/user-attachments/assets/22b2af7b-0214-44a0-b27d-54eadeb1e85a" />

## Why It's Good For The Game
Decapitations only occurring on Strong intent is a change that has been discussed before and guarantees that decapitations can only happen with explicit intention behind them. No more accidental decapitations.

Dismembering whole arms and legs by aiming for hands or feet has always been contentious and exacerbates the 'gear check' effect of armor being generally useless if you're not sporting a full competitive set, with at least lightly plated boots.

Finally, dismemberment as a whole is too easy at the moment, being guaranteed once you hit the limb damage threshold. This tones it down by making it a chance instead, unless you commit to a rather subpar stance (Strong) to bypass it.
