### PR TITLE
Add status effect badge to wretch supporter carebox system

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -187,3 +187,12 @@
 /datum/status_effect/compliance
 	id = "compliance"
 	alert_type = /atom/movable/screen/alert/status_effect/compliance
+
+/datum/status_effect/carebox
+	id = "carebox"
+	alert_type = /atom/movable/screen/alert/status_effect/carebox
+
+/atom/movable/screen/alert/status_effect/carebox
+	name = "Package"
+	desc = "I have a parcel waiting for me at the HERMES."
+	icon_state = "mail"

--- a/code/modules/_mini/carebox/carebox.dm
+++ b/code/modules/_mini/carebox/carebox.dm
@@ -28,6 +28,7 @@ GLOBAL_DATUM_INIT(carebox, /datum/carebox, new())
 
 /datum/carebox/proc/give_carebox(mob/living/carbon/human/human, datum/carebox_table/table)
 	ADD_TRAIT(human, TRAIT_CAREBOX, TRAIT_GENERIC)
+	human.apply_status_effect(/datum/status_effect/carebox)
 	to_chat(human, span_notice("New letter from <b>[table.sender].</b>"))
 	human.playsound_local(human, 'sound/misc/mail.ogg', 100, FALSE, -1)
 
@@ -86,6 +87,8 @@ GLOBAL_DATUM_INIT(carebox, /datum/carebox, new())
 		return
 	// Success
 	REMOVE_TRAIT(human, TRAIT_CAREBOX, TRAIT_GENERIC)
+	human.remove_status_effect(/datum/status_effect/carebox)
+	to_chat(human, span_notice("I collect my package."))
 
 	var/turf/spawn_loc = get_turf(human)
 	playsound(spawn_loc, 'sound/misc/hiss.ogg', 100, FALSE, -1)


### PR DESCRIPTION
## About The Pull Request
Tiny little warmup PR to add a notification at the bottom right of the screen when you've received your Wretch package. The status effect showing this is simply to display the notif and is never checked. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="880" height="234" alt="image" src="https://github.com/user-attachments/assets/4982f70d-238b-46c3-8644-d2074f308352" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Shows an actual persistent notification to tell you when you've got the box waiting on you, instead of just showing a missable message in chat. More consistent with how other mail works.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
