### PR TITLE
The moderate option: Removes almost all publicly accessible SCOMs, reduces dense distribution of private ones

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -1325,6 +1325,10 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach/forest)
+"avM" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town)
 "avO" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -251444,7 +251448,7 @@ gyu
 oJe
 jdu
 jdu
-jdu
+avM
 jdu
 bSF
 uAr
@@ -251902,7 +251906,7 @@ iOV
 lKO
 lKO
 lKO
-sNZ
+quW
 sNZ
 sNZ
 sNZ

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -2367,10 +2367,6 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cave/dungeon1/gethsmane)
-"aNR" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
 "aNZ" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
@@ -4089,10 +4085,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
-"bsE" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "bsI" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -5358,10 +5350,6 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon1/gethsmane)
-"bML" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/church/chapel)
 "bMU" = (
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/rogue/churchmarble,
@@ -6192,10 +6180,6 @@
 "caL" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/mountains/decap)
-"caW" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/dwarfin)
 "caZ" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/dirt,
@@ -7228,13 +7212,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/mazedungeon)
-"cuE" = (
-/obj/structure/roguemachine/scomm/r,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "cuF" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/grassyel,
@@ -9296,7 +9273,6 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
 	},
-/obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "deZ" = (
@@ -10467,10 +10443,6 @@
 /obj/structure/boatbell/fluff,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach/forest)
-"dBc" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/tile/harem2,
-/area/rogue/indoors/town/bath)
 "dBl" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -12076,10 +12048,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/orcdungeon)
-"edP" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "edT" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -12246,7 +12214,6 @@
 /area/rogue/outdoors/mountains/decap)
 "ehi" = (
 /obj/structure/chair/stool/rogue,
-/obj/structure/roguemachine/scomm/l,
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
@@ -12282,11 +12249,6 @@
 "ehp" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"ehr" = (
-/obj/structure/chair/stool/rogue,
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "ehv" = (
 /obj/structure/roguewindow,
 /obj/structure/fluff/littlebanners{
@@ -15388,8 +15350,8 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/underdark)
 "fgM" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/dirt/road,
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "fgP" = (
 /obj/structure/table/wood,
@@ -18170,10 +18132,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
-"gbY" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "gca" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/shop)
@@ -19517,12 +19475,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/shelter/woods)
-"gyY" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "gzi" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -19761,10 +19713,6 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
-"gDG" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
 "gDJ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -20248,10 +20196,6 @@
 "gKT" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
-"gLj" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/town/basement)
 "gLr" = (
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/cobble,
@@ -21638,10 +21582,6 @@
 "hie" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
-"hii" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/manor)
 "hio" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/skull{
@@ -22293,12 +22233,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
-"hsS" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
 "hsX" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -22602,7 +22536,6 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "hwF" = (
-/obj/structure/roguemachine/scomm,
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
@@ -24061,13 +23994,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cave/mazedungeon)
-"hWv" = (
-/obj/structure/roguemachine/scomm/r,
-/obj/structure/fluff/wallclock{
-	dir = 3
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "hWw" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/manorguardsman,
@@ -25701,10 +25627,6 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/indoors/town/garrison)
-"ixs" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "ixx" = (
 /turf/open/water/river{
 	dir = 4;
@@ -25863,15 +25785,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
-"iAO" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
 /area/rogue/indoors/town/manor)
 "iAR" = (
 /obj/structure/chair/bench/church/smallbench,
@@ -26633,12 +26546,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/woods)
-"iMQ" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/carpet/lord/right,
-/area/rogue/indoors/town/manor)
 "iMR" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -30440,7 +30347,6 @@
 	dir = 10;
 	pixel_y = 1
 	},
-/obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/bog)
 "kcx" = (
@@ -32236,10 +32142,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter)
-"kHk" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/beach)
 "kHC" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
 /obj/structure/closet/crate/chest/wicker,
@@ -32307,10 +32209,6 @@
 /obj/item/seeds/berryrogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"kIh" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
 "kIi" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/herringbone,
@@ -32563,10 +32461,6 @@
 "kNH" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
-"kNL" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
 "kNO" = (
 /obj/structure/fluff/alch,
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -33153,13 +33047,6 @@
 /obj/structure/chair/bench/couch/r,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
-"kYZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "kZy" = (
 /obj/structure/chair/bench/church,
 /turf/open/floor/rogue/church,
@@ -33772,10 +33659,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"lkz" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town)
 "lkD" = (
 /obj/structure/flora/newbranch/leafless{
 	dir = 4
@@ -35005,10 +34888,6 @@
 /obj/effect/spawner/roguemap/hauntpile,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/mazedungeon)
-"lDg" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town)
 "lDh" = (
 /obj/item/paper,
 /obj/item/natural/feather,
@@ -36440,10 +36319,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
-"mdW" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/tile/harem2,
-/area/rogue/indoors/town/bath)
 "mdX" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -37199,7 +37074,6 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
 "mrg" = (
@@ -38493,13 +38367,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
-"mOk" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "mOp" = (
 /obj/effect/landmark/start/wretchlate{
 	pixel_x = 2
@@ -40031,12 +39898,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
-"nnb" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/physician)
 "nni" = (
 /obj/effect/decal/mossy{
 	dir = 8
@@ -40169,13 +40030,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/town/basement)
-"noR" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
 "noW" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
@@ -40538,13 +40392,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"nwu" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
 "nwF" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
@@ -40567,10 +40414,6 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/basement)
-"nwZ" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
 "nxc" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -40676,10 +40519,6 @@
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
-"nzo" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "nzs" = (
 /obj/structure/fluff/traveltile/bandit{
 	aportalgoesto = "banditin";
@@ -43426,10 +43265,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
-"oxa" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/sewer)
 "oxi" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/wood,
@@ -45884,11 +45719,6 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
-"pnw" = (
-/obj/structure/table/wood,
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
 "pnA" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/tile,
@@ -46724,10 +46554,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/goatmale,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
-"pBF" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
 "pBH" = (
 /obj/structure/bars/cemetery,
 /obj/effect/decal/cobbleedge{
@@ -46744,10 +46570,6 @@
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach)
-"pBX" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/sewer)
 "pBY" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -46799,9 +46621,6 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
 "pCr" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
-	},
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
@@ -47883,7 +47702,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
 	},
-/obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/magician)
 "pVA" = (
@@ -48514,10 +48332,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
-"qfx" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "qfA" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
@@ -52694,12 +52508,6 @@
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/basement)
-"rBB" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/manor)
 "rBC" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -53799,12 +53607,6 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"rUf" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "rUk" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/potion_ingredient,
@@ -54801,7 +54603,6 @@
 	dir = 10;
 	icon_state = "cobbleedge-e"
 	},
-/obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "slx" = (
@@ -55594,10 +55395,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/orcdungeon)
-"svS" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/magician)
 "svU" = (
 /obj/machinery/light/roguestreet{
 	dir = 1
@@ -59662,7 +59459,6 @@
 	dir = 10;
 	icon_state = "cobbleedge-w"
 	},
-/obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "tPH" = (
@@ -62129,12 +61925,6 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
-"uDa" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "uDh" = (
 /obj/structure/chair/bench/couch,
 /obj/item/clothing/mask/cigarette/pipe/westman,
@@ -62250,12 +62040,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
-"uEt" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "uEw" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -63811,7 +63595,6 @@
 /obj/structure/stairs{
 	dir = 4
 	},
-/obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "vgo" = (
@@ -66186,9 +65969,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "vUZ" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/garrison)
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "vVa" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/dirt,
@@ -66431,11 +66214,6 @@
 /obj/item/flint,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
-"vYy" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "vYz" = (
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/pink,
 /turf/open/floor/rogue/tile/harem2,
@@ -67168,10 +66946,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
-"wjW" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "wkc" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
@@ -68809,10 +68583,6 @@
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
-"wLA" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "wLC" = (
 /obj/structure/stairs{
 	dir = 1
@@ -69308,12 +69078,6 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/beach/forest)
-"wTY" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "wTZ" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet/bogcaves)
@@ -72190,12 +71954,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"xSm" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/magician)
 "xSq" = (
 /obj/effect/decal/remains/human,
 /obj/structure/fluff/walldeco/bigpainting/lake{
@@ -72738,10 +72496,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"ybZ" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/town/cell)
 "ycc" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/dirt/road,
@@ -72925,7 +72679,6 @@
 	dir = 4
 	},
 /obj/machinery/light/rogue/torchholder/r,
-/obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "yeH" = (
@@ -73173,10 +72926,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"yiC" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
 "yiT" = (
 /obj/item/grown/log/tree/small{
 	pixel_x = -11;
@@ -143176,7 +142925,7 @@ eTd
 eTd
 eTd
 sPR
-dBc
+uIl
 uIl
 uIl
 uIl
@@ -143639,7 +143388,7 @@ rqY
 rqY
 rqY
 rqY
-mdW
+uIl
 uIl
 uIl
 bmK
@@ -144991,7 +144740,7 @@ vsI
 vsI
 vsI
 vsI
-mzk
+vsI
 sQg
 xPZ
 uQa
@@ -146787,7 +146536,7 @@ ylh
 mMx
 eXr
 eXr
-gLj
+kfk
 hSR
 hSR
 dcp
@@ -154434,7 +154183,7 @@ xAN
 jVl
 cHC
 cHC
-oxa
+cHC
 cHC
 fyw
 cHC
@@ -155384,7 +155133,7 @@ opX
 dlK
 amm
 dlK
-pBX
+cHC
 cHC
 daP
 gdm
@@ -155798,7 +155547,7 @@ xVg
 ylh
 mMx
 fCP
-gbY
+dUU
 feu
 jZG
 jZG
@@ -164023,7 +163772,7 @@ bhJ
 bhJ
 bhJ
 knA
-kHk
+nZU
 icp
 icp
 uwl
@@ -167593,7 +167342,7 @@ wCC
 fWS
 bYC
 bYC
-vrC
+eWv
 wCC
 bkj
 bYC
@@ -176607,7 +176356,7 @@ uPP
 tWO
 nKF
 iad
-vrC
+eWv
 wCC
 tUV
 uNj
@@ -178000,7 +177749,7 @@ dlK
 utr
 pqu
 jrf
-ybZ
+bNE
 pJN
 pJN
 cQV
@@ -240393,7 +240142,7 @@ fVo
 pxF
 pxF
 uBc
-rUf
+sYZ
 sYZ
 jKv
 gGV
@@ -248525,7 +248274,7 @@ iqH
 fmp
 sVK
 uBc
-kIh
+fpx
 fpx
 gyu
 sVK
@@ -250260,7 +250009,7 @@ exD
 exD
 exD
 uBc
-cuE
+mAh
 rRQ
 cDX
 ngb
@@ -252090,7 +251839,7 @@ qAY
 gkW
 hfa
 vYm
-bML
+hfa
 vYm
 hfa
 hfa
@@ -253878,7 +253627,7 @@ exD
 xPx
 cDX
 cDX
-wTY
+sYZ
 sxy
 sYZ
 cDX
@@ -254800,7 +254549,7 @@ tXM
 jPk
 oKc
 oKc
-mHe
+vUZ
 sTM
 lCF
 iPO
@@ -255708,7 +255457,7 @@ sTM
 iPO
 oKc
 bVQ
-aNR
+iPO
 sTM
 ben
 fMA
@@ -256610,7 +256359,7 @@ qAY
 jbX
 fwK
 qax
-uwg
+fwK
 qax
 fwK
 fwK
@@ -257527,7 +257276,7 @@ qRB
 iPO
 qbZ
 bCz
-noR
+btK
 sns
 sns
 sns
@@ -257536,7 +257285,7 @@ cns
 cGN
 rbu
 taS
-kYZ
+teV
 teV
 pia
 aLh
@@ -258478,7 +258227,7 @@ cDX
 uBc
 uIt
 bTe
-nwu
+arJ
 kRg
 eLT
 kRg
@@ -262092,7 +261841,7 @@ sns
 fpx
 fpx
 uBc
-pnw
+fha
 kRg
 oFZ
 uBc
@@ -262451,7 +262200,7 @@ sZD
 gHl
 njB
 uBc
-nwZ
+kRg
 oZg
 kRg
 kRg
@@ -262534,7 +262283,7 @@ wSP
 fpx
 fpx
 nIq
-fgM
+fpx
 aFv
 pWT
 njB
@@ -263413,7 +263162,7 @@ hrc
 cDX
 hrc
 cDX
-mOk
+vAX
 exD
 exD
 exD
@@ -263425,7 +263174,7 @@ hDX
 hDX
 hDX
 cDX
-wjW
+exD
 wRJ
 pxc
 pGb
@@ -264299,7 +264048,7 @@ dQG
 dQG
 sGj
 sGj
-lkz
+kDS
 uhV
 lHe
 sRm
@@ -266161,7 +265910,7 @@ exD
 exD
 exD
 exD
-exD
+fgM
 exD
 fpx
 fpx
@@ -267429,7 +267178,7 @@ phl
 phl
 phl
 cDX
-kIh
+fpx
 fpx
 fpx
 fpx
@@ -274274,7 +274023,7 @@ phl
 phl
 phl
 phl
-vYy
+dmL
 exD
 exD
 exD
@@ -275101,7 +274850,7 @@ dra
 cDX
 uBc
 cDX
-kIh
+fpx
 exD
 exD
 exD
@@ -275210,7 +274959,7 @@ mrI
 aFp
 bZZ
 uBc
-wjW
+exD
 exD
 exD
 exD
@@ -275590,7 +275339,7 @@ phl
 phl
 phl
 phl
-edP
+pWT
 exD
 exD
 exD
@@ -284232,7 +283981,7 @@ guo
 vgH
 guo
 cDX
-wjW
+exD
 exD
 exD
 exD
@@ -288732,7 +288481,7 @@ rMf
 rMf
 rMf
 wMU
-yiC
+rMf
 vAw
 vAw
 vAw
@@ -291859,7 +291608,7 @@ vxe
 vxe
 ogR
 crD
-pBF
+uWp
 uWp
 amM
 fJL
@@ -293275,7 +293024,7 @@ pVO
 eSl
 jdu
 eKH
-wjW
+exD
 exD
 fwp
 fwp
@@ -295947,7 +295696,7 @@ nRv
 gqP
 iSm
 pBa
-svS
+rDp
 rDp
 pSa
 pSa
@@ -296346,7 +296095,7 @@ gyu
 phl
 phl
 phl
-iBJ
+sns
 sns
 sns
 phl
@@ -297250,7 +296999,7 @@ gyu
 phl
 phl
 phl
-sns
+iBJ
 sns
 sns
 phl
@@ -366419,7 +366168,7 @@ jdu
 vGV
 sTl
 apZ
-lDg
+apZ
 uBc
 xfm
 bGf
@@ -370934,7 +370683,7 @@ aBB
 xfm
 uBc
 mAh
-rUf
+sYZ
 poW
 uBc
 nPm
@@ -374561,7 +374310,7 @@ bGf
 bGf
 bGf
 uBc
-hWv
+oVn
 jew
 vXn
 jew
@@ -375469,7 +375218,7 @@ oVn
 jew
 bKa
 jew
-bsE
+jew
 uBc
 kSK
 bGf
@@ -375507,13 +375256,13 @@ kSK
 kSK
 kSK
 tvR
-lUf
+uyR
 uyR
 rtm
 eVJ
 rtm
 tvR
-qfx
+pvg
 udU
 nXL
 nXL
@@ -375549,7 +375298,7 @@ fkz
 kRg
 kRg
 lgj
-cXD
+jdu
 phz
 uBc
 uBc
@@ -398993,7 +398742,7 @@ vxe
 rJA
 fAA
 pfi
-uEt
+uQS
 fAA
 qkv
 mxu
@@ -399898,7 +399647,7 @@ tjY
 tjY
 vxe
 vbR
-gyY
+uQS
 jcT
 ida
 aYU
@@ -404418,7 +404167,7 @@ xeD
 vxe
 vxe
 uQS
-nzo
+fAA
 qFa
 gWb
 vxe
@@ -405319,7 +405068,7 @@ vxe
 dsi
 fAA
 vxe
-ixs
+fAA
 myt
 uQS
 vxe
@@ -405777,7 +405526,7 @@ uQS
 vxe
 pLt
 tkH
-rBB
+tkH
 vxe
 szS
 szS
@@ -406208,7 +405957,7 @@ vxe
 vxe
 vxe
 vxe
-kNL
+bcB
 bcB
 bcB
 xOK
@@ -407126,7 +406875,7 @@ vxe
 vxe
 vxe
 vxe
-uDa
+uQS
 uQS
 rjF
 vxe
@@ -408472,11 +408221,11 @@ vmi
 vmi
 vmi
 vxe
-iAO
+bpp
 uQS
 uQS
 vxe
-iAO
+bpp
 uQS
 uQS
 vxe
@@ -474062,7 +473811,7 @@ bAZ
 btN
 eTR
 apU
-ehr
+szH
 hlK
 nus
 nAQ
@@ -484868,7 +484617,7 @@ iRn
 iRn
 iRn
 vpU
-wLA
+iRn
 wKQ
 fwK
 fwK
@@ -494822,7 +494571,7 @@ mZP
 fSD
 wcX
 xqr
-nnb
+xqr
 uxY
 yfn
 bGf
@@ -497987,7 +497736,7 @@ iTC
 lvw
 syk
 mlQ
-caW
+mlQ
 mlQ
 kBg
 ahe
@@ -510208,7 +509957,7 @@ vHy
 jWw
 jWw
 tMv
-vUZ
+tMv
 tMv
 lju
 kSN
@@ -510216,7 +509965,7 @@ kSN
 kSN
 pMW
 laf
-gDG
+nBo
 ijk
 jWw
 jWw
@@ -512920,7 +512669,7 @@ jWw
 jWw
 mkj
 qSC
-gDG
+nBo
 nBo
 jWw
 jWw
@@ -513834,7 +513583,7 @@ nBo
 vmI
 vmI
 vmI
-hsS
+nBo
 jWw
 iLV
 lMc
@@ -516505,7 +516254,7 @@ iln
 rLB
 vxe
 tkH
-hii
+tkH
 xbs
 pVP
 kwQ
@@ -516950,7 +516699,7 @@ vxe
 lzQ
 lzQ
 bfR
-iMQ
+lzQ
 vxe
 vxe
 vxe
@@ -520121,7 +519870,7 @@ vxe
 mYz
 lyG
 uQS
-gyY
+uQS
 cJk
 rov
 vxe
@@ -520578,7 +520327,7 @@ fAA
 uQS
 vxe
 khf
-gyY
+uQS
 uQS
 wxD
 oou
@@ -528742,7 +528491,7 @@ kus
 kus
 kus
 jmD
-xSm
+jmD
 iSm
 iSm
 uTc


### PR DESCRIPTION
## About The Pull Request
This is an alternative solution to the one posed in https://github.com/Scarlet-Reach/Scarlet-Reach/pull/542 as a different solution to disabling input on all SCOMs entirely. **I like the loudmouth device and don't seek to replace that part of the PR, just the wholesale disabling of the use of SCOMs.** There is absolutely truth that it is unfeasably difficult in many areas to do any antagonism without being immediately tattled on, even in _actual sewers;_ however, I feel that the function of _some_ SCOMs in certain areas is a functional necessity, such as those outside of city gates that're sometimes closed and unmanned, and disabling all SCOMs thoroughly fucks over vulnerable roles like soilsons, the merchant and guildies who already struggle to attract people and already get robbed many times over in a given round. This PR **removes most publicly available SCOMs while aiming to leave SCOMs in businesses and secure locations.** The general idea is that if you are a random nobody foreigner, you should have to go to the Loudmouth, but if you are in the Guild and having all your windows smashed, or the bathhouse is being raided, **_the staff_** can still call for help. Just not random nobodies without access. Thus, they become _a privilege of having a business in town or being part of an institution like the Church or Keep_ and not easily accessible in corners of the town or out on the road.

Also, fuck anybody who spams the SCOM way out in the middle of Buttfuck, Nowhere. This added nothing of value to the game.

I have also removed a bunch of SCOMs from private locations that are usable as meeting rooms, and SCOMs that are just redundant when there is one immediately just a room over; this is to allow people to plot, scheme, strongarm and blackmail people without people being able to immediately tattle. Places like the marshal's desk and the Keep's meeting room are places where shadowy deals should be possible without someone going and telling immediately without being able to stop them; most of these places belong to roles that already get their own SCOMstone of some variety already, so the removal of stationary SCOMs simply gives them more control within their own spaces.

This PR will overwrite / be overwritten by other map PRs. That's okay; this was very easy to do and I'm fine with having to do it over again after another map PR takes priority. This is mostly as an alternative testmerge to see what happens.

**Removed publicly available SCOMs:**

SCOMs in publicly accessible areas, SCOMs literally just out in the town and in random places on the road in the middle of bumfuck nowhere in and around the city, and SCOMs even out on the fucking coast.
 
<img width="241" height="242" alt="StrongDMM_QFaU1n9JWb" src="https://github.com/user-attachments/assets/84f3a828-f5fb-416f-b34a-a490d2517b8f" />
 
<img width="232" height="244" alt="StrongDMM_cdo0tb75yK" src="https://github.com/user-attachments/assets/13126f90-d57d-4cb8-9dde-edee88547fe3" />
 
<img width="233" height="230" alt="StrongDMM_XZjFMr44cS" src="https://github.com/user-attachments/assets/32d981fd-335e-4082-8596-afb1d077099b" />
 
<img width="232" height="221" alt="StrongDMM_wTy9WbP4Ls" src="https://github.com/user-attachments/assets/ef64d004-c7c6-44cf-92b7-2e138a770ed2" />
 
<img width="254" height="238" alt="StrongDMM_4hf7sAzNQf" src="https://github.com/user-attachments/assets/f1d2b2e9-4356-4545-ad2c-565016d563ff" />
 
<img width="236" height="245" alt="StrongDMM_cksvgHCMeE" src="https://github.com/user-attachments/assets/eb487560-3603-43b9-9f8f-db17f2e27852" />
 
<img width="236" height="243" alt="StrongDMM_gdQpUlddln" src="https://github.com/user-attachments/assets/cd44f3cd-74c6-4313-9a18-46187765615f" />
 
<img width="429" height="281" alt="StrongDMM_11fFEn5m9I" src="https://github.com/user-attachments/assets/d0876f1c-8f53-4d7a-a3ac-ab41af8daeae" />
 
<img width="242" height="234" alt="StrongDMM_mGGsvQWM8D" src="https://github.com/user-attachments/assets/833ccb50-2e6b-4ce8-86a5-b3c767510507" />
 
<img width="235" height="238" alt="StrongDMM_gfz5ltU0uM" src="https://github.com/user-attachments/assets/e3b43e20-5dff-4212-81ae-27f63628d435" />
 
<img width="236" height="245" alt="StrongDMM_cksvgHCMeE" src="https://github.com/user-attachments/assets/01c9679e-8947-42d2-aaa7-0dc802f10d3a" />
 
<img width="232" height="244" alt="StrongDMM_cdo0tb75yK" src="https://github.com/user-attachments/assets/57a66994-5788-477b-b1c6-dbb064f27892" />
 
<img width="243" height="243" alt="StrongDMM_nLS2jC8kE9" src="https://github.com/user-attachments/assets/52489a52-a6e7-48d5-a4d3-5224d9728d10" />
 
<img width="244" height="250" alt="StrongDMM_k24xuLux1i" src="https://github.com/user-attachments/assets/8e60eb7b-d075-4fb9-bcc3-b1e6ba73e23e" />
 
<img width="241" height="238" alt="StrongDMM_Ke8tmJdtMX" src="https://github.com/user-attachments/assets/30b9bc8f-d95c-4631-90c3-e54a9f4b2e61" />
 
<img width="234" height="242" alt="StrongDMM_UqWdN97qRW" src="https://github.com/user-attachments/assets/882bac58-c515-4602-8e80-30e24f95a5ad" />
 

 
Sewer SCOMs and SCOMs far outside of town in the middle of fucking nowhere. Being able to scream ZIZOZIZOZIZO I SLURP PINTLE THE CAKE IS A LIE all round while being impossible to find is fucking unbearable. People only ever abused these. If you used these, I hate you. The sewer systems should be places free for antagonists to antagonize.
 
<img width="380" height="381" alt="StrongDMM_vGK359Is0s" src="https://github.com/user-attachments/assets/6aa64648-26bc-414b-930f-554f116fd3b8" />
 
<img width="240" height="239" alt="StrongDMM_RqcoZ48Znr" src="https://github.com/user-attachments/assets/7e60f5bb-c320-4532-937c-3ab7f69c0f70" />
 
<img width="192" height="239" alt="StrongDMM_NPjGEtYCG8" src="https://github.com/user-attachments/assets/0c1e1d38-2317-4b39-bfbc-e98176465545" />
 
I strongly debated whether I should remove the Inn's scom as it's a community area we want to incentivise people to hang out in and that should feel relatively loud. However, the Inn is just so close in proximity to the Loudmouth that the concern is that nobody will go to them if this is available. I could go either way on this one.
 
<img width="349" height="386" alt="StrongDMM_IvtlnAbcYA" src="https://github.com/user-attachments/assets/1aefee6b-9060-493a-81d6-c4b2c15b5d46" />
 
**Removed PRIVATE area SCOMs:**
 
SCOMs around the heir's rooms, the Seneschal's and Hand's, the meeting room, and the guest rooms removed. You can now stick up the princess or have tense secret conversations to plot against the Duke without people being able to step over and scream THE LORD OF HEARTFELT IS TRYING TO GET ME TO OVERTHROW THE DUKE.
 
<img width="189" height="230" alt="StrongDMM_f66B8FtIkO" src="https://github.com/user-attachments/assets/caaf9593-27bd-44a8-a2cd-317325c4842f" />
 
<img width="379" height="285" alt="StrongDMM_g7hZH9KJX9" src="https://github.com/user-attachments/assets/af9785ab-74f7-45e4-a2e9-0044a4d4db6c" />
 
<img width="188" height="231" alt="StrongDMM_FqYnUGN0CU" src="https://github.com/user-attachments/assets/e5bca6a8-677e-434b-b058-7fd8b0a99280" />
 
<img width="236" height="195" alt="StrongDMM_oBLrPhHzeb" src="https://github.com/user-attachments/assets/0b47cf61-e780-4e01-9bad-ecd0b46cda75" />
 
<img width="287" height="190" alt="StrongDMM_cZ29Kyky1A" src="https://github.com/user-attachments/assets/1826c790-29ed-4e80-8a3c-25e8c1b88593" />
 
<img width="337" height="483" alt="StrongDMM_oV5UwfNPtk" src="https://github.com/user-attachments/assets/eb71e895-9a99-4338-b30b-fa8a39978cfc" />
 
<img width="239" height="250" alt="StrongDMM_JtjeB6Zgcl" src="https://github.com/user-attachments/assets/c67fce08-04ae-4d7e-829b-acf7f45840b8" />
 
<img width="287" height="190" alt="StrongDMM_cZ29Kyky1A" src="https://github.com/user-attachments/assets/b3604fc9-9943-4d6d-a127-8bdd5e452c94" />
 
<img width="238" height="238" alt="StrongDMM_wyOH8PRCdI" src="https://github.com/user-attachments/assets/5900af25-53e8-4f9c-b333-c0655d34cce0" />
 
<img width="237" height="286" alt="StrongDMM_vUE3nlut7I" src="https://github.com/user-attachments/assets/8f2db7ee-b7ab-4631-ac3c-a3bbc791c2d8" />
 
SCOMs in offices and meeting rooms where people might conceivably scheme. Most of these areas belong to roles who already get a SCOMstone or crownstone anyways, like the Marshal's, or people who can EASILY afford one, like the nightmaster, so they can still listen; this simply allows them to better strongarm or blackmail people and plan dirty deeds, effectively giving them more control in their own private areas by denying SCOM use _to guests in their areas._
 
<img width="187" height="236" alt="StrongDMM_OHSm9zzqbm" src="https://github.com/user-attachments/assets/b2c8f340-57bb-400a-be0e-c46dbe28d7de" />
 
<img width="283" height="190" alt="StrongDMM_nIMmCdpdGM" src="https://github.com/user-attachments/assets/596f2ecc-5347-44eb-b094-93cc6e9f9265" />
 
<img width="334" height="288" alt="StrongDMM_Q9JVT9ONiu" src="https://github.com/user-attachments/assets/28b3ebf9-642b-42d8-a275-d5a48fcfb29b" />
 
<img width="290" height="333" alt="StrongDMM_uXniGpMlO6" src="https://github.com/user-attachments/assets/4790b3b6-1a5d-4786-a809-c3ef2f396610" />
 
<img width="331" height="287" alt="StrongDMM_wmkVCEb1kt" src="https://github.com/user-attachments/assets/f5771471-924c-49b3-8973-24a89c4cd8d8" />
 
<img width="289" height="273" alt="StrongDMM_cXlhcNNq30" src="https://github.com/user-attachments/assets/0f62a0ca-9378-4b1d-9b6b-de29437b9ab4" />
 
The councilors still get one immediately downstairs from this one in their meeting room:
 
<img width="380" height="236" alt="StrongDMM_tdTD4IHdUf" src="https://github.com/user-attachments/assets/d7179bbc-c110-4d38-ab9b-d7a3c5b2a0b2" />
 
SCOMs in the Duke's areas: the Duke gets the crown and the crownstone to communicate in already, so this gives him more control in his own private areas to be able to blackmail or scheme in his zones without being tattled on immediately:
 
<img width="241" height="286" alt="StrongDMM_deZPQ3pP2i" src="https://github.com/user-attachments/assets/a437faa9-b4f6-4efa-9edc-f10997e674ec" />
 
<img width="286" height="295" alt="StrongDMM_RpK2oCTA4S" src="https://github.com/user-attachments/assets/f1e9eda4-fad6-405d-a02a-c1ede7a4ae61" />
 
<img width="241" height="245" alt="StrongDMM_gIjH05Ro63" src="https://github.com/user-attachments/assets/40c14923-aaf5-424b-8798-e1ffa9c30c10" />
 
Redundant SCOMs and SCOMs that just don't really make any fucking sense and aren't needed: why is there a SCOM in the fucking torture chamber? In the treehouse? SCOMs literally just to have a SCOM in every single room when another is 5 tiles away in the next room over?
 
<img width="230" height="242" alt="StrongDMM_DOEbjq8ymF" src="https://github.com/user-attachments/assets/4a128ebd-9e9d-4f5b-9824-5e492d675bfd" />
 
<img width="331" height="238" alt="StrongDMM_3TiqHVCPzH" src="https://github.com/user-attachments/assets/1af46b3c-d8b2-42c5-ade8-3c08d3179228" />
 

 
These SCOMs in the Soilson's that're practically right next to their central more prominent one. Soilsons should get to keep one as they are a very vulnerable job that struggles to attract people, but the density of SCOMs here was pretty ridiculous, literally within eyeshot.
 
<img width="242" height="234" alt="StrongDMM_GBmk0ZcrFA" src="https://github.com/user-attachments/assets/1c0057db-0e80-4725-8247-bb327c06f662" />
 
<img width="240" height="221" alt="StrongDMM_AGS7AyqIRq" src="https://github.com/user-attachments/assets/9e6fd79a-41ee-4ade-824c-0fe3489d8bef" />
 
There are literally 3 SCOMs around the garrison armory basement, one can go:
 
<img width="243" height="244" alt="StrongDMM_kGGfgwHyot" src="https://github.com/user-attachments/assets/814a3806-1632-43c1-95f4-944be8825725" />
 
There are SCOMs all over inside this gatehouse building already:
 
<img width="336" height="334" alt="StrongDMM_BNnhGtW4KR" src="https://github.com/user-attachments/assets/ae6619aa-2b4e-46b8-a0a3-100b03bd23f9" />
 
SCOMs in private houses and residences: All businesses got to keep SCOMs, but many private homes had SCOMs built in that make them extremely difficult to feasably rob, or do any antagonism in.
 
<img width="509" height="509" alt="StrongDMM_RNP5vv4etG" src="https://github.com/user-attachments/assets/db23fa38-e00a-410e-9cfb-aad36445d88c" />
 
<img width="236" height="240" alt="StrongDMM_a3gxanVAny" src="https://github.com/user-attachments/assets/6122672f-de83-4932-9a80-312bab5769d5" />
 
<img width="237" height="233" alt="StrongDMM_KAaEEBdRlt" src="https://github.com/user-attachments/assets/597b59bc-28f3-4514-886f-05174497aee5" />
 
<img width="241" height="333" alt="StrongDMM_gmGYZpZiSd" src="https://github.com/user-attachments/assets/b9d45ffb-3404-483c-9862-d2fd7660631d" />
 
<img width="241" height="333" alt="StrongDMM_gmGYZpZiSd" src="https://github.com/user-attachments/assets/787302ba-7d01-4916-a937-030d9d313afc" />
 
**ADDED / MOVED SCOMS:**
The church has had their SCOM moved here in the back; still highly accessible but something locked to the public by default that they can still easily let people in to use if they so wish.
 
<img width="436" height="244" alt="StrongDMM_wvE2bhELPh" src="https://github.com/user-attachments/assets/c023aaa5-b381-40c0-93d0-6eae0ef47574" />
 
Before:
 
<img width="530" height="288" alt="StrongDMM_hzkIyRttzc" src="https://github.com/user-attachments/assets/0d2ae189-5ed3-4c2f-a594-37b3ccfd3ea8" />
 
<img width="186" height="223" alt="StrongDMM_rn70YK9cPS" src="https://github.com/user-attachments/assets/c4c6b432-b241-42ae-9b31-e3af8859cf58" />
 
This SCOM has been moved here because it is fucking insurmountably annoying that it's inaccessible when this gate is closed unlike all the other gates and there are absolutely no ways nearby to call for it to be opened nor a gatehouse that can be manned at all:
 
<img width="269" height="239" alt="StrongDMM_BK7uleKHy3" src="https://github.com/user-attachments/assets/bcc9f0a9-19c3-4ba0-8291-80907e772d52" />
 
**The south gate SCOM has bee moved here.** It was **really really** close in proximity to the Loudmouth just like 15 tiles down the road; the concern is, why would anybody ever go to the loudmouth and deal with interacting with another player when a publicly available free SCOM is right here? At the same time, being able to call for the gate to be opened is a NECESSARY amenity. So, it's been moved just a little ways further out to the crossroads between the two gates, so if you want to use it, you at least make yourself vulnerable and have to go a short distance outside of the city gate. It's still on the way!
 
<img width="426" height="420" alt="StrongDMM_ZiHwV0SMaT" src="https://github.com/user-attachments/assets/7fc7e369-10de-4ae2-acba-0ffd58b3511a" />

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![ezgif-78f75c9c74715a](https://github.com/user-attachments/assets/67b2a0d9-39ea-4550-b65c-83587fd624b8)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
A reduction to SCOMs is probably necessary to allow antagonists to better function and antagonize anybody, but taking SCOM functionality from already vulnerable and abused roles few people want to play is probably not a great idea. Some SCOMs are absolutely necessary and serve a real function, like the ones at the gates and the entrance of the Keep.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
