### PR TITLE
Bandit scom ring can't transmit outside of the bandit camp

### DIFF
--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -539,6 +539,10 @@
 
 /obj/item/mattcoin/attack_right(mob/living/carbon/human/user)
 	user.changeNext_move(CLICK_CD_INTENTCAP)
+	var/area/user_area = get_area(user)
+	if (!istype(user_area, /area/rogue/indoors/banditcamp))
+		to_chat(user, span_danger("The scomstone does not respond outside of the camp!"))
+		return
 	var/input_text = input(user, "Enter your message:", "Message")
 	if(input_text)
 		var/usedcolor = user.voice_color


### PR DESCRIPTION
## About The Pull Request

Makes it so that the bandit scom ring can't transmit messages unless you're in the bandit camp

## Testing Evidence

<img width="2156" height="1069" alt="Screenshot_6" src="https://github.com/user-attachments/assets/dca591f2-b6fc-4efe-b443-650105ae3161" />
<img width="2221" height="922" alt="Screenshot_7" src="https://github.com/user-attachments/assets/93987d65-9be9-4219-969a-5a56b05c85f0" />
<img width="2184" height="898" alt="Screenshot_8" src="https://github.com/user-attachments/assets/98b86045-ea99-4cec-84c8-539df302f74f" />


## Why It's Good For The Game

HELP NORTH KEEP!!

Mouth to mouth being the main way to communicate like it was in medieval times is part of the server's vision
Source: Me, one of the hosts
