### PR TITLE
makes the strap easier to take (from)

### DIFF
--- a/modular_azurepeak/code/game/objects/items/gwstrap.dm
+++ b/modular_azurepeak/code/game/objects/items/gwstrap.dm
@@ -30,7 +30,7 @@
 		if(weps == null)
 			for(var/obj/item/gwstrap/I in user.get_equipped_items(TRUE))
 				to_chat(loc, span_warning("I work the latches of my strap to sheathe [A]."))
-				if(do_after(user, 50, target = user))
+				if(do_after(user, 25, target = user))
 					user.transferItemToLoc(A, weps)
 					weps = A
 					update_icon()
@@ -49,7 +49,7 @@
 	if(weps != null)
 		if(!user.get_active_held_item())
 			to_chat(loc, span_warning("I work the latches of my strap to unsheathe [weps]."))
-			if(do_after(user, 50, target = user))
+			if(do_after(user, 25, target = user))
 				user.put_in_active_hand(weps, user.active_hand_index)
 				name = "greatweapon back-strap"
 				weps = null


### PR DESCRIPTION
## About The Pull Request
I usually throw out the greatweapon strap whenever I spawn with it because it takes so long I don't even want to use it outside of combat
this should half it from I think a 5 second delay to 2.5 seconds, making it still very difficult / unworkable in the middle of combat, but not so excruciatingly cheesegrater-tier to use.
halfing the time seems like a good middle point between "people being able to use this in combat" and "people not wanting to use this fucking thing at all".
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_lirikTaVpx](https://github.com/user-attachments/assets/357bb25d-09cf-4f96-b6de-d9794b98fbd4)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I don't think anybody likes this thing with how long it takes and it gets thrown away every single time
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
