### PR TITLE
Hotfix an oversight from my leash proc that will cause runtimes

### DIFF
--- a/code/game/objects/items/rogueitems/leash.dm
+++ b/code/game/objects/items/rogueitems/leash.dm
@@ -391,7 +391,7 @@
 					nearby_pet = target
 					break
 			if(!nearby_pet)
-				if(!do_not_remove) // leash will unregister them next process(), to not spontaneously throw pet up a z-level
+				if(leash.leash_pet && !do_not_remove) // leash will unregister them next process(), to not spontaneously throw pet up a z-level
 					leash.leash_pet.remove_status_effect(/datum/status_effect/leash_pet)
 				continue
 			else


### PR DESCRIPTION
## About The Pull Request
Saw the notif that the main PR got merged and had a small nagging feeling that there's something I overlooked about those procs. Sure enough, there was.

When optimizing the earlier checks that see if they're still nearby and that they belong to the person, I neglected the fact that, after that block, we still don't know for sure if the leash even has an assigned pet. This will runtime for people holding a mix of connected and unconnected leashes at the time they teleport to the other travel tile.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
None. Did this on my phone.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Less weird runtimes yippee
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
