### PR TITLE
Revert "Handcart refactor: Refactored the code, also now you can load things like bins and chests into them, added new feedback messages for doing this and that ADDITIONALLY: refactored bins to be structures and use signals, instead, because it was necessary in the commission of handcart objectives"

### DIFF
--- a/_maps/map_files/dun_manor/azure_coast.dmm
+++ b/_maps/map_files/dun_manor/azure_coast.dmm
@@ -333,7 +333,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
 "bh" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/shelter)
 "bk" = (
@@ -1717,7 +1717,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/cave)
 "kO" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
 "kP" = (
@@ -2538,7 +2538,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/orcdungeon)
 "qz" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/mazedungeon)
 "qA" = (
@@ -3209,7 +3209,7 @@
 	},
 /area/rogue/under/cave/dukecourt)
 "vf" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "vg" = (
@@ -4408,7 +4408,7 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/cave/dukecourt)
 "CP" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/orcdungeon)
 "CQ" = (
@@ -4442,7 +4442,7 @@
 /area/rogue/indoors/cave)
 "CW" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "CZ" = (
@@ -4829,7 +4829,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "FK" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
 "FP" = (

--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -965,7 +965,7 @@
 /obj/effect/decal/wood/herringbone2{
 	dir = 8
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/shelter/woods)
 "hX" = (
@@ -1420,7 +1420,7 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "lD" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
 "lF" = (
@@ -1876,7 +1876,7 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/town/basement)
 "pv" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
 "px" = (
@@ -5072,7 +5072,7 @@
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "PC" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/woods)
 "PD" = (
@@ -5823,7 +5823,7 @@
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/woods)
 "Vt" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet/bogcaves)
 "Vu" = (

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -934,7 +934,7 @@
 	dir = 8
 	},
 /obj/effect/decal/mossy,
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "aEN" = (
@@ -3259,7 +3259,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "cis" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "civ" = (
@@ -3709,7 +3709,7 @@
 /area/rogue/outdoors/town)
 "cyA" = (
 /obj/machinery/light/rogue/torchholder/l,
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "cyB" = (
@@ -4602,7 +4602,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "dcV" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -5419,7 +5419,7 @@
 	dir = 1;
 	icon_state = "borderfall"
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "dCK" = (
@@ -5887,7 +5887,7 @@
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "dVw" = (
@@ -6030,7 +6030,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "dZA" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/town)
 "dZI" = (
@@ -6124,7 +6124,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "edD" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
@@ -7738,7 +7738,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/dwarfin)
 "fnb" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "fnh" = (
@@ -8034,7 +8034,7 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
 "fzA" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
 "fzF" = (
@@ -8793,7 +8793,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/physician)
 "gdQ" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "gdU" = (
@@ -11520,7 +11520,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -11681,7 +11681,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "iqT" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "irf" = (
@@ -12757,7 +12757,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "jdd" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -12943,7 +12943,7 @@
 /turf/open/water/ocean/deep,
 /area/rogue/outdoors/beach)
 "jiX" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "jiY" = (
@@ -13515,7 +13515,7 @@
 /turf/open/water/pond,
 /area/rogue/outdoors/mountains)
 "jHo" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/physician)
@@ -14060,7 +14060,7 @@
 	},
 /area/rogue/indoors/town/physician)
 "jWq" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -14443,7 +14443,7 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
 	},
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
 "knJ" = (
@@ -14493,7 +14493,7 @@
 	},
 /area/rogue/outdoors/town)
 "koH" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "koU" = (
@@ -14651,7 +14651,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "kva" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -16005,7 +16005,7 @@
 	},
 /area/rogue/indoors/town)
 "lkl" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
 "lkr" = (
@@ -16333,7 +16333,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "lvu" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "lvL" = (
@@ -16955,7 +16955,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "lUr" = (
@@ -17798,7 +17798,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "myw" = (
@@ -18519,7 +18519,7 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/shop)
 "mXA" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "mXJ" = (
@@ -18692,7 +18692,7 @@
 /area/rogue/indoors/town/physician)
 "ndv" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "neh" = (
@@ -20075,7 +20075,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
 "nYY" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
 "nZm" = (
@@ -20367,7 +20367,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "oiO" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "oiW" = (
@@ -20889,7 +20889,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "oBK" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "oCc" = (
@@ -20985,7 +20985,7 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "oEl" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
 "oEX" = (
@@ -21180,7 +21180,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/mountains)
 "oMI" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "oMJ" = (
@@ -23167,7 +23167,7 @@
 /area/rogue/indoors/town/manor)
 "qjQ" = (
 /obj/machinery/light/rogue/torchholder/c,
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "qjR" = (
@@ -24603,7 +24603,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rjb" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "rjf" = (
@@ -25544,7 +25544,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "rSG" = (
-/obj/structure/roguebin,
+/obj/item/roguebin,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "rSH" = (
@@ -25879,7 +25879,7 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
 "sfF" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town)
 "sfP" = (
@@ -28885,7 +28885,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "uik" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
@@ -28977,7 +28977,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
 "umb" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
@@ -30790,7 +30790,7 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town/roofs)
 "vJu" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/structure/roguemachine/atm{
 	location_tag = "Keep Front Gate"
 	},
@@ -30811,7 +30811,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "vKL" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "vKT" = (
@@ -32076,7 +32076,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
 "wEc" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = -6;
 	pixel_y = 15
@@ -32464,7 +32464,7 @@
 	dir = 4
 	},
 /obj/effect/decal/wood/herringbone2,
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors)
 "wQt" = (
@@ -33727,7 +33727,7 @@
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "xFm" = (
@@ -33770,7 +33770,7 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
 "xGu" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "xGz" = (

--- a/_maps/map_files/dun_manor/smalldecap.dmm
+++ b/_maps/map_files/dun_manor/smalldecap.dmm
@@ -130,7 +130,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "cp" = (
-/obj/structure/roguebin/trash,
+/obj/item/roguebin/trash,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "cq" = (
@@ -647,7 +647,7 @@
 	},
 /area/rogue/under/cave/undeadmanor)
 "ii" = (
-/obj/structure/roguebin/trash,
+/obj/item/roguebin/trash,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "il" = (
@@ -727,7 +727,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/undeadmanor)
 "iU" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/structure/fluff/walldeco/med2{
 	pixel_y = 32
 	},
@@ -893,7 +893,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
-/obj/structure/roguebin/trash,
+/obj/item/roguebin/trash,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "lI" = (
@@ -1460,7 +1460,7 @@
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/mountains/decap)
 "tO" = (
-/obj/structure/roguebin/trash,
+/obj/item/roguebin/trash,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "tQ" = (
@@ -2099,7 +2099,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "AZ" = (
-/obj/structure/roguebin/trash,
+/obj/item/roguebin/trash,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "Ba" = (
@@ -3307,7 +3307,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
 "QT" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "QX" = (
@@ -3633,7 +3633,7 @@
 /turf/open/lava,
 /area/rogue/under/cave/undeadmanor)
 "Vw" = (
-/obj/structure/roguebin/trash,
+/obj/item/roguebin/trash,
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "VC" = (

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -321,7 +321,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "agm" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
 	},
@@ -727,7 +727,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "amN" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/dwarfin)
 "amS" = (
@@ -3541,7 +3541,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "bgr" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "bgG" = (
@@ -3784,7 +3784,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
 "blt" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -4076,7 +4076,7 @@
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/mountains)
 "bqZ" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "bra" = (
@@ -4223,7 +4223,7 @@
 /obj/effect/decal/wood/herringbone2{
 	dir = 8
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/shelter/woods)
 "btj" = (
@@ -5256,7 +5256,7 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
 "bJs" = (
-/obj/structure/roguebin/water{
+/obj/item/roguebin/water{
 	pixel_y = 5
 	},
 /turf/open/floor/rogue/metal,
@@ -5823,7 +5823,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "bSO" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/sewer)
 "bSP" = (
@@ -7478,7 +7478,7 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town)
 "cvV" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "cvX" = (
@@ -9607,7 +9607,7 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach)
 "dgu" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
 "dgv" = (
@@ -13227,7 +13227,7 @@
 /area/rogue/outdoors/beach)
 "epk" = (
 /obj/machinery/light/rogue/torchholder/l,
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "epm" = (
@@ -13290,7 +13290,7 @@
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/effect/decal/cobbleedge{
 	dir = 8;
 	pixel_y = 1
@@ -16314,7 +16314,7 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors)
 "fnZ" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "foa" = (
@@ -17087,7 +17087,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "fAz" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/fishmandungeon)
 "fAA" = (
@@ -18339,7 +18339,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "fVF" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "fVR" = (
@@ -19661,7 +19661,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "gtp" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "gtt" = (
@@ -20055,7 +20055,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "gyL" = (
@@ -20504,7 +20504,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/woods)
 "gGF" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "gGL" = (
@@ -21443,7 +21443,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "gWG" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "gWI" = (
@@ -22134,7 +22134,7 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "hgP" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "hgX" = (
@@ -23775,7 +23775,7 @@
 /turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/shelter/mountains/decap)
 "hFF" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/shelter)
 "hFM" = (
@@ -25082,7 +25082,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
 "icU" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/mazedungeon)
 "icV" = (
@@ -25185,7 +25185,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/fishmandungeon)
 "iea" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "ieb" = (
@@ -26524,7 +26524,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/woods)
 "iAB" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
 "iAF" = (
@@ -26590,7 +26590,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church/chapel)
 "iBx" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblindungeon)
 "iBC" = (
@@ -28092,7 +28092,7 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/basement)
 "iZi" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = 11;
 	pixel_y = -2
@@ -28275,7 +28275,7 @@
 	dir = 4
 	},
 /obj/effect/decal/wood/herringbone2,
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "jcr" = (
@@ -30923,7 +30923,7 @@
 	},
 /area/rogue/indoors/town/garrison)
 "jWX" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "jXb" = (
@@ -32200,7 +32200,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "ktE" = (
@@ -33037,7 +33037,7 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "kFE" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
 "kFJ" = (
@@ -33308,7 +33308,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
 "kKL" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
@@ -33782,7 +33782,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/skeletoncrypt)
 "kUd" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
 "kUe" = (
@@ -34556,7 +34556,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "lhq" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -35552,7 +35552,7 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
 	},
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
 "lxH" = (
@@ -35671,7 +35671,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "lyI" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/sewer)
 "lyJ" = (
@@ -37150,7 +37150,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains)
 "lZM" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "lZN" = (
@@ -37598,7 +37598,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "mgk" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
 "mgq" = (
@@ -37981,7 +37981,7 @@
 /area/rogue/indoors)
 "mmJ" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "mmN" = (
@@ -38157,7 +38157,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
 "mqx" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/mountains/decap)
 "mqz" = (
@@ -38900,7 +38900,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/skeletoncrypt)
 "mDa" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
@@ -41315,7 +41315,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/dukecourt)
 "not" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach)
 "noA" = (
@@ -41598,7 +41598,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "ntR" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
 "ntX" = (
@@ -42297,7 +42297,7 @@
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
 	},
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/basement)
 "nFN" = (
@@ -46061,7 +46061,7 @@
 /area/rogue/indoors/shelter/woods)
 "oRu" = (
 /obj/machinery/light/rogue/torchholder/c,
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "oRv" = (
@@ -47592,7 +47592,7 @@
 	},
 /area/rogue/indoors/town)
 "psu" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "psx" = (
@@ -47677,7 +47677,7 @@
 	},
 /area/rogue/indoors/town/garrison)
 "ptF" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/dwarfin)
 "puw" = (
@@ -47979,7 +47979,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "pyL" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /obj/structure/mirror,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/magician)
@@ -48047,7 +48047,7 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/physician)
 "pzw" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -48807,7 +48807,7 @@
 	},
 /area/rogue/under/town/basement/keep)
 "pKZ" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "pLb" = (
@@ -49882,7 +49882,7 @@
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
 	},
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /obj/effect/decal/cobbleedge{
 	dir = 10;
 	icon_state = "cobbleedge-n"
@@ -51513,7 +51513,7 @@
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/effect/decal/cobbleedge{
 	dir = 9
 	},
@@ -52422,7 +52422,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "qRV" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "qRY" = (
@@ -52499,7 +52499,7 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield/eora)
 "qTk" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/cave)
 "qTl" = (
@@ -53708,7 +53708,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/basement)
 "rob" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
@@ -53858,7 +53858,7 @@
 /area/rogue/outdoors/woods)
 "rqE" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "rqI" = (
@@ -53944,7 +53944,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/sewer)
 "rsI" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/fishmandungeon)
 "rsR" = (
@@ -54190,7 +54190,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
 "rxg" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
 "rxh" = (
@@ -55563,7 +55563,7 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/town/basement/keep)
 "rTU" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "rUb" = (
@@ -55895,7 +55895,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -56410,7 +56410,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
 "sjk" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
@@ -58294,7 +58294,7 @@
 	dir = 1;
 	icon_state = "borderfall"
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "sOC" = (
@@ -58508,7 +58508,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/sewer)
 "sRm" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
 "sRn" = (
@@ -60151,7 +60151,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "ttn" = (
@@ -62115,7 +62115,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "tZJ" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
 "tZR" = (
@@ -62738,7 +62738,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "ukg" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "ukj" = (
@@ -64948,7 +64948,7 @@
 /obj/effect/decal/mossy{
 	dir = 1
 	},
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "uSC" = (
@@ -65393,7 +65393,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "uZN" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "uZQ" = (
@@ -66675,7 +66675,7 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "vvS" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/metal,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "vvU" = (
@@ -67312,7 +67312,7 @@
 /area/rogue/under/cave/scarymaze)
 "vGM" = (
 /obj/machinery/light/rogue/torchholder/c,
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "vGV" = (
@@ -67727,7 +67727,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave)
 "vNR" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "vOc" = (
@@ -68226,7 +68226,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "vWp" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet/bogcaves)
 "vWu" = (
@@ -69595,7 +69595,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "wqT" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/sewer)
 "wra" = (
@@ -71736,7 +71736,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "xaf" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/shelter/mountains/decap)
 "xai" = (
@@ -72936,7 +72936,7 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors)
 "xtp" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "xtD" = (
@@ -73964,7 +73964,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
 "xNg" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
 "xNk" = (
@@ -74631,7 +74631,7 @@
 	dir = 8
 	},
 /obj/effect/decal/mossy,
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "xYM" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -614,7 +614,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue)
 "bn" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue)
 "bo" = (
@@ -1595,7 +1595,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/inhumen)
 "hr" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/banditcamp)
 "hy" = (
@@ -3428,7 +3428,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/inhumen)
 "QX" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -3510,7 +3510,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/banditcamp)
 "TD" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/inhumen)
 "TK" = (

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1970,7 +1970,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "bbO" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "bcu" = (
@@ -2034,7 +2034,7 @@
 	},
 /area/rogue/indoors)
 "bgI" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "bgQ" = (
@@ -2073,7 +2073,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "bkd" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "bke" = (
@@ -2908,7 +2908,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
 "cfY" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/chapel)
 "cgq" = (
@@ -3559,7 +3559,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/roofs)
 "cNr" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
@@ -4122,8 +4122,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "drA" = (
-/obj/structure/roguebin/water/gross,
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "dsu" = (
@@ -5029,7 +5029,7 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church)
 "emM" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
 "emX" = (
@@ -5552,7 +5552,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
 "eSc" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
 	},
@@ -6677,7 +6677,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "gfl" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
 "gfP" = (
@@ -10670,7 +10670,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/town/basement)
 "ksH" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
 "ksI" = (
@@ -11112,7 +11112,7 @@
 	},
 /area/rogue/indoors/town/shop)
 "kSh" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
@@ -12064,7 +12064,7 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves)
 "lXo" = (
-/obj/structure/roguebin/trash,
+/obj/item/roguebin/trash,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "lXJ" = (
@@ -12478,7 +12478,7 @@
 /turf/open/water/sewer,
 /area/rogue/under/cave)
 "muu" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "muz" = (
@@ -13411,7 +13411,7 @@
 "nBo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "nBz" = (
@@ -13460,7 +13460,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "nEj" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/bog)
 "nFg" = (
@@ -13791,7 +13791,7 @@
 	},
 /area/rogue/outdoors/town)
 "nYR" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 32
 	},
@@ -17100,7 +17100,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rKn" = (
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "rLm" = (
@@ -20903,7 +20903,7 @@
 /area/rogue/indoors/town/manor)
 "vKX" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/structure/roguebin/water,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church)
 "vLy" = (
@@ -21490,7 +21490,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "wue" = (
-/obj/structure/roguebin,
+/obj/item/roguebin,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "wuh" = (
@@ -22324,7 +22324,7 @@
 	},
 /area/rogue/under/town/basement)
 "xoS" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "xoT" = (

--- a/_maps/map_files/roguetest/roguetest.dmm
+++ b/_maps/map_files/roguetest/roguetest.dmm
@@ -501,7 +501,7 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors)
 "rf" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "rK" = (

--- a/_maps/map_files/templates/sewers/sewers_bottomleft_2.dmm
+++ b/_maps/map_files/templates/sewers/sewers_bottomleft_2.dmm
@@ -15,7 +15,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "k" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "l" = (

--- a/_maps/map_files/templates/sewers/sewers_topleft_3.dmm
+++ b/_maps/map_files/templates/sewers/sewers_topleft_3.dmm
@@ -233,7 +233,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "S" = (
-/obj/structure/roguebin/crackers,
+/obj/item/roguebin/crackers,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)

--- a/_maps/map_files/templates/smalldungeons/smalldungeon1.dmm
+++ b/_maps/map_files/templates/smalldungeons/smalldungeon1.dmm
@@ -2137,7 +2137,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/dungeon1)
 "Wj" = (
-/obj/structure/roguebin/water/gross,
+/obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
 "Wv" = (

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -180,13 +180,7 @@
 	#define COMPONENT_NO_MOUSEDROP 1
 #define COMSIG_MOUSEDROPPED_ONTO "mousedropped_onto"			//from base of atom/MouseDrop_T: (/atom/from, /mob/user)
 
-#define COMSIG_STORAGE_MOUSEDROP "storage_mousedrop"			//from base of datum/component/storage/mousedrop_onto: (datum/component/storage/storage_datum, atom/actual_dropped_atom)
-
 #define COMSIG_CLICK_RIGHT_SHIFT "shift_right_click"
-	#define COMPONENT_RELEASE_TO_MOUSEDROPPED (1<<0)
-
-#define COMSIG_STORAGE_CAN_BE_INSERTED "can_be_inserted"		//from base of datum/component/storage/can_be_inserted: (obj/item/storing)
-	#define COMPONENT_STORAGE_BLOCK (1<<0)
 
 // /area signals
 #define COMSIG_AREA_ENTERED "area_entered" 						//from base of area/Entered(): (atom/movable/M)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -611,9 +611,6 @@
 
 	var/atom/A = parent
 	A.add_fingerprint(M)
-	if(SEND_SIGNAL(over_object, COMSIG_STORAGE_MOUSEDROP, src, parent) & COMPONENT_RELEASE_TO_MOUSEDROPPED)
-		. = NONE
-		return
 	// this must come before the screen objects only block, dunno why it wasn't before
 	if(over_object == M)
 		user_show_to_mob(M)
@@ -649,6 +646,9 @@
 			if(!L.incapacitated() && I == L.get_active_held_item())
 				if(!SEND_SIGNAL(I, COMSIG_CONTAINS_STORAGE) && can_be_inserted(I, FALSE))	//If it has storage it should be trying to dump, not insert.
 					handle_item_insertion(I, FALSE, L)
+
+/obj/item/proc/StorageBlock(obj/item/I, mob/user)
+	return FALSE
 
 /obj
 	var/component_block = FALSE
@@ -709,6 +709,8 @@
 			if(!stop_messages)
 				to_chat(M, span_warning("[IP] cannot hold [I] as it's a storage item of the same size!"))
 			return FALSE //To prevent the stacking of same sized storage items.
+		if(IP.StorageBlock(I, M))
+			return FALSE
 	if(HAS_TRAIT(I, TRAIT_NODROP)) //SHOULD be handled in unEquip, but better safe than sorry.
 		if(!stop_messages)
 			to_chat(M, span_warning("\the [I] is stuck to your hand, you can't put it in \the [host]!"))

--- a/code/game/objects/items/storage/new_storage/tetris.dm
+++ b/code/game/objects/items/storage/new_storage/tetris.dm
@@ -287,8 +287,6 @@
 		if(!stop_messages)
 			to_chat(user, span_warning("[storing] won't fit in [host], make some space!"))
 		return FALSE
-	if(SEND_SIGNAL(host, COMSIG_STORAGE_CAN_BE_INSERTED, storing, user) & COMPONENT_STORAGE_BLOCK)
-		return FALSE
 	if(isitem(host))
 		var/obj/item/host_item = host
 		var/datum/component/storage/storage_internal = storing.GetComponent(/datum/component/storage)
@@ -296,6 +294,8 @@
 			if(!stop_messages)
 				to_chat(user, span_warning("[host_item] cannot hold [storing] as it's a storage item of the same size!"))
 			return FALSE //To prevent the stacking of same sized storage items
+		if(host_item.StorageBlock(storing, user))
+			return FALSE
 	//SHOULD be handled in unEquip, but better safe than sorry
 	if(HAS_TRAIT(storing, TRAIT_NODROP))
 		if(!stop_messages)

--- a/code/game/objects/structures/roguetown/handcart.dm
+++ b/code/game/objects/structures/roguetown/handcart.dm
@@ -8,11 +8,14 @@
 	anchored = FALSE
 	climbable = TRUE
 
-	var/current_capacity = 0
-	/// Maximujm amount of weight the cart can hold
-	var/maximum_capacity = 60
+	var/list/stuff_shit = list()
 
+	var/current_capacity = 0
+	var/maximum_capacity = 60 //arbitrary maximum amount of weight allowed in the cart before it says fuck off
+
+	var/arbitrary_living_creature_weight = 10 // The arbitrary weight for any thing of a mob and living variety
 	var/upgrade_level = 0 // This is the carts upgrade level, capacity increases with upgrade level
+	var/obj/item/cart_upgrade/upgrade = null
 	facepull = FALSE
 	throw_range = 1
 
@@ -30,12 +33,16 @@
 	desc = "A wheelbrace, skillfully cut by a woodworker that can increase the carry capacity of a wooden cart."
 	icon_state = "upgrade"
 	ulevel = 1
+	//filters = filter(type="drop_shadow", x=0, y=0, size=0.5, offset=1, color=rgb(26, 13, 150, 150))
+	//Commented out the filter effect until I or somebody else can properly fix it I guess
 
 /obj/item/cart_upgrade/level_2
 	name = "reinforced woodcutters wheelbrace"
 	desc = "A wheelbrace, expertly crafted by a woodworker that can further increase the carry capacity of a wooden cart. The first upgrade is required for this one to function."
 	icon_state = "upgrade2"
 	ulevel = 2
+	//filters = filter(type="drop_shadow", x=0, y=0, size=0.5, offset=1, color=rgb(32, 196, 218, 200))
+	//Commented out the filter effect until I or somebody else can properly fix it I guess
 
 /obj/structure/handcart/examine(mob/user)
 	. = ..()
@@ -43,168 +50,143 @@
 		. += span_notice("This cart has a <i>level 1</i> woodcutters wheelbrace instaled.")
 	else if(upgrade_level == 2)
 		. += span_notice("This cart has a <i>level 2</i> woodcutters wheelbrace instaled.")
-	. += span_notice("[span_bold("Drag")] large items such as chests or people onto this to load them in.")
-	. += span_notice("[span_bold("Lie down")] and drag yourself onto it to climb inside.")
-	. += span_notice("[span_bold("Right click")] to dump it out.")
 
-
-/obj/structure/handcart/proc/manage_upgrade(obj/item/cart_upgrade/upgrade, mob/living/user)
-	if(upgrade_level == upgrade.ulevel)
-		to_chat(user, span_warn("[src] already has an upgrade of that type."))
-		return
-	switch(upgrade.ulevel)
+/obj/structure/handcart/proc/manage_upgrade()
+	switch(upgrade_level)
 		if(1)
 			maximum_capacity = 90
 		if(2)
 			maximum_capacity = 120
-	to_chat(user, span_notice("You install [upgrade] into [src]."))
-	qdel(upgrade)
 	update_icon()
 
 /obj/structure/handcart/Initialize(mapload)
-	RegisterSignal(src, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_EXITED), PROC_REF(contents_changed))
-	RegisterSignal(src, COMSIG_STORAGE_MOUSEDROP, PROC_REF(commandeer_mousedrop))
 	if(mapload)		// if closed, any item at the crate's loc is put in the contents
 		addtimer(CALLBACK(src, PROC_REF(take_contents)), 0)
 	. = ..()
-
-/obj/structure/handcart/Destroy()
-	UnregisterSignal(src, list(COMSIG_STORAGE_MOUSEDROP, COMSIG_ATOM_ENTERED, COMSIG_ATOM_EXITED))
-	dump_contents()
-	return ..()
-
-/obj/structure/handcart/proc/commandeer_mousedrop(datum/source, datum/component/storage/storage_datum, atom/actual_dropped_atom)
-	SIGNAL_HANDLER
-
-	if(isitem(actual_dropped_atom))
-		return NONE
-	return COMPONENT_RELEASE_TO_MOUSEDROPPED
+	update_icon()
 
 /obj/structure/handcart/container_resist(mob/living/user)
-	visible_message(span_notice("[src] rocks slightly as something inside seems to be jostling forcefully."), vision_distance = 3)
-	if(user.incapacitated())
-		// Resist logic chain will cause them to attempt to remove their cuffs regardless
-		// so they need to do that before they can escape the cart
-		return FALSE
-	to_chat(user, "You clamber out of [src].")
-	user.forceMove(drop_location())
-
-/obj/structure/handcart/proc/contents_changed(datum/source, atom/movable/atom_moving)
-	SIGNAL_HANDLER
-
-	// Don't do anything if it's not a real object
-	if(!istype(atom_moving, /obj) && !istype(atom_moving, /mob/living))
-		return NONE
-	recalculate_weight(atom_moving)
-
-/obj/structure/handcart/proc/recalculate_weight(atom/movable/moved_atom)
-	var/weight
-	var/entering = (moved_atom.loc == src)
-	var/mob/living/moved_living = null
-	var/obj/item/moved_item = null
-	if(isliving(moved_atom))
-		moved_living = moved_atom
-		weight = min(moved_living.mob_size * 5, 1)
-	else if(isitem(moved_atom))
-		moved_item = moved_atom
-		weight = moved_item.w_class
-	else // presumably a mobile structure or machine, assume they're all roughly twice as big as a person
-		weight = MOB_SIZE_HUMAN * 5 * 2 // 2 * 5 * 2
-	if(entering)
-		current_capacity += weight
-		if(current_capacity > maximum_capacity)
-			//shortened distance on this message to minimize the potential of it being spammed
-			visible_message(span_warn("[moved_atom] is simply too big to fit within the space remaining inside [src], and it tumbles out."), vision_distance = 1)
-			moved_atom.forceMove(drop_location())
-			moved_item?.after_throw()	
-	else
-		current_capacity -= weight
-	update_icon()
+	var/atom/L = drop_location()
+	for(var/atom/movable/AM in stuff_shit)
+		if(AM == user)
+			AM.forceMove(L)
+			stuff_shit -= AM
+			current_capacity = max(current_capacity-arbitrary_living_creature_weight, 0)
+			update_icon()
+			break
 
 /obj/structure/handcart/dump_contents()
 	var/atom/L = drop_location()
 	for(var/atom/movable/AM in src)
 		AM.forceMove(L)
-		if(isitem(AM))
-			var/obj/item/moved_item = AM
-			moved_item.after_throw()
+	stuff_shit = list()
+	current_capacity = 0
 
-/obj/structure/handcart/MouseDrop_T(atom/movable/mousedropping, mob/living/user)
-	if(!istype(mousedropping) || !isturf(mousedropping.loc) || istype(mousedropping, /atom/movable/screen))
-		return FALSE
-	if(!istype(user) || user.incapacitated())
-		return FALSE
-	if(!Adjacent(user) || !user.Adjacent(mousedropping))
-		return FALSE
-	if(user == mousedropping) //try to climb into or onto it
-		if(user.mobility_flags & MOBILITY_STAND)
-			return ..()
-		put_in(mousedropping, user)
-		return TRUE
-	if(!insertion_allowed(mousedropping, user))
-		return FALSE
-	if(!put_in(mousedropping, user))
-		return FALSE
-	return TRUE
-			
-/obj/structure/handcart/attackby(obj/item/I, mob/user, params)
-	if(user.cmode)
-		return ..()
-	if(istype(I, /obj/item/cart_upgrade))
-		manage_upgrade(I, user)
-		return TRUE
-	if(!insertion_allowed(I, user))
-		return NONE
-	if(put_in(I, user))
-		return TRUE
+/obj/structure/handcart/Destroy()
+	dump_contents()
 	return ..()
 
-/obj/structure/handcart/interact(mob/living/user)
-	var/turf/user_turf = get_turf(user)
-	if(user_turf != user.loc)
-		return FALSE
-	for(var/obj/item/I in user_turf)
-		if(!insertion_allowed(I, user))
-			continue
-		put_in(I, user)
+/obj/structure/handcart/MouseDrop_T(atom/movable/O, mob/living/user)
+	if(!istype(O) || !isturf(O.loc) || istype(O, /atom/movable/screen))
+		return
+	if(!istype(user) || user.incapacitated())
+		return
+	if(!Adjacent(user) || !user.Adjacent(O))
+		return
+	if(user == O) //try to climb into or onto it
+		if(!(user.mobility_flags & MOBILITY_STAND))
+			if(!do_after(user, 20, target = src))
+				return FALSE
+			if(put_in(O))
+				playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
+			return TRUE
+		return ..()
+	if(!insertion_allowed(O))
+		return
+	//only these intents should be able to move objects into handcarts
+	if(user.used_intent.type == INTENT_HELP || user.used_intent.type == /datum/intent/grab/move)
+		if(isliving(O))
+			var/list/targets = list(O, src)
+			if(!do_after_mob(user, targets, 20))
+				return FALSE
+		if(put_in(O))
+			playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
+		return TRUE
 
-/obj/structure/handcart/attack_right(mob/user)
-	if(!can_interact(user))
-		return FALSE
-	if(!length(contents))
-		to_chat(user, span_notice("But [src] is already empty."))
-		return FALSE
-	user.changeNext_move(CLICK_CD_MELEE)
-	dump_contents()
-	visible_message(span_info("[user] dumps out [src]!"))
-	playsound(loc, 'sound/foley/cartdump.ogg', 100, FALSE, -1)
-	return TRUE
+/obj/structure/handcart/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/cart_upgrade))
+		var/obj/item/cart_upgrade/item = I
+		if(item.ulevel == 1)
+			if(upgrade_level != 0)
+				to_chat(user, "<span class='warning'>This wheelbrace is obsolete.</span>")
+				return
+			else
+				upgrade = item
+				upgrade_level = item.ulevel
+				qdel(item)
+				manage_upgrade()
+				playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
+		if(item.ulevel == 2)
+			if(upgrade_level != 1)
+				to_chat(user, "<span class='warning'>The cart needs a normal wheelbrace before this one can be used!</span>")
+				return
+			else
+				upgrade = item
+				upgrade_level = item.ulevel
+				qdel(item)
+				manage_upgrade()
+				playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
+	if(!user.cmode)
+		if(!insertion_allowed(I))
+			return
+		if(put_in(I, user))
+			playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
+		return
+	..()
 
-/obj/structure/handcart/proc/put_in(atom/movable/moved_atom, mob/user)
-	if(moved_atom == user)
-		user.visible_message(span_notice("[user] starts shimmying up inside of [src]..."))
-		if(!do_after(user, 2 SECONDS))
-			return FALSE
-		. = TRUE
-	else if(isitem(moved_atom))
-		if(!user.transferItemToLoc(moved_atom, src))
-			return FALSE
-		. = TRUE
-	else // we already checked if it's allowed to be moved into here
-		user.visible_message(span_notice("[user] starts moving [moved_atom] into [src]..."))
-		if(!do_after_mob(user, moved_atom, 2 SECONDS))
-			return FALSE
-		. = TRUE
+/obj/structure/handcart/attack_hand(mob/living/user)
+	. = ..()
 	if(.)
-		playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
-		moved_atom.forceMove(src)
+		return
+	if(user.cmode)
+		return
+	var/turf/T = get_turf(user)
+	if(isturf(T))
+		user.changeNext_move(CLICK_CD_MELEE)
+		var/fou
+		for(var/obj/item/I in T)
+			if(!insertion_allowed(I))
+				continue
+			put_in(I)
+			fou = TRUE
+		if(fou)
+			playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
+
+/obj/structure/handcart/proc/put_in(atom/movable/O, mob/user)
+	var/weight = 0
+	if(isitem(O))
+		var/obj/item/I = O
+		if((current_capacity + I.w_class) > maximum_capacity)
+			return FALSE
+		weight = I.w_class
+	if(isliving(O))
+		if((current_capacity + arbitrary_living_creature_weight) > maximum_capacity)
+			return FALSE
+		weight = arbitrary_living_creature_weight
+	if(user && !user.transferItemToLoc(O, src))
+		return FALSE
+	else
+		O.forceMove(src)
+	current_capacity += weight
+	stuff_shit += O
+	update_icon()
 	return TRUE
 
 /obj/structure/handcart/proc/take_contents()
 	var/atom/L = drop_location()
-	for(var/atom/movable/AM as anything in L)
-		if(AM != src && insertion_allowed(AM, null))
-			AM.forceMove(src)
+	for(var/atom/movable/AM in L)
+		if(AM != src && put_in(AM)) // limit reached
+			break
 
 /obj/structure/handcart/update_icon()
 	. = ..()
@@ -214,60 +196,46 @@
 			add_overlay("ov_upgrade")
 		if(upgrade_level == 2)
 			add_overlay("ov_upgrade2")
-	if(length(contents))
+	if(stuff_shit.len)
 		icon_state = "cart-full"
 	else
 		icon_state = "cart-empty"
 
-/obj/structure/handcart/proc/try_mob_insert(mob/living/inserted_mob, mob/living/user)
-	. = TRUE
-	var/to_user = null
-	if(!istype(inserted_mob))
-		. = FALSE
-	else if(!isliving(inserted_mob)) //let's not put ghosts or camera mobs inside closets...
-		. = FALSE
-	else if(inserted_mob.anchored)
-		to_user = span_warn("You can't seem to move [span_bold("[inserted_mob]")].")
-		. = FALSE
-	else if((inserted_mob.buckled && inserted_mob.buckled != src))
-		to_user = span_warn("Unbuckle [span_bold("[inserted_mob]")] first!")
-		. = FALSE
-	else if(inserted_mob.incorporeal_move)
-		to_user = span_warn("Your hands phase right through [span_bold("[inserted_mob]")]!")
-		. = FALSE
-	else if(inserted_mob.has_buckled_mobs())
-		to_user = span_warn("You can only move one living thing at a time into [span_bold("[src]")].")
-		. = FALSE
-	if(istype(user) && !isnull(to_user))
-		to_chat(user, to_user)
-	return .
+/obj/structure/handcart/attack_right(mob/user)
+	. = ..()
+	if(.)
+		return
+	user.changeNext_move(CLICK_CD_MELEE)
+	if(stuff_shit.len)
+		dump_contents()
+		visible_message(span_info("[user] dumps out [src]!"))
+		playsound(loc, 'sound/foley/cartdump.ogg', 100, FALSE, -1)
+	update_icon()
 
-/obj/structure/handcart/proc/try_obj_insert(obj/inserted_object, mob/living/user)
-	. = TRUE
-	var/to_user = null
-	if(!istype(inserted_object))
-		. = FALSE
-	else if(inserted_object.anchored)
-		to_user = span_warn("You can't seem to move [span_bold("[inserted_object]")].")
-		. = FALSE
-	else if(inserted_object.has_buckled_mobs())
-		to_user = span_warn("Unbuckle everything on [span_bold("[inserted_object]")] first.")
-		. = FALSE
-	else if(isitem(inserted_object))
-		var/obj/item/inserted_item = inserted_object
-		if(HAS_TRAIT(inserted_item, TRAIT_NODROP) || inserted_item.item_flags & ABSTRACT)
-			. = FALSE
-	if(istype(user) && !isnull(to_user))
-		to_chat(user, to_user)
-	return .
-
-/obj/structure/handcart/proc/insertion_allowed(atom/movable/AM, mob/living/user)
-	if(!ismovable(AM))
-		return FALSE
+/obj/structure/handcart/proc/insertion_allowed(atom/movable/AM)
 	if(ismob(AM))
-		return try_mob_insert(AM, user)
-	if(isobj(AM))
-		return try_obj_insert(AM, user)
+		if(!isliving(AM)) //let's not put ghosts or camera mobs inside closets...
+			return FALSE
+		var/mob/living/L = AM
+		if(L.anchored || (L.buckled && L.buckled != src) || L.incorporeal_move || L.has_buckled_mobs())
+			return FALSE
+		if(L.mob_size > MOB_SIZE_TINY) // Tiny mobs are treated as items.
+			if(L.density)
+				return FALSE
+		L.stop_pulling()
+
+	else if(isobj(AM))
+		if((AM.density) || AM.anchored || AM.has_buckled_mobs())
+			return FALSE
+		else
+			if(isitem(AM))
+				var/obj/item/I = AM
+				if(HAS_TRAIT(I, TRAIT_NODROP) || I.item_flags & ABSTRACT)
+					return FALSE
+	else // not a mob or object
+		return FALSE
+
+	return TRUE
 
 /obj/structure/handcart/Move(atom/newloc, direct, glide_size_override)
 	. = ..()

--- a/code/modules/admin/verbs/beakerpanel.dm
+++ b/code/modules/admin/verbs/beakerpanel.dm
@@ -8,7 +8,7 @@
 
 /proc/beakersforbeakers()
 	. = list()
-	for(var/t in subtypesof(/obj/item/reagent_containers) + list(/obj/structure/fermentation_keg, /obj/structure/roguebin))
+	for(var/t in subtypesof(/obj/item/reagent_containers) + list(/obj/structure/fermentation_keg, /obj/item/roguebin))
 		var/obj/item/reagent_containers/C = t
 		. += list(list("id" = t, "text" = initial(C.name), "volume" = initial(C.volume)))
 

--- a/code/modules/farming/big_liquid_containers.dm
+++ b/code/modules/farming/big_liquid_containers.dm
@@ -1,12 +1,12 @@
 // For storing roguebin and fermenting barrel or something
 
 // Bin
-/obj/structure/roguebin/water/Initialize()
+/obj/item/roguebin/water/Initialize()
 	. = ..()
 	reagents.add_reagent(/datum/reagent/water,500)
 	update_icon()
 
-/obj/structure/roguebin/water/gross/Initialize()
+/obj/item/roguebin/water/gross/Initialize()
 	. = ..()
 	reagents.add_reagent(/datum/reagent/water/gross,500)
 	update_icon()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -220,8 +220,8 @@
 		O.visible_message(span_notice("The <font color=[O.color]>paint</font> on [O] washes away!"))
 		O.color = initial(O.color)
 
-	if(istype(O, /obj/structure/roguebin))
-		var/obj/structure/roguebin/RB = O
+	if(istype(O, /obj/item/roguebin))
+		var/obj/item/roguebin/RB = O
 		if(!RB.kover)
 			if(RB.reagents)
 				RB.reagents.add_reagent(src.type, reac_volume)

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -179,7 +179,7 @@
 
 /datum/crafting_recipe/roguetown/roguebin
 	name = "wooden bin"
-	result = /obj/structure/roguebin
+	result = /obj/item/roguebin
 	reqs = list(/obj/item/grown/log/tree/small = 2)
 	verbage_simple = "make"
 	verbage = "makes"

--- a/code/modules/roguetown/roguestock/import.dm
+++ b/code/modules/roguetown/roguestock/import.dm
@@ -5,11 +5,11 @@
 /datum/roguestock/import/crackers
 	name = "Bin of Rations"
 	desc = "Low moisture bread that keeps well."
-	item_type = /obj/structure/roguebin/crackers
+	item_type = /obj/item/roguebin/crackers
 	export_price = 100
 	importexport_amt = 1
 
-/obj/structure/roguebin/crackers/Initialize()
+/obj/item/roguebin/crackers/Initialize()
 	. = ..()
 	new /obj/item/reagent_containers/food/snacks/rogue/crackerscooked(src)
 	new /obj/item/reagent_containers/food/snacks/rogue/crackerscooked(src)
@@ -321,7 +321,7 @@
 	new /obj/item/natural/stone(src)
 	new /obj/item/natural/stone(src)
 	new /obj/item/natural/stone(src)
-	new /obj/structure/roguebin(src)
+	new /obj/item/roguebin(src)
 	new /obj/item/reagent_containers/glass/bucket(src)
 
 /datum/roguestock/import/craftsman


### PR DESCRIPTION
Reverts Scarlet-Reach/Scarlet-Reach#524

It's throwing warnings.