### PR TITLE
Stat bug fix no more 20 stats abuse

### DIFF
--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -59,6 +59,15 @@
 
 /datum/status_effect/proc/on_apply() //Called whenever the buff is applied; returning FALSE will cause it to autoremove itself.
 	for(var/S in effectedstats)
+		if(effectedstats[S] < 0)	//We only care about negative bonuses here
+			if((owner.get_stat(S) + effectedstats[S]) < 1)	//The status effect would reduce our stats beyond the limit of !1! Not 0.
+				for(var/i in 1 to abs(effectedstats[S]))
+					if((owner.get_stat(S) + (effectedstats[S] + i)) == 1)	//We keep incrementing the status effect until it will reduce it to 1.
+						effectedstats[S] = (effectedstats[S] + i)
+						break
+		else
+			if((owner.get_stat(S) + effectedstats[S]) > 20)	//We check for overflow as well.
+				effectedstats[S] = max(((owner.get_stat(S) + effectedstats[S]) - 20), 0)
 		owner.change_stat(S, effectedstats[S])
 	return TRUE
 
@@ -149,21 +158,24 @@
 				qdel(S)
 				. = TRUE
 
-/mob/living/proc/has_status_effect(effect) //returns the effect if the mob calling the proc owns the given status effect
-	. = FALSE
-	if(status_effects)
-		var/datum/status_effect/S1 = effect
-		for(var/datum/status_effect/S in status_effects)
-			if(initial(S1.id) == S.id)
-				return S
+/mob/living/proc/has_status_effect(datum/status_effect/checked_effect)
+	RETURN_TYPE(/datum/status_effect)
 
-/mob/living/proc/has_status_effect_list(effect) //returns a list of effects with matching IDs that the mod owns; use for effects there can be multiple of
-	. = list()
-	if(status_effects)
-		var/datum/status_effect/S1 = effect
-		for(var/datum/status_effect/S in status_effects)
-			if(initial(S1.id) == S.id)
-				. += S	
+	for(var/datum/status_effect/present_effect as anything in status_effects)
+		if(present_effect.id == initial(checked_effect.id))
+			return present_effect
+
+	return null
+
+/mob/living/proc/has_status_effect_list(datum/status_effect/checked_effect)
+	RETURN_TYPE(/list)
+
+	var/list/effects_found = list()
+	for(var/datum/status_effect/present_effect as anything in status_effects)
+		if(present_effect.id == initial(checked_effect.id))
+			effects_found += present_effect
+
+	return effects_found
 
 //////////////////////
 // STACKING EFFECTS //

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -1,4 +1,3 @@
-	
 #define STAT_STRENGTH "strength"
 #define STAT_PERCEPTION "perception"
 #define STAT_INTELLIGENCE "intelligence"
@@ -90,6 +89,27 @@
 				testing("foundpsych")
 				H.eye_color = "ff0000"
 				H.voice_color = "ff0000"
+
+/mob/living/proc/get_stat(stat)
+	if(!stat)
+		return
+	switch(stat)
+		if(STAT_STRENGTH)
+			return STASTR
+		if(STAT_PERCEPTION)
+			return STAPER
+		if(STAT_INTELLIGENCE)
+			return STAINT
+		if(STAT_CONSTITUTION)
+			return STACON
+		if(STAT_ENDURANCE)
+			return STAEND
+		if(STAT_SPEED)
+			return STASPD
+		if(STAT_FORTUNE)
+			return STALUC
+		else
+			CRASH("get_stat called on [src] with an erroneous stat flag: [stat]")
 
 /mob/living/proc/change_stat(stat, amt, index)
 	if(!stat)


### PR DESCRIPTION
## About The Pull Request

https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3450
removes cool pvp meta dump your stats to 1 remove all debuffs (like you had -15 con) and get 1+15 con

## Testing Evidence

<img width="1558" height="1003" alt="image" src="https://github.com/user-attachments/assets/b2c13217-6f47-48c8-a1a0-263bc54f4afa" />

<img width="1538" height="1011" alt="image" src="https://github.com/user-attachments/assets/a1a82dfd-4425-4775-a357-03398edff135" />

## Why It's Good For The Game

sorry no more 20 str con per speed pvp fraggers 