### PR TITLE
Update dun_world.dmm

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -116,11 +116,6 @@
 "acj" = (
 /turf/open/floor/rogue/grassyel,
 /area/rogue/under/cave)
-"acn" = (
-/obj/structure/closet/crate/chest/wicker,
-/obj/item/rope,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "acD" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -130,10 +125,6 @@
 "acF" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave)
-"acQ" = (
-/obj/structure/fluff/alch,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "acY" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -368,6 +359,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"agN" = (
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 10
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "agZ" = (
 /obj/structure/stairs/fancy/r{
 	dir = 1
@@ -693,6 +693,11 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/metal,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"amh" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "ami" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/metal,
@@ -749,6 +754,13 @@
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
+"amZ" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_y = -11
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "anj" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/roofs)
@@ -793,6 +805,15 @@
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
+"anW" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "slittedwooddark"
+	},
+/area/rogue/outdoors/woods)
 "aoe" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
@@ -1110,10 +1131,6 @@
 	max_integrity = 50000
 	},
 /area/rogue/under/cave/mazedungeon)
-"arS" = (
-/turf/closed/wall/mineral/rogue/craftstone,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
 "arT" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile,
@@ -1158,26 +1175,11 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
-"asu" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot/stone,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "asw" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
-"asA" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_x = 8
-	},
-/obj/structure/closet/crate/roguecloset,
-/obj/item/flashlight/flare/torch/lantern,
-/obj/item/storage/backpack/rogue/satchel,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "asJ" = (
 /obj/effect/decal/cleanable/debris/glassy,
 /turf/open/floor/rogue/naturalstone,
@@ -1276,6 +1278,10 @@
 /obj/item/clothing/neck/roguetown/zcross/aalloy,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"auf" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "auj" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -1630,13 +1636,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter/woods)
-"azJ" = (
-/obj/structure/glowshroom{
-	icon_state = "glowshroom3"
-	},
-/obj/structure/flora/roguegrass/thorn_bush,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "azP" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood{
@@ -1676,23 +1675,10 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town/roofs)
-"aAs" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 10;
-	pixel_y = 0
-	},
+"aAv" = (
+/obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
-"aAv" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
 "aAy" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/blocks,
@@ -1716,6 +1702,14 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
+"aAT" = (
+/obj/structure/fluff/walldeco/stone{
+	icon_state = "walldec6";
+	pixel_y = -12;
+	pixel_x = 1
+	},
+/turf/closed/wall/mineral/rogue/decostone/fluffstone,
+/area/rogue/indoors/town/tavern)
 "aAV" = (
 /obj/effect/decal/cleanable/debris/woody{
 	dir = 1
@@ -1778,6 +1772,10 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"aCt" = (
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "aCu" = (
 /obj/machinery/light/rogue/torchholder/c{
 	dir = 1
@@ -2017,6 +2015,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"aGz" = (
+/obj/structure/roguemachine/noticeboard{
+	pixel_y = 7;
+	pixel_x = 15
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "aGJ" = (
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/rogue/cobble,
@@ -2331,6 +2336,10 @@
 /obj/structure/fluff/statue/myth,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap)
+"aLg" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "aLh" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -2433,10 +2442,6 @@
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"aMK" = (
-/obj/structure/flora/newleaf,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "aMX" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -2517,6 +2522,15 @@
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/dwarfin)
+"aOy" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 9
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "aOA" = (
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/rogue/tile/brick,
@@ -2588,14 +2602,6 @@
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"aPu" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 8;
-	pixel_y = 0;
-	pixel_x = 7
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
 "aPz" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -2695,10 +2701,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
-"aQJ" = (
-/obj/structure/flora/roguegrass/bush,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/indoors/town)
 "aQK" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -2831,12 +2833,6 @@
 	smooth_icon = null
 	},
 /area/rogue/indoors/town)
-"aTo" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
 "aTs" = (
 /obj/machinery/light/rogue/wallfire/candle/off/r,
 /turf/open/floor/rogue/metal,
@@ -2860,10 +2856,6 @@
 /obj/structure/far_travel,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains)
-"aTV" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/shelter/woods)
 "aTX" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -2877,10 +2869,6 @@
 /obj/effect/spawner/lootdrop/potion_ingredient/herb,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cave/skeletoncrypt)
-"aUe" = (
-/obj/item/natural/rock,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "aUk" = (
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/cobble/mossy,
@@ -2969,19 +2957,8 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
-"aWd" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 1
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
-"aWh" = (
-/obj/item/natural/rock,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/woods)
 "aWl" = (
-/obj/structure/flora/newleaf,
-/turf/open/floor/rogue/grass,
+/turf/closed/wall/shroud,
 /area/rogue/outdoors/woods)
 "aWn" = (
 /obj/structure/vine{
@@ -3072,6 +3049,13 @@
 /obj/structure/fermentation_keg,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/beach)
+"aXK" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/leafless{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "aXQ" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -3142,12 +3126,6 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/under/town/basement)
-"aYu" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 1
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/shelter/woods)
 "aYE" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/fluff/railing/border,
@@ -3362,10 +3340,6 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement/keep)
-"bbQ" = (
-/obj/structure/flora/hotspring_rocks/grassy,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "bbR" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/grass,
@@ -3378,14 +3352,6 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
-"bcf" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/obj/structure/bars/shop/bronze,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/shelter/woods)
 "bcl" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/dirt,
@@ -3407,10 +3373,6 @@
 /obj/structure/fermentation_keg,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
-"bcv" = (
-/obj/structure/vine,
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
 "bcx" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/AzureSand,
@@ -3484,6 +3446,11 @@
 "bdl" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"bdp" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "bdq" = (
 /obj/structure/closet/crate/roguecloset/dark{
 	keylock = 1;
@@ -3541,15 +3508,6 @@
 "bdZ" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/mazedungeon)
-"bef" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "bem" = (
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/shelter/mountains/decap)
@@ -3784,6 +3742,10 @@
 /obj/effect/landmark/start/wapprentice,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
+"biI" = (
+/turf/closed/wall/mineral/rogue/wooddark,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "biT" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -3836,10 +3798,31 @@
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/forest)
+"bjV" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "bjX" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"bkc" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
+/obj/machinery/light/rogue/wallfire/candle/floorcandle{
+	pixel_y = -14
+	},
+/obj/item/alch/rosa{
+	pixel_y = -2;
+	pixel_x = -8
+	},
+/obj/item/alch/rosa{
+	pixel_y = -9;
+	pixel_x = 5
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "bkf" = (
 /obj/structure/stairs{
 	dir = 4
@@ -3982,6 +3965,11 @@
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
+"bmR" = (
+/obj/structure/vine,
+/obj/structure/vine,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "bmX" = (
 /obj/item/natural/stone{
 	pixel_x = -5;
@@ -4023,6 +4011,16 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
+"bnB" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
+/obj/machinery/light/rogue/wallfire/candle/floorcandle{
+	pixel_y = -14
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "bnF" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/dirt/road,
@@ -4201,6 +4199,14 @@
 "bqP" = (
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/mountains)
+"bqQ" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/structure/roguetent,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "bqZ" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/churchrough,
@@ -4239,24 +4245,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblindungeon)
 "brh" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
 	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1";
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
-"bri" = (
-/obj/structure/hotspring,
-/obj/effect/lily_petal,
-/obj/structure/hotspring/border/twelve{
-	pixel_y = 13;
-	pixel_x = -13
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
+/area/rogue/outdoors/woods)
 "brv" = (
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/rogue/grassyel,
@@ -4278,9 +4270,6 @@
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
-"brR" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "brS" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -4289,10 +4278,6 @@
 	smooth_icon = null
 	},
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"brT" = (
-/obj/structure/stairs,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "brW" = (
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
@@ -4417,7 +4402,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "btN" = (
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/bed/rogue/bedroll,
+/obj/effect/landmark/start/druid{
+	dir = 1
+	},
+/turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/woods)
 "btP" = (
 /turf/closed/wall/mineral/rogue/tent{
@@ -4482,6 +4471,12 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
+"buC" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "buD" = (
 /obj/structure/rack/rogue/shelf,
 /obj/item/reagent_containers/glass/cup/wooden{
@@ -4575,10 +4570,6 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
-"bvM" = (
-/obj/structure/flora/roguegrass/herb/random,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/shelter/woods)
 "bwp" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -4718,6 +4709,15 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
+"bxQ" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/machinery/light/rogue/cauldron,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "bxW" = (
 /obj/structure/closet/crate/chest/neu_fancy{
 	locked = 1;
@@ -4752,11 +4752,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/basement)
 "byw" = (
-/obj/structure/flora/sakura{
-	pixel_x = -54;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/grassyel,
+/obj/structure/chair/hotspring_bench/left,
+/obj/effect/decal/mossy,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "byz" = (
 /obj/machinery/tanningrack,
@@ -4770,13 +4768,6 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
-"byK" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/obj/structure/fluff/railing/border{
-	pixel_y = -6
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "byP" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/cobble,
@@ -4829,6 +4820,10 @@
 /obj/structure/bed/rogue/inn/wool,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/woods)
+"bzF" = (
+/obj/item/alch/salvia,
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "bzG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -4908,6 +4903,12 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"bAD" = (
+/obj/structure/curtain/magenta{
+	color = 54202a
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "bAO" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /obj/structure/closet/crate/chest,
@@ -4923,9 +4924,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "bAZ" = (
-/obj/item/alch/salvia,
-/turf/open/water/bath,
-/area/rogue/indoors/town/bath)
+/turf/open/water/swamp,
+/area/rogue/outdoors/river)
 "bBi" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -4941,6 +4941,12 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"bBp" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/rtfield/eora)
 "bBq" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/dirt,
@@ -4977,7 +4983,7 @@
 	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "bBG" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/sewer)
@@ -5057,13 +5063,6 @@
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
-"bDe" = (
-/obj/machinery/light/rogue/torchholder/hotspring/standing,
-/obj/effect/decal/cobble/mossy{
-	dir = 6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "bDg" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/rogue/torchholder/l,
@@ -5086,12 +5085,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"bDu" = (
-/obj/structure/glowshroom{
-	icon_state = "glowshroom2"
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
 "bDv" = (
 /obj/structure/rack/rogue,
 /obj/item/ingot/gold,
@@ -5178,6 +5171,13 @@
 "bFf" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/cave)
+"bFm" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "bFA" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -5208,6 +5208,15 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/sewer)
+"bFS" = (
+/obj/structure/hotspring,
+/obj/effect/lily_petal/two,
+/obj/structure/hotspring/border/ten{
+	pixel_y = -19;
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "bFV" = (
 /obj/effect/decal/remains/mole,
 /turf/open/floor/rogue/naturalstone,
@@ -5351,10 +5360,10 @@
 /area/rogue/indoors/town)
 "bIK" = (
 /obj/structure/fluff/railing/border{
-	dir = 10
+	dir = 6
 	},
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "bJa" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -5475,12 +5484,6 @@
 /obj/structure/fluff/wallclock,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement)
-"bJI" = (
-/obj/structure/flora/newbranch{
-	dir = 8
-	},
-/turf/open/water/pond,
-/area/rogue/outdoors/woods)
 "bJM" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/herringbone,
@@ -5585,6 +5588,10 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/basement)
+"bLH" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "bLK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -5702,13 +5709,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/cell)
-"bNB" = (
-/obj/structure/flora/sakura{
-	pixel_x = -58;
-	pixel_y = -9
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield/eora)
 "bNE" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/cell)
@@ -5787,11 +5787,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
-"bPB" = (
-/obj/structure/closet/crate/drawer,
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "bPC" = (
 /obj/effect/decal/mossy{
 	dir = 4
@@ -5813,6 +5808,11 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
+"bPK" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/natural/bundle/fibers/full,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "bPN" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/tile{
@@ -5856,6 +5856,11 @@
 /obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
+"bQI" = (
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "slittedwooddark"
+	},
+/area/rogue/indoors/shelter/woods)
 "bQU" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -5964,13 +5969,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter)
-"bSd" = (
-/obj/structure/table/wood{
-	icon_state = "longtable_mid"
-	},
-/obj/structure/rogue/trophy/deer,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/tavern)
 "bSn" = (
 /obj/item/grown/log/tree/small,
 /turf/open/water/swamp,
@@ -6174,13 +6172,6 @@
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"bUW" = (
-/obj/structure/flora/roguegrass/bush,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
 "bUX" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/beach/forest)
@@ -6189,6 +6180,10 @@
 /obj/effect/landmark/start/mercenary,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
+"bVk" = (
+/obj/structure/flora/hotspring_rocks/small/five,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "bVl" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile/masonic,
@@ -6280,8 +6275,8 @@
 /area/rogue/indoors/shelter)
 "bXk" = (
 /obj/structure/flora/newtree,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/shelter/woods)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "bXl" = (
 /obj/structure/fluff/walldeco/bigpainting{
 	pixel_x = 2
@@ -6358,11 +6353,18 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "bYj" = (
+/obj/item/rogue/instrument/lute,
+/obj/item/rogue/instrument/harp,
+/obj/item/rogue/instrument/guitar,
+/obj/item/rogue/instrument/flute,
+/obj/structure/closet/crate/chest/crate,
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/curtain/magenta{
-	color = 54202a;
-	pixel_y = 0
+	color = 54202a
 	},
+/obj/item/rogue/instrument/harp/handcarved,
+/obj/item/rogue/instrument/viola,
+/obj/item/rogue/instrument/hurdygurdy,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
 "bYk" = (
@@ -6460,6 +6462,13 @@
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"bZq" = (
+/obj/structure/hotspring,
+/obj/structure/hotspring/border/five{
+	pixel_y = 13
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "bZA" = (
 /obj/item/natural/rock/salt,
 /obj/effect/decal/cobbleedge{
@@ -6487,6 +6496,16 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
+"bZO" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/rtfield/eora)
+"bZR" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "bZT" = (
 /obj/structure/stairs{
 	dir = 1
@@ -6528,12 +6547,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
-"cak" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "cas" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -6559,6 +6572,10 @@
 "caL" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/mountains/decap)
+"caU" = (
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "caW" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/carpet,
@@ -6597,13 +6614,15 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/dwarfin)
-"cbE" = (
-/obj/structure/bars/shop/bronze,
-/turf/open/water/river{
+"cbt" = (
+/obj/structure/fluff/railing/wood{
 	dir = 1;
-	icon_state = "rockwd"
+	layer = 2.7;
+	pixel_y = 7
 	},
-/area/rogue/outdoors/woods)
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "cbR" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/dwarfin)
@@ -6634,11 +6653,13 @@
 /obj/effect/spawner/lootdrop/potion_ingredient,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/cave)
-"ccY" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/obj/structure/flora/roguegrass/bush,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/shelter/woods)
+"ccV" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch{
+	dir = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "cdf" = (
 /obj/structure/roguerock,
 /turf/open/water/swamp,
@@ -6704,20 +6725,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"ceO" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/obj/structure/table/wood/folding,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "ceR" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -6943,16 +6950,6 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"ciL" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
 "ciS" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt/road,
@@ -6985,12 +6982,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors)
-"cjd" = (
-/obj/structure/flora/roguegrass/bush{
-	pixel_x = -5
-	},
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/woods)
 "cjj" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/cooking,
@@ -7211,10 +7202,6 @@
 "cne" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/town)
-"cni" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "cnj" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/blocks,
@@ -7234,12 +7221,18 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "cnp" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink,
-/obj/machinery/light/rogue/wallfire/candle/floorcandle{
-	pixel_y = -14
+/obj/effect/falling_sakura,
+/obj/structure/table/church,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_y = 6
 	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals{
+	pixel_y = 6;
+	pixel_x = 11
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "cns" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/railing/border,
@@ -7289,15 +7282,6 @@
 	max_integrity = 5000
 	},
 /area/rogue/under/cave/mazedungeon)
-"cot" = (
-/obj/structure/chair/hotspring_bench/right{
-	dir = 4
-	},
-/obj/effect/decal/mossy{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "coB" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor6-old"
@@ -7392,6 +7376,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter)
+"cqv" = (
+/obj/structure/curtain/magenta{
+	color = 54202a;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "cqz" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/naturalstone,
@@ -7670,6 +7661,12 @@
 /obj/item/bedsheet/rogue/wool,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"cup" = (
+/obj/structure/flora/newbranch{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "cux" = (
 /obj/structure/lever/wall{
 	name = "Inner Portcullis Lever";
@@ -7734,16 +7731,6 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
-"cvP" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
-	},
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "cvU" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -7809,6 +7796,11 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"cwj" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
+/obj/structure/flora/rogueshroom/happy/mushroom4,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/river)
 "cwC" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/dirt,
@@ -7890,10 +7882,6 @@
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/mountains)
 "cxC" = (
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield/eora)
-"cxH" = (
-/obj/structure/hotspring/border/seven,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "cxP" = (
@@ -8209,17 +8197,6 @@
 "cDB" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/under/cave/dukecourt)
-"cDJ" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
 "cDU" = (
 /obj/effect/landmark/start/bogguardsman{
 	dir = 8;
@@ -8253,10 +8230,6 @@
 /obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/metal,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"cEy" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/shelter/woods)
 "cEz" = (
 /obj/structure/closet/dirthole,
 /turf/open/floor/rogue/dirt/road,
@@ -8347,6 +8320,11 @@
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/skeletoncrypt)
+"cFV" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/machinery/light/rogue/lanternpost,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "cFX" = (
 /mob/living/simple_animal/hostile/rogue/haunt,
 /turf/open/floor/rogue/wood,
@@ -8397,18 +8375,12 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "cGN" = (
-/obj/structure/chair/stool/rogue,
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"cGO" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle,
-/obj/item/alch/rosa,
-/obj/item/alch/rosa{
-	pixel_y = -7;
-	pixel_x = -13
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "cGT" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia,
 /turf/open/water/swamp/deep,
@@ -8435,6 +8407,10 @@
 "cHC" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"cHF" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "cHJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -8445,11 +8421,9 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
 "cHP" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
+/obj/structure/fluff/alch,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
+/area/rogue/indoors/shelter/woods)
 "cIe" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor6-old"
@@ -8584,14 +8558,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/underdark)
-"cKI" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 8;
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "cKK" = (
 /obj/item/cigbutt/roach{
 	pixel_x = 7;
@@ -8810,10 +8776,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/magician)
-"cML" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
 "cMM" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1
@@ -8905,6 +8867,12 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
+"cNN" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "cNS" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
@@ -8987,11 +8955,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
-"cOP" = (
-/obj/item/natural/rock,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/woods)
 "cOS" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/newtree,
@@ -9045,6 +9008,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblindungeon)
+"cPq" = (
+/obj/structure/vine,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "cPy" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cave/goblindungeon)
@@ -9101,6 +9068,33 @@
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
+"cQu" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/seeds/apple,
+/obj/item/seeds/apple,
+/obj/item/seeds/pear,
+/obj/item/seeds/pear,
+/obj/item/seeds/wheat/oat,
+/obj/item/seeds/wheat/oat,
+/obj/item/seeds/tea,
+/obj/item/seeds/tea,
+/obj/item/seeds/tangerine,
+/obj/item/seeds/tangerine,
+/obj/item/seeds/cabbage,
+/obj/item/seeds/cabbage,
+/obj/item/seeds/potato,
+/obj/item/seeds/potato,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/garlick,
+/obj/item/seeds/garlick,
+/obj/item/seeds/strawberry,
+/obj/item/seeds/plum,
+/obj/item/seeds/raspberry,
+/obj/item/seeds/blackberry,
+/obj/item/seeds/berryrogue,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "cQz" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -9128,11 +9122,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"cQR" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newleaf,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "cQS" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp/deep,
@@ -9168,6 +9157,10 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
+"cRf" = (
+/obj/effect/lily_petal/three,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "cRk" = (
 /obj/item/clothing/neck/roguetown/psicross/necra,
 /obj/structure/table/wood/fancy/black,
@@ -9183,27 +9176,17 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
+"cRJ" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "cRN" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/underdark)
-"cRQ" = (
-/obj/structure/hotspring,
-/obj/effect/lily_petal/three,
-/obj/structure/hotspring/border/nine{
-	pixel_x = 13;
-	pixel_y = -15
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
-"cSb" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 8
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "cSx" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/whip,
@@ -9227,10 +9210,6 @@
 /obj/item/reagent_containers/glass/bottle/claybottle/wine,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"cSM" = (
-/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
-/turf/open/water/bath,
-/area/rogue/indoors/town/bath)
 "cSN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia,
 /turf/open/floor/rogue/dirt,
@@ -9290,10 +9269,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
-"cTD" = (
-/obj/structure/vine,
-/turf/closed/wall/shroud,
-/area/rogue/outdoors/woods)
 "cTF" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -9665,11 +9640,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "cZA" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/fluff/railing/border,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
+	},
+/area/rogue/outdoors/rtfield/eora)
 "cZB" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt,
@@ -9698,6 +9675,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"dak" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "dap" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
@@ -9750,6 +9736,11 @@
 "daQ" = (
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
+"daR" = (
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "slittedwooddark"
+	},
+/area/rogue/outdoors/woods)
 "daS" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8;
@@ -9802,14 +9793,6 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/mazedungeon)
-"dcl" = (
-/obj/structure/fluff/walldeco/stone{
-	icon_state = "walldec6";
-	pixel_y = -12;
-	pixel_x = 1
-	},
-/turf/closed/wall/mineral/rogue/decostone/fluffstone,
-/area/rogue/indoors/town/tavern)
 "dcn" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/cave)
@@ -9838,6 +9821,12 @@
 /obj/structure/mannequin,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin)
+"dcP" = (
+/obj/structure/flora/newbranch{
+	dir = 1
+	},
+/turf/open/water/pond,
+/area/rogue/outdoors/woods)
 "dcU" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
@@ -9853,6 +9842,13 @@
 	},
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
+"dds" = (
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "ddu" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/church,
@@ -9945,10 +9941,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "dfN" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 6
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "dfR" = (
 /obj/structure/fluff/railing/border{
@@ -10017,12 +10013,12 @@
 /obj/structure/stone_tile/surrounding_tile/burnt,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"dgI" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+"dgQ" = (
+/obj/structure/flora/roguetree/pine{
+	icon_state = "pine3"
 	},
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield)
 "dgV" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -10059,6 +10055,12 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/infernal/hellhound,
 /turf/open/floor/carpet/stellar,
 /area/rogue/under/cave/goblinfort)
+"dhG" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 9
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "dhP" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/church,
@@ -10293,6 +10295,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town)
+"dmn" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "dmo" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
@@ -10319,6 +10328,25 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs/keep)
+"dmV" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
+"dnc" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle,
+/obj/item/alch/rosa,
+/obj/item/alch/rosa{
+	pixel_y = -7;
+	pixel_x = -13
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "dnd" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/carpet/inn,
@@ -10430,11 +10458,15 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
-"doK" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/machinery/light/rogue/lanternpost,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+"doN" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/item/alch/rosa,
+/obj/item/candle/eora/lit,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "doY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/royalblack,
@@ -10474,12 +10506,6 @@
 "dpy" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/shelter/woods)
-"dpz" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "dpF" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/dirt/road,
@@ -10494,9 +10520,15 @@
 	},
 /area/rogue/under/cave/dukecourt)
 "dpQ" = (
-/obj/structure/flora/roguegrass/thorn_bush,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
+/obj/structure/hotspring,
+/obj/effect/lily_petal/two,
+/obj/structure/hotspring/border/twelve{
+	icon_state = "hotspring_border_11";
+	pixel_y = 11;
+	pixel_x = 12
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "dqi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -10526,8 +10558,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
 "dqy" = (
-/turf/open/water/river,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/wallfire/candle/floorcandle,
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_x = -3;
+	pixel_y = -12
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "dqz" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -10564,6 +10601,10 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach)
+"dre" = (
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/indoors/town)
 "drf" = (
 /turf/closed/wall/mineral/rogue/stone/window,
 /area/rogue/outdoors/beach/forest)
@@ -10700,11 +10741,8 @@
 /turf/open/water/ocean,
 /area/rogue/under/cave)
 "dsA" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/river)
 "dsC" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -10747,6 +10785,18 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"dtc" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "dte" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/carpet/purple,
@@ -10767,6 +10817,12 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/dwarfin)
+"dtz" = (
+/obj/structure/fluff/railing/border{
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "dtA" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -10800,10 +10856,6 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
-"duw" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "duA" = (
 /obj/effect/decal/wood/herringbone{
 	dir = 10;
@@ -10866,9 +10918,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "dwp" = (
-/obj/structure/vine,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
+/obj/structure/flora/newtree,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "dwF" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia,
 /turf/open/water/swamp,
@@ -10968,12 +11021,6 @@
 "dyx" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave)
-"dyB" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
 "dyE" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -10985,6 +11032,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"dyO" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/swamp,
+/area/rogue/outdoors/river)
 "dyQ" = (
 /obj/item/book/rogue/beardling,
 /obj/item/book/rogue/blackmountain,
@@ -11132,6 +11183,16 @@
 	smooth_icon = null
 	},
 /area/rogue/indoors/town/garrison)
+"dAW" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "dBc" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/tile/harem2,
@@ -11238,11 +11299,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/woods)
-"dDi" = (
-/turf/closed/wall/mineral/rogue/wooddark{
-	icon_state = "slittedwooddark"
-	},
-/area/rogue/outdoors/woods)
 "dDj" = (
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/twig,
@@ -11367,14 +11423,6 @@
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
-"dFv" = (
-/obj/effect/particle_effect/smoke{
-	lifetime = 14400
-	},
-/turf/open/water/river{
-	icon_state = "rockwd"
-	},
-/area/rogue/outdoors/woods)
 "dFy" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/potion_ingredient/herb,
@@ -11401,9 +11449,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "dGk" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/newtree,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "dGl" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/cobble,
@@ -11474,13 +11525,6 @@
 /obj/item/rogueweapon/sword/decorated,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
-"dHy" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/decal/mossy{
-	dir = 8
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield/eora)
 "dHA" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -11537,11 +11581,9 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/underdark)
 "dIr" = (
-/obj/structure/glowshroom{
-	icon_state = "glowshroom3"
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/woods)
 "dIu" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/dirt/road,
@@ -11570,6 +11612,15 @@
 /obj/structure/flora/roguetree/pine/dead,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"dJj" = (
+/obj/structure/chair/hotspring_bench{
+	dir = 4
+	},
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "dJm" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/water/swamp/deep,
@@ -11711,10 +11762,6 @@
 /obj/structure/fluff/walldeco/psybanner,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/church/chapel)
-"dKU" = (
-/obj/machinery/gear_painter,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/shelter/woods)
 "dLa" = (
 /obj/machinery/light/rogue/torchholder/hotspring/standing,
 /turf/open/floor/rogue/grass,
@@ -11723,6 +11770,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/skeletoncrypt)
+"dLe" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "dLf" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -11813,10 +11866,6 @@
 	},
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/mountains/decap)
-"dMR" = (
-/obj/item/natural/stone,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/woods)
 "dMS" = (
 /obj/structure/table/church,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -11874,6 +11923,10 @@
 "dNG" = (
 /turf/open/water/pond,
 /area/rogue/outdoors/mountains)
+"dNJ" = (
+/obj/structure/closet/crate/chest/wicker,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "dNM" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -12008,7 +12061,7 @@
 	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "dQe" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cave/mazedungeon)
@@ -12026,10 +12079,11 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "dQi" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
+/obj/structure/flora/newbranch{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "dQo" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -12047,6 +12101,13 @@
 /obj/item/clothing/suit/roguetown/shirt/rags,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/cell)
+"dQu" = (
+/obj/structure/roguewindow,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "trader_stock_shutter"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/shop)
 "dQv" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -12159,10 +12220,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"dSw" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "dSz" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/AzureSand,
@@ -12292,6 +12349,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"dTL" = (
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "dTQ" = (
 /obj/structure/fermentation_keg/random,
 /turf/open/floor/rogue/tile{
@@ -12311,14 +12374,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/sewer)
-"dUx" = (
-/obj/structure/bed/rogue/inn/hay,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "dUy" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -12493,6 +12548,12 @@
 	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/vault)
+"dXb" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "dXi" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -12601,6 +12662,11 @@
 /obj/item/rogueweapon/shovel,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/church/basement)
+"dZt" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt/pink,
+/obj/effect/lily_petal/three,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "dZz" = (
 /obj/machinery/anvil,
 /obj/item/rogueweapon/hammer/iron,
@@ -12614,11 +12680,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
-"dZH" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
-/obj/item/alch/rosa,
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "dZM" = (
 /obj/machinery/light/rogue/oven/east,
 /turf/open/floor/rogue/hexstone,
@@ -12868,6 +12929,10 @@
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/beach)
+"edA" = (
+/obj/effect/decal/carpet/square,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "edB" = (
 /obj/structure/stairs{
 	dir = 1
@@ -12906,6 +12971,10 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"eew" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "eeF" = (
 /obj/effect/decal/remains/mole,
 /turf/open/floor/rogue/dirt,
@@ -12999,6 +13068,11 @@
 	},
 /turf/open/floor/rogue/concrete/bronze,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"efX" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/roguegrass/thorn_bush,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "egm" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -13064,12 +13138,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
-"ehh" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 5
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "ehi" = (
 /obj/structure/chair/stool/rogue,
 /obj/structure/roguemachine/scomm/l,
@@ -13109,9 +13177,8 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "ehr" = (
-/obj/structure/curtain/green,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "ehv" = (
 /obj/structure/roguewindow,
 /obj/structure/fluff/littlebanners{
@@ -13136,11 +13203,6 @@
 "ehN" = (
 /turf/open/floor/rogue/snowpatchy,
 /area/rogue/outdoors/mountains)
-"ehR" = (
-/obj/structure/chair/hotspring_bench/left,
-/obj/effect/decal/mossy,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield/eora)
 "ehT" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/beach)
@@ -13470,16 +13532,6 @@
 /obj/effect/decal/cleanable/blood/puddle,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors)
-"emf" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/newtree,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
 "emg" = (
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/cobble,
@@ -13557,6 +13609,12 @@
 "enr" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/cave/dragonden)
+"eny" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "enA" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -13834,9 +13892,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
-"ern" = (
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/woods)
 "err" = (
 /obj/item/natural/bone,
 /turf/open/floor/rogue/naturalstone,
@@ -13994,12 +14049,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
-"euz" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/bath)
 "euB" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -14637,6 +14686,19 @@
 /obj/item/rogueweapon/spear/billhook,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"eDY" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/obj/structure/rack/rogue,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/item/rogueweapon/stoneaxe,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "eDZ" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood/herringbone{
@@ -14663,6 +14725,9 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
+"eEM" = (
+/turf/closed/wall/mineral/rogue/stone/moss,
+/area/rogue/outdoors/river)
 "eEQ" = (
 /obj/effect/decal/remains/human,
 /obj/structure/fluff/railing/border{
@@ -14764,11 +14829,16 @@
 /turf/open/water/bloody,
 /area/rogue/indoors/shelter/mountains/decap)
 "eGq" = (
-/obj/structure/glowshroom{
-	icon_state = "glowshroom3"
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
 	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "eGx" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/outdoors/mountains)
@@ -14783,6 +14853,13 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/forest)
+"eGR" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "eGS" = (
 /obj/structure/lever/wall{
 	dir = 8;
@@ -14790,16 +14867,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
-"eGU" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/candle/yellow{
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/tavern)
 "eHa" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
@@ -14820,11 +14887,12 @@
 /turf/closed/mineral/rogue/coal,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "eHC" = (
-/obj/structure/glowshroom{
-	icon_state = "glowshroom3"
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/connector{
+	dir = 4
 	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "eHJ" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt,
@@ -14924,10 +14992,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
-"eJz" = (
-/obj/effect/decal/carpet/kover_purple,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "eJC" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -14980,6 +15044,12 @@
 /obj/effect/landmark/start/orphan,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"eLc" = (
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "slittedwooddark"
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "eLe" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -15066,12 +15136,6 @@
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/shelter/mountains/decap)
-"eMp" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "eMr" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/naturalstone,
@@ -15088,6 +15152,10 @@
 "eMx" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/woods)
+"eMB" = (
+/obj/structure/glowshroom,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/indoors/cave)
 "eMG" = (
 /obj/structure/bars{
 	color = "#755f48";
@@ -15147,10 +15215,11 @@
 	},
 /area/rogue/indoors/shelter/woods)
 "eOe" = (
-/obj/item/natural/rock,
-/turf/open/water/river{
-	icon_state = "rockwd"
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
 	},
+/turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "eOn" = (
 /obj/item/grown/log/tree/stick,
@@ -15257,14 +15326,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter)
-"eQf" = (
-/obj/structure/hotspring/border/three,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield/eora)
-"eQi" = (
-/obj/structure/flora/rogueshroom/happy/mushroom4,
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
 "eQn" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
@@ -15274,6 +15335,10 @@
 /obj/item/rope/chain,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
+"eQE" = (
+/obj/effect/lily_petal,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "eQF" = (
 /obj/structure/bars/passage{
 	density = 0;
@@ -15324,6 +15389,16 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
+"eRi" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "eRm" = (
 /obj/structure/chair/bench/couchablack,
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
@@ -15457,10 +15532,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
-"eTF" = (
-/obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/shelter/woods)
 "eTJ" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -15888,6 +15959,15 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
+"faJ" = (
+/obj/structure/hotspring{
+	icon_state = "lilypetals2"
+	},
+/obj/structure/flora/newbranch{
+	dir = 8
+	},
+/turf/open/water/pond,
+/area/rogue/outdoors/woods)
 "faM" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grassred,
@@ -15978,6 +16058,12 @@
 "fce" = (
 /turf/open/water/ocean,
 /area/rogue/outdoors/beach)
+"fcm" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "fcn" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -16134,10 +16220,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "fdJ" = (
-/turf/closed/wall/mineral/rogue/wooddark{
-	icon_state = "wooddark-k"
-	},
-/area/rogue/under/cave/goblindungeon)
+/obj/structure/flora/newleaf,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/flashlight/flare/torch/lantern,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "fdL" = (
 /obj/structure/fluff/littlebanners,
 /turf/open/floor/rogue/grass,
@@ -16188,6 +16276,11 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
+"feq" = (
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
+	},
+/area/rogue/under/cave/goblindungeon)
 "feu" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave)
@@ -16226,9 +16319,13 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/woods)
 "feV" = (
-/obj/structure/flora/newleaf,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "ffa" = (
 /obj/structure/fluff/customsign{
 	name = "TURN BACK NOW!!!"
@@ -16475,11 +16572,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach/forest)
-"fjp" = (
-/obj/structure/hotspring/border/eleven,
-/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "fju" = (
 /turf/open/water/swamp,
 /area/rogue/under/cave)
@@ -16501,7 +16593,7 @@
 /turf/open/water/river{
 	icon_state = "rockwd"
 	},
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "fjI" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/blocks,
@@ -16599,6 +16691,10 @@
 	},
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
+"fle" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "flm" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = 32
@@ -16714,10 +16810,6 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"fmC" = (
-/obj/structure/vine,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/shelter/woods)
 "fmF" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16791,12 +16883,6 @@
 "fnC" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
-"fnG" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 5
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
 "fnJ" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/outdoors/bog)
@@ -16879,12 +16965,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"foS" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
 "foY" = (
 /obj/structure/bed/rogue/inn/double{
 	dir = 1
@@ -16909,15 +16989,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/cave)
-"fpq" = (
-/obj/structure/flora/roguetree/burnt{
-	pixel_y = 11
-	},
-/obj/structure/fluff/railing/border,
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
 "fpx" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -16969,6 +17040,14 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/dwarfin)
+"fqb" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "fqc" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
@@ -17092,19 +17171,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"frC" = (
-/obj/structure/flora/sakura{
-	pixel_x = -57;
-	pixel_y = -3
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield/eora)
-"frL" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/bath)
 "frP" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/horny_armor_spawner,
@@ -17236,6 +17302,12 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/roofs/keep)
+"fuA" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "fuG" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -17394,6 +17466,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/exposed/town/keep)
+"fwZ" = (
+/obj/structure/vine,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/woods)
 "fxp" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
@@ -17523,15 +17599,6 @@
 /obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
-"fyO" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/obj/machinery/light/rogue/cauldron,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "fyQ" = (
 /obj/item/bedsheet/rogue/double_pelt,
 /obj/structure/bed/rogue/inn/wooldouble,
@@ -17595,6 +17662,13 @@
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"fzT" = (
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "fzU" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -17610,6 +17684,18 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"fAa" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
+"fAi" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "fAm" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/basement)
@@ -17735,14 +17821,6 @@
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
-"fCm" = (
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	pixel_x = -4;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "fCr" = (
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/blocks,
@@ -17952,15 +18030,6 @@
 /obj/item/clothing/suit/roguetown/shirt/robe/mage,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"fGf" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "fGp" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/structure/fluff/walldeco/med5{
@@ -18051,15 +18120,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"fHG" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 6
-	},
-/obj/effect/decal/cobble/mossy{
-	dir = 9
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
 "fHT" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -18135,6 +18195,12 @@
 /obj/item/storage/belt/rogue/pouch/coins/rich,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"fJf" = (
+/obj/structure/spider/stickyweb{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "fJk" = (
 /obj/item/natural/stone{
 	pixel_x = -5;
@@ -18232,9 +18298,14 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "fKJ" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/roguegrass,
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "fKK" = (
 /obj/structure/bed/rogue/inn/hay{
 	dir = 1
@@ -18292,10 +18363,7 @@
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/under/cave/licharena)
 "fLM" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/obj/effect/landmark/start/villager,
+/obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "fLP" = (
@@ -18357,16 +18425,6 @@
 	},
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
-"fMu" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
-/obj/machinery/light/rogue/wallfire/candle/floorcandle{
-	pixel_y = -14
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "fMw" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/outdoors/mountains)
@@ -18406,6 +18464,9 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/shelter/woods)
+"fNd" = (
+/turf/closed/wall/mineral/rogue/decostone/fluffstone,
+/area/rogue/indoors/town/tavern)
 "fNn" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -18500,6 +18561,13 @@
 /obj/item/ingot/iron,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"fOE" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch{
+	dir = 1
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "fOQ" = (
 /obj/structure/bed/rogue/inn/hay,
 /mob/living/carbon/human/species/goblin/npc/ambush/sea,
@@ -18533,11 +18601,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/cell)
-"fPD" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "fPO" = (
 /obj/structure/glowshroom,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -18678,6 +18741,10 @@
 /mob/living/simple_animal/pet/cat/rogue/black,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church/basement)
+"fRQ" = (
+/obj/structure/flora/roguegrass/herb/random,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "fRR" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
@@ -18838,6 +18905,18 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/volcanic,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"fUu" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
+"fUB" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "fUD" = (
 /obj/machinery/light/rogue/wallfire/candle/off/r,
 /turf/open/floor/rogue/wood,
@@ -18921,13 +19000,6 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
-"fVL" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/connector{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "fVR" = (
 /obj/structure/closet/crate/drawer,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -18978,12 +19050,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
 "fWu" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
+/obj/structure/hotspring/border/three,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "fWw" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -19160,14 +19229,9 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "fZe" = (
-/obj/structure/chair/hotspring_bench/corner{
-	dir = 4
-	},
-/obj/effect/decal/mossy{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
+/obj/item/natural/rock,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "fZg" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/naturalstone,
@@ -19256,13 +19320,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/woods)
-"gbd" = (
-/obj/structure/bars,
-/obj/structure/glowshroom{
-	icon_state = "glowshroom2"
-	},
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cave/goblindungeon)
 "gbg" = (
 /obj/structure/fermentation_keg/random/water,
 /obj/machinery/light/rogue/torchholder/l,
@@ -19286,17 +19343,6 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cavewet/bogcaves)
-"gby" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield/eora)
 "gbU" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -19447,11 +19493,6 @@
 	},
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
-"ged" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/woodclub,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "gee" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/gloves/roguetown/fingerless_leather,
@@ -19517,12 +19558,6 @@
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
-"gfu" = (
-/obj/structure/glowshroom{
-	icon_state = "glowshroom2"
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "gfv" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -19572,6 +19607,10 @@
 /obj/machinery/light/rogue/oven/east,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"ggv" = (
+/obj/structure/flora/roguegrass/thorn_bush,
+/turf/closed/wall/shroud,
+/area/rogue/outdoors/woods)
 "ggy" = (
 /obj/structure/flora/roguetree/pine/dead,
 /turf/open/floor/rogue/grass,
@@ -19638,15 +19677,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
-"ghB" = (
-/obj/structure/flora/newleaf,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_x = 8
-	},
-/obj/structure/bed/rogue/inn/hay,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "ghJ" = (
 /mob/living/carbon/human/species/goblin/npc/hell,
 /turf/open/floor/rogue/grasscold,
@@ -19914,6 +19944,13 @@
 "gnI" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/shelter/woods)
+"gnJ" = (
+/obj/structure/vine,
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "gnN" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -19957,9 +19994,11 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/under/underdark)
 "gpd" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/roguewindow/harem3{
+	name = "Frosted Glass Window"
+	},
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/indoors/town/tavern)
 "gpe" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road,
@@ -20217,16 +20256,6 @@
 	},
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
-"gry" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/bath)
-"grz" = (
-/obj/effect/lily_petal/three,
-/turf/open/water/bath,
-/area/rogue/indoors/town/bath)
 "grA" = (
 /obj/item/clothing/suit/roguetown/shirt/dress/royal,
 /obj/item/clothing/wrists/roguetown/royalsleeves,
@@ -20338,6 +20367,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"gtQ" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "gtR" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/fabric,
@@ -20531,7 +20566,7 @@
 "gwq" = (
 /obj/structure/roguerock,
 /turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "gwr" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -20830,6 +20865,10 @@
 /obj/item/rogueweapon/shovel,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"gAk" = (
+/obj/structure/flora/roguegrass/herb/random,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "gAn" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -20874,6 +20913,20 @@
 /obj/structure/fluff/walldeco/wantedposter/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"gAS" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/greenstone/runed,
+/area/rogue/outdoors/woods)
 "gAZ" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 1
@@ -20908,6 +20961,12 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/woods)
+"gBo" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/river)
 "gBD" = (
 /turf/closed/wall/mineral/rogue/decostone/cand{
 	max_integrity = 99999
@@ -20939,11 +20998,6 @@
 "gCJ" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/shelter)
-"gCO" = (
-/obj/structure/closet/crate/chest/wicker,
-/obj/item/natural/bundle/fibers/full,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "gCP" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/rogue/blocks,
@@ -20956,6 +21010,9 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
+"gDq" = (
+/turf/closed/mineral/random/rogue,
+/area/rogue/outdoors/river)
 "gDu" = (
 /obj/structure/globe,
 /turf/open/floor/rogue/dirt,
@@ -21063,14 +21120,6 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"gEA" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/roguemachine/noticeboard{
-	pixel_y = -12;
-	pixel_x = 2
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
 "gEC" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/cobblerock,
@@ -21087,6 +21136,14 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
+"gFb" = (
+/obj/structure/table/church/m,
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "gFm" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -21241,10 +21298,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter/mountains/decap)
-"gHx" = (
-/obj/structure/flora/roguegrass/herb/random,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/woods)
 "gHA" = (
 /obj/structure/bed/rogue/inn/hay{
 	dir = 1
@@ -21486,9 +21539,9 @@
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "gLC" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "gLG" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt,
@@ -21704,6 +21757,11 @@
 /obj/structure/vine,
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cave/goblindungeon)
+"gQj" = (
+/obj/item/natural/rock,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "gQr" = (
 /obj/effect/decal/cleanable/debris/woody{
 	dir = 2
@@ -21748,12 +21806,6 @@
 	},
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/cave)
-"gRo" = (
-/obj/structure/hotspring{
-	icon_state = "lilypetals1"
-	},
-/turf/open/water/pond,
-/area/rogue/outdoors/woods)
 "gRy" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/railing/wood{
@@ -21913,11 +21965,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach/forest)
-"gTC" = (
-/obj/structure/flora/newtree,
-/obj/structure/flora/newleaf,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/shelter/woods)
 "gTH" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/beach/forest)
@@ -21958,6 +22005,10 @@
 "gTY" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church/chapel)
+"gUd" = (
+/obj/effect/particle_effect/smoke,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "gUu" = (
 /obj/structure/far_travel,
 /turf/open/floor/rogue/cobblerock,
@@ -22094,12 +22145,6 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/mountains/decap/stepbelow)
-"gWt" = (
-/turf/open/floor/rogue/grass,
-/turf/closed/wall/mineral/rogue/wooddark{
-	icon_state = "wooddark-k"
-	},
-/area/rogue/indoors/shelter/woods)
 "gWE" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -22148,6 +22193,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town)
+"gWP" = (
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "gWQ" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -22162,9 +22211,12 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
 "gXi" = (
-/obj/structure/flora/newtree,
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch{
+	dir = 4
+	},
 /turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/area/rogue/outdoors/mountains)
 "gXk" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -22215,13 +22267,23 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
-"gYo" = (
-/turf/open/floor/rogue/grassyel,
-/area/rogue/indoors/town)
 "gYq" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"gYy" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 6;
+	pixel_y = 0
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "gYE" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
@@ -22311,6 +22373,12 @@
 /obj/item/roguegem/violet,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
+"gZY" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "hag" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -22375,19 +22443,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter/mountains/decap)
-"haW" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/obj/structure/rack/rogue,
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/obj/item/rogueweapon/stoneaxe,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "haY" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt/road,
@@ -22472,11 +22527,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/physician)
-"hbH" = (
-/obj/effect/falling_sakura,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield/eora)
 "hbQ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/rogue/hexstone,
@@ -22701,12 +22751,16 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/exposed/town/keep)
 "heG" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch{
-	dir = 1
-	},
-/turf/open/floor/rogue/twig,
+/turf/closed/wall/shroud,
 /area/rogue/outdoors/mountains)
+"heP" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = 7
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "hfa" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
@@ -22754,12 +22808,15 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/beach)
 "hfu" = (
-/obj/effect/wisp/prestidigitation,
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
+/obj/structure/flora/newtree,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "hfx" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/beach)
+"hfA" = (
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/outdoors/rtfield/eora)
 "hfK" = (
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/naturalstone,
@@ -22785,6 +22842,12 @@
 /obj/structure/glowshroom,
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bog)
+"hgj" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "hgl" = (
 /obj/structure/bed/rogue/inn{
 	dir = 1
@@ -22842,12 +22905,22 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
+"hhu" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "hhv" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
+"hhA" = (
+/obj/item/natural/rock,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "hhG" = (
 /obj/item/roguestatue/iron,
 /obj/structure/table/wood,
@@ -22912,6 +22985,18 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"hhU" = (
+/obj/structure/stairs,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/woods)
 "hhX" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/wood/herringbone{
@@ -22929,6 +23014,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"hid" = (
+/turf/open/floor/rogue/dirt/road,
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
+	},
+/area/rogue/indoors/shelter/woods)
 "hie" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
@@ -22936,6 +23027,11 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/manor)
+"hik" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/leafless,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "hio" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/skull{
@@ -22986,6 +23082,13 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/skeletoncrypt)
+"hiB" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/woods)
 "hiH" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -23011,6 +23114,10 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
+"hjf" = (
+/obj/structure/glowshroom,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "hji" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/closed/mineral/random/rogue/med,
@@ -23033,10 +23140,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/underdark)
-"hjL" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town)
 "hkf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -23130,8 +23233,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "hlK" = (
-/turf/closed/wall/shroud,
-/area/rogue/outdoors/woods)
+/obj/structure/stairs,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "hlN" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/outdoors/exposed/town/keep)
@@ -23165,6 +23269,10 @@
 "hmi" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"hml" = (
+/obj/effect/decal/carpet/kover_purple,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "hmp" = (
 /obj/structure/closet/crate/drawer,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -23198,11 +23306,18 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "hmM" = (
-/obj/effect/decal/cobble/mossy{
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/rtfield/eora)
+"hmP" = (
+/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "hmQ" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/dirt/road,
@@ -23286,12 +23401,6 @@
 /obj/item/clothing/gloves/roguetown/chain,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
-"hon" = (
-/obj/structure/flora/roguetree/pine{
-	icon_state = "pine3"
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield)
 "hoo" = (
 /obj/structure/flora/rogueshroom{
 	pixel_y = -5
@@ -23391,13 +23500,10 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
 "hqA" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 4;
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
+/obj/structure/flora/newleaf,
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "hqE" = (
 /obj/structure/flora/roguegrass/water/reeds{
 	pixel_y = 4
@@ -23461,12 +23567,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
-"hrm" = (
-/obj/structure/spider/stickyweb{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "hrn" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -23493,6 +23593,15 @@
 	dir = 1
 	},
 /area/rogue/outdoors/mountains)
+"hry" = (
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "hrz" = (
 /obj/structure/bars/steel{
 	max_integrity = 500
@@ -23538,6 +23647,13 @@
 "hrT" = (
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/goblinfort)
+"hrV" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink,
+/obj/machinery/light/rogue/wallfire/candle/floorcandle{
+	pixel_y = -14
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "hrY" = (
 /obj/structure/mineral_door/wood/donjon,
 /turf/open/floor/rogue/cobble/mossy,
@@ -23638,6 +23754,9 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach)
+"htp" = (
+/turf/closed/wall/mineral/rogue/stone/window/moss,
+/area/rogue/outdoors/woods)
 "htv" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
@@ -23858,6 +23977,13 @@
 /obj/structure/table/church/m,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
+"hwf" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "hwj" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -23916,6 +24042,15 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cave/skeletoncrypt)
+"hwV" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/yellow{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/tavern)
 "hxa" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/church,
@@ -23985,6 +24120,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"hyg" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/river)
 "hyh" = (
 /obj/structure/stairs{
 	dir = 8
@@ -24040,6 +24182,17 @@
 /obj/machinery/anvil,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"hyy" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "hyA" = (
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/alt/pink,
 /turf/open/floor/rogue/tile/brownbrick,
@@ -24058,10 +24211,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/physician)
-"hyF" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "hyG" = (
 /obj/structure/fluff/psycross{
 	pixel_y = 15
@@ -24171,10 +24320,6 @@
 /obj/item/rogueweapon/huntingknife/idagger/steel,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"hAp" = (
-/obj/structure/vine,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
 "hAG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -24383,18 +24528,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/shelter/woods)
-"hDG" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "hDH" = (
 /obj/structure/rack/rogue,
 /obj/item/book/rogue/sword,
@@ -24420,12 +24553,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"hEi" = (
-/obj/effect/lily_petal/three{
-	icon_state = "lilypetals1"
-	},
-/turf/open/water/bath,
-/area/rogue/indoors/town/bath)
 "hEo" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
@@ -24479,11 +24606,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
 "hEY" = (
-/turf/open/floor/rogue/twig,
-/turf/closed/wall/mineral/rogue/wooddark{
-	icon_state = "wooddark-k"
-	},
-/area/rogue/indoors/shelter/woods)
+/obj/structure/table/church,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "hFr" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dukecourt)
@@ -24504,6 +24629,14 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
 /turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/shelter/mountains/decap)
+"hFC" = (
+/obj/structure/flora/roguegrass/herb/random,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/river)
+"hFD" = (
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "hFF" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -24613,8 +24746,9 @@
 	},
 /area/rogue/indoors/town/physician)
 "hHg" = (
-/obj/structure/fluff/statue/gargoyle/moss,
-/turf/open/floor/rogue/dirt,
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/woods)
 "hHl" = (
 /turf/open/water/river{
@@ -24627,11 +24761,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/woods)
 "hHG" = (
-/obj/effect/lily_petal/three{
-	icon_state = "lilypetals2"
-	},
-/turf/open/water/bath,
-/area/rogue/indoors/town/bath)
+/obj/effect/decal/carpet/kover_black,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/tavern)
 "hHJ" = (
 /obj/structure/bars/steel,
 /turf/open/floor/rogue/blocks,
@@ -24717,17 +24849,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"hJn" = (
-/obj/structure/flora/hotspring_rocks/small{
-	pixel_y = -17;
-	pixel_x = 8
-	},
-/obj/structure/closet/crate/chest/wicker,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/clothing/under/roguetown/loincloth,
-/obj/item/soap/bath,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/woods)
 "hJo" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -24761,13 +24882,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/underdark)
-"hJW" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/obj/structure/fluff/railing/border{
-	pixel_y = -6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "hKh" = (
 /obj/structure/bars/pipe{
 	dir = 9
@@ -24865,6 +24979,16 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
+"hLA" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
+"hLJ" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "hLN" = (
 /obj/structure/far_travel,
 /turf/open/floor/rogue/cobble,
@@ -24898,11 +25022,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement)
 "hMt" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/bearpelt{
+	pixel_y = -16;
+	pixel_x = -13
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/woods)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "hMv" = (
 /obj/structure/stairs{
 	dir = 1
@@ -24942,13 +25067,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cave/mazedungeon)
-"hMM" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "hMR" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -25238,9 +25356,6 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet/bogcaves)
-"hSt" = (
-/turf/closed/wall/mineral/rogue/decostone/fluffstone,
-/area/rogue/indoors/town/tavern)
 "hSE" = (
 /obj/item/natural/bowstring,
 /turf/open/floor/rogue/concrete,
@@ -25253,6 +25368,12 @@
 "hSR" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"hSV" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "hSY" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/carpet/red,
@@ -25307,13 +25428,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
-"hTS" = (
-/obj/structure/hotspring,
-/obj/structure/hotspring/border/five{
-	pixel_y = 13
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "hUe" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -25368,10 +25482,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/shelter/woods)
-"hVz" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/woods)
 "hVG" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork{
@@ -25442,14 +25552,6 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town)
-"hWm" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 10;
-	pixel_y = 0;
-	pixel_x = 7
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
 "hWq" = (
 /obj/structure/mineral_door/wood/violet{
 	locked = 1
@@ -25485,6 +25587,13 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"hWB" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "hWN" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 8
@@ -25663,6 +25772,16 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"hZI" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "iaa" = (
 /obj/structure/curtain/magenta{
 	color = 54202a
@@ -25706,19 +25825,16 @@
 	},
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "iaM" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
+/obj/structure/hotspring,
+/obj/structure/hotspring/border/seven{
+	pixel_x = -18
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "iaP" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"iaY" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "ibc" = (
 /obj/structure/fluff/walldeco/painting/queen,
 /turf/closed/wall/mineral/rogue/decostone/long{
@@ -26078,6 +26194,13 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone/window,
 /area/rogue/outdoors/beach/forest)
+"ifC" = (
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "ifD" = (
 /obj/item/rogueore/silver,
 /turf/open/floor/rogue/naturalstone,
@@ -26247,10 +26370,6 @@
 /obj/structure/flora/newleaf,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
-"iiC" = (
-/obj/structure/flora/hotspring_rocks/small/three,
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
 "iiJ" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/natural/stone,
@@ -26274,13 +26393,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
-"iiV" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/newtree,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
 "ijd" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -26398,12 +26510,6 @@
 /obj/structure/fluff/statue/scare,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
-"iko" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 1
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/shelter/woods)
 "ikr" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -26438,22 +26544,17 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "ikY" = (
-/obj/structure/fluff/railing/border{
-	dir = 10;
-	pixel_y = -7
+/obj/structure/vine,
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
+/obj/structure/plasticflaps,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave/goblindungeon)
 "ila" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave)
-"ilj" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "ilm" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -26521,11 +26622,24 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter)
+"imi" = (
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/river)
 "imq" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/candle/yellow,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"imy" = (
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "imz" = (
 /obj/structure/closet/crate/chest,
 /obj/item/paper/inquisition_poultice_info,
@@ -26568,6 +26682,10 @@
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves)
+"imP" = (
+/obj/structure/flora/rogueshroom/happy/mushroom2,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave)
 "imT" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -26615,12 +26733,6 @@
 "inF" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/mazedungeon)
-"inL" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "inM" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -26697,6 +26809,12 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
+"ioO" = (
+/obj/structure/hotspring{
+	icon_state = "lilypetals3"
+	},
+/turf/open/water/pond,
+/area/rogue/outdoors/woods)
 "ioQ" = (
 /obj/structure/stairs{
 	dir = 8
@@ -26788,6 +26906,17 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
+"ipZ" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "iqc" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 1
@@ -27056,6 +27185,9 @@
 /obj/effect/spawner/lootdrop/general_loot_low,
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cave/orcdungeon)
+"itZ" = (
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/river)
 "iub" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grassred,
@@ -27074,12 +27206,6 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
-"ium" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/shelter/woods)
 "iuA" = (
 /obj/structure/roguemachine/vendor/bathhouse,
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -27099,6 +27225,10 @@
 	dir = 8
 	},
 /area/rogue/indoors/shelter)
+"ivj" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "ivl" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -27146,10 +27276,6 @@
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"ivZ" = (
-/obj/structure/vine,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/woods)
 "iwm" = (
 /obj/structure/vine{
 	opacity = 1
@@ -27262,11 +27388,6 @@
 /obj/item/ingot/blacksteel,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
-"iyc" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newleaf,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
 "iyf" = (
 /obj/structure/table/vtable/v2,
 /obj/item/roguegem/violet{
@@ -27352,9 +27473,14 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/shelter)
 "iAh" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/town)
+/obj/effect/particle_effect/smoke{
+	lifetime = 14400
+	},
+/obj/item/natural/rock,
+/turf/open/water/river{
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/river)
 "iAB" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/grasscold,
@@ -27493,10 +27619,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/mountains/decap)
-"iCt" = (
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water/pond,
-/area/rogue/outdoors/woods)
 "iCw" = (
 /obj/structure/bars/passage/shutter/open,
 /turf/open/floor/rogue/metal{
@@ -27696,6 +27818,10 @@
 	},
 /turf/open/floor/rogue/concrete/bronze,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"iFZ" = (
+/obj/structure/fluff/statue/knight/interior/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "iGc" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/neck/roguetown/chaincoif/iron,
@@ -28057,10 +28183,6 @@
 "iLo" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
-"iLt" = (
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
 "iLv" = (
 /obj/structure/chair/wood/rogue/chair3,
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
@@ -28263,14 +28385,6 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors)
-"iOg" = (
-/obj/machinery/light/rogue/torchholder/hotspring/standing,
-/obj/effect/decal/cobble/mossy{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "iOk" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -28293,12 +28407,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
 "iOt" = (
-/obj/structure/hotspring,
-/obj/effect/lily_petal/two,
-/obj/structure/hotspring/border/ten{
-	pixel_y = -19;
-	pixel_x = -14
-	},
+/obj/structure/hotspring/border/eleven,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "iOC" = (
@@ -28355,11 +28465,6 @@
 "iOX" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/shelter/woods)
-"iPf" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "iPh" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned,
@@ -28644,6 +28749,18 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
+"iUI" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 9
+	},
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "iUO" = (
 /obj/structure/bed/rogue/inn{
 	dir = 1
@@ -28677,6 +28794,10 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
+"iVD" = (
+/obj/structure/flora/roguegrass/thorn_bush,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "iVE" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/garrison)
@@ -28735,6 +28856,12 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
+"iWu" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "iWC" = (
 /obj/structure/flora/roguegrass/thorn_bush,
 /obj/structure/fluff/railing/wood{
@@ -28815,9 +28942,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "iXm" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/river)
 "iXq" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -28882,6 +29011,13 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
+"iYi" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
+	},
+/obj/structure/flora/roguegrass/thorn_bush,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "iYj" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/ruinedwood{
@@ -29001,10 +29137,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"iZR" = (
-/obj/machinery/tanningrack,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "iZX" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 4
@@ -29037,6 +29169,13 @@
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"jaB" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "jaL" = (
 /obj/structure/bars/passage/shutter{
 	redstone_id = "merchroofshutt"
@@ -29236,12 +29375,6 @@
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"jdg" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "jdh" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -29515,17 +29648,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/shelter/woods)
-"jhf" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "jhm" = (
 /obj/structure/vine,
 /obj/effect/decal/cleanable/greenglow{
@@ -29633,6 +29755,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"jiH" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "jiQ" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -29703,6 +29829,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"jjM" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "jjR" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/mountains)
@@ -29805,6 +29937,11 @@
 /obj/item/ingot/silver,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
+"jlR" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/woodclub,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "jlT" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/machinery/light/rogue/hearth,
@@ -29877,6 +30014,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"jmX" = (
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "jnh" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/table/wood,
@@ -29941,6 +30084,17 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
+"joN" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "joP" = (
 /obj/effect/decal/mossy{
 	dir = 1
@@ -30125,15 +30279,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
-"jrR" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1";
-	pixel_y = -4
-	},
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "jrV" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -30305,6 +30450,13 @@
 "juE" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/cave)
+"jvb" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "jvc" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/greenstone,
@@ -30391,6 +30543,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cave/dukecourt)
+"jwy" = (
+/obj/structure/hotspring,
+/obj/effect/lily_petal/three,
+/obj/structure/hotspring/border/nine{
+	pixel_x = 13;
+	pixel_y = -15
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "jwL" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/dirt,
@@ -30416,7 +30577,7 @@
 "jxj" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "jxk" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood,
@@ -30440,10 +30601,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/mountains/decap)
-"jxy" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "jxz" = (
 /obj/item/grown/log/tree/small,
 /obj/structure/table/wood{
@@ -30559,6 +30716,10 @@
 	},
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
+"jzb" = (
+/obj/item/natural/stone,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "jzk" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
@@ -30897,10 +31058,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/under/cave/dukecourt)
-"jGc" = (
-/obj/structure/flora/roguegrass/thorn_bush,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "jGd" = (
 /obj/structure/fluff/pillow/magenta,
 /turf/open/floor/rogue/tile/harem,
@@ -31030,6 +31187,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"jIC" = (
+/obj/structure/vine,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/woods)
 "jIE" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -31048,6 +31209,9 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/church/basement)
+"jIP" = (
+/turf/closed/wall/shroud,
+/area/rogue/outdoors/river)
 "jIT" = (
 /obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -31137,14 +31301,6 @@
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"jKc" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "jKf" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 8
@@ -31196,12 +31352,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
-"jKU" = (
-/obj/structure/flora/roguegrass/bush{
-	pixel_x = 5
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "jKV" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/robber,
@@ -31215,11 +31365,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"jLH" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newleaf,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "jLU" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors)
@@ -31599,6 +31744,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
+"jSF" = (
+/obj/effect/particle_effect/smoke{
+	lifetime = 14400
+	},
+/turf/open/water/river{
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/river)
 "jSG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -31622,10 +31775,6 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"jST" = (
-/obj/machinery/light/rogue/torchholder/hotspring,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "jTc" = (
 /obj/structure/hotspring/border/three,
 /obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
@@ -31733,12 +31882,6 @@
 /obj/structure/roguemachine/vendor,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/shop)
-"jUT" = (
-/turf/open/floor/rogue/dirt/road,
-/turf/closed/wall/mineral/rogue/wooddark{
-	icon_state = "wooddark-k"
-	},
-/area/rogue/indoors/shelter/woods)
 "jVh" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/golden{
@@ -31834,6 +31977,16 @@
 	},
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"jWQ" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "jWT" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -32209,6 +32362,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/under/cavewet/bogcaves)
+"kcW" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 5
+	},
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "kcX" = (
 /obj/structure/glowshroom,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -32583,18 +32745,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"kio" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 9
-	},
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/effect/decal/cobble/mossy{
-	dir = 1
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/shelter/woods)
 "kis" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/spawner/lootdrop/potion_vitals,
@@ -32636,20 +32786,12 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
-"kjw" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall"
-	},
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
+"kjr" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/fluff/railing/border,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "kjC" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/carpet/red,
@@ -32815,6 +32957,7 @@
 /area/rogue/indoors/town/tavern)
 "klH" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
+/obj/structure/vine,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/woods)
 "klM" = (
@@ -32831,12 +32974,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"klO" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "klR" = (
 /obj/structure/stairs{
 	dir = 1
@@ -32859,13 +32996,6 @@
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
-"kmp" = (
-/obj/structure/flora/hotspring_rocks{
-	pixel_y = -8;
-	pixel_x = -9
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/woods)
 "kmz" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -32928,6 +33058,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"koa" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/river)
 "kod" = (
 /obj/item/rogueweapon/huntingknife/chefknife,
 /obj/structure/table/wood{
@@ -33075,6 +33209,16 @@
 /obj/structure/fermentation_keg/random/water,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
+"krt" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/storage/backpack/rogue/satchel,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "kry" = (
 /obj/structure/bars/pipe,
 /obj/machinery/light/rogue/oven/east{
@@ -33109,15 +33253,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"ksx" = (
-/obj/structure/hotspring{
-	icon_state = "lilypetals2"
-	},
-/obj/structure/flora/newbranch{
-	dir = 8
-	},
-/turf/open/water/pond,
-/area/rogue/outdoors/woods)
 "ksA" = (
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /turf/open/floor/rogue/cobble,
@@ -33281,6 +33416,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"kuQ" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/connector{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "kuR" = (
 /obj/structure/fluff/railing/border,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -33372,16 +33514,6 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
-"kwi" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_x = 8
-	},
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "kwt" = (
 /obj/structure/bars/passage{
 	max_integrity = 3000;
@@ -33453,13 +33585,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"kwV" = (
-/obj/structure/closet/dirthole/grave,
-/obj/item/alch/rosa,
-/obj/effect/landmark/start/orphan,
-/obj/item/rogueweapon/shovel,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
 "kxk" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/cobblerock,
@@ -33698,6 +33823,12 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"kAL" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "kAQ" = (
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/sewer)
@@ -33770,13 +33901,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cave/mazedungeon)
-"kBO" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/newbranch{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "kBQ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -33786,6 +33910,18 @@
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"kBT" = (
+/obj/structure/stairs,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "kBY" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8;
@@ -33888,15 +34024,6 @@
 /obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
-"kDm" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 5
-	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/shelter/woods)
 "kDx" = (
 /obj/item/roguestatue/aalloy,
 /turf/open/floor/rogue/naturalstone,
@@ -33907,13 +34034,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/cave)
-"kDA" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
 "kDC" = (
 /obj/structure/stairs{
 	dir = 4
@@ -33932,14 +34052,6 @@
 "kDS" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
-"kDV" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
-	},
-/obj/structure/flora/newleaf,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "kEf" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/table/wood{
@@ -33972,6 +34084,12 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
+"kEG" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "kEI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -34133,6 +34251,9 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter)
+"kHb" = (
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/shelter/woods)
 "kHi" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/church,
@@ -34176,12 +34297,6 @@
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/carpet/red,
 /area/rogue/outdoors/mountains/decap)
-"kHS" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "kHY" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -34412,6 +34527,12 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/cave)
+"kMI" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "kMM" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -34566,6 +34687,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/church/chapel)
+"kPQ" = (
+/obj/item/natural/stone,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "kPX" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
@@ -34862,10 +34987,6 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement/keep)
-"kUO" = (
-/obj/structure/flora/roguegrass/bush,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/shelter/woods)
 "kVf" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -34874,14 +34995,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"kVg" = (
-/obj/structure/flora/hotspring_rocks,
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
-"kVi" = (
-/obj/structure/flora/newleaf,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "kVm" = (
 /obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/woodturned,
@@ -34943,10 +35056,6 @@
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
-"kWi" = (
-/obj/structure/fluff/statue/knight/interior/r,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "kWj" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -35126,12 +35235,11 @@
 /turf/closed,
 /area/rogue/outdoors/mountains/decap)
 "kZU" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
+/obj/structure/roguewindow/harem3{
+	name = "Frosted Glass Window"
 	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "kZV" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -35145,13 +35253,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"kZX" = (
-/obj/effect/particle_effect/smoke,
-/turf/open/water/river{
-	dir = 1;
-	icon_state = "rockwd"
-	},
-/area/rogue/outdoors/woods)
 "kZY" = (
 /obj/structure/stairs{
 	dir = 4
@@ -35272,6 +35373,12 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains/decap)
+"lbO" = (
+/obj/structure/flora/newbranch/connector{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "lbR" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/closed/wall/mineral/rogue/stone/window,
@@ -35296,12 +35403,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"lca" = (
-/turf/closed/wall/mineral/rogue/wooddark{
-	icon_state = "wooddark-k"
+"lcb" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "lch" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -35545,6 +35652,14 @@
 /obj/structure/roguemachine/noticeboard,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
+"lgr" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/obj/structure/bars/shop/bronze,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "lgz" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -35644,7 +35759,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "liv" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -35664,6 +35779,12 @@
 /obj/structure/flora/roguetree/pine,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"liN" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "liV" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 8
@@ -35886,11 +36007,6 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"lmg" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/obj/machinery/light/rogue/torchholder,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
 "lmh" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -35939,12 +36055,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"lmS" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/shelter/woods)
 "lmV" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9;
@@ -36045,18 +36155,6 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
-"lop" = (
-/obj/structure/stairs,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_x = 8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "loq" = (
 /obj/structure/roguewindow,
 /obj/structure/fluff/railing/border{
@@ -36162,6 +36260,17 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
+"lpn" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/closet/crate/chest/wicker,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "lpq" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
@@ -36180,14 +36289,17 @@
 "lpu" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"lpK" = (
+/obj/structure/flora/hotspring_rocks/small/five,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/river)
 "lpV" = (
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "lpW" = (
-/obj/structure/vine,
-/turf/open/transparent/openspace,
-/area/rogue/under/cave/goblindungeon)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/river)
 "lpZ" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -36275,20 +36387,19 @@
 "lro" = (
 /turf/open/water/ocean,
 /area/rogue/under/cave)
-"lry" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
 "lrE" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/item/rogueweapon/mace/wsword,
 /obj/item/rogueweapon/mace/wsword,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"lrK" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/newbranch{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "lrM" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -36641,6 +36752,11 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"lwX" = (
+/obj/structure/hotspring/border/seven,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "lwZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
@@ -36765,6 +36881,11 @@
 	},
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/indoors/cave)
+"lyD" = (
+/obj/structure/hotspring/border/five,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals_dried,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "lyE" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -36931,6 +37052,13 @@
 /obj/structure/roguemachine/bounty,
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/town)
+"lAP" = (
+/obj/structure/table/wood{
+	icon_state = "longtable_mid"
+	},
+/obj/structure/rogue/trophy/deer,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "lAT" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -37153,6 +37281,11 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
+"lEb" = (
+/turf/open/water/river{
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/mountains)
 "lEe" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -37163,6 +37296,13 @@
 "lEl" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/under/underdark)
+"lEo" = (
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "lEs" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/dirt/road,
@@ -37312,6 +37452,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"lGI" = (
+/obj/structure/spider/stickyweb{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "lGK" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -37363,6 +37509,11 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"lHJ" = (
+/obj/structure/hotspring/border/two,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals_dried,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "lHM" = (
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/herringbone,
@@ -37485,12 +37636,6 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/woods)
-"lKJ" = (
-/obj/structure/glowshroom{
-	icon_state = "glowshroom2"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
 "lKO" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -37662,6 +37807,11 @@
 	},
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/outdoors/town/roofs)
+"lMU" = (
+/obj/structure/closet/crate/drawer,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "lMW" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/indoors/shelter/woods)
@@ -37694,6 +37844,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"lNl" = (
+/obj/structure/flora/roguetree/burnt{
+	pixel_y = 11
+	},
+/obj/structure/fluff/railing/border,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "lNr" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
@@ -37713,11 +37872,15 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/chapel)
-"lNE" = (
-/turf/closed/wall/mineral/rogue/wooddark{
-	icon_state = "slittedwooddark"
+"lNP" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
 	},
-/area/rogue/indoors/shelter/woods)
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "lNW" = (
 /obj/structure/flora/hotspring_rocks/small/four,
 /turf/open/floor/rogue/grass,
@@ -37812,10 +37975,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/roofs)
-"lPz" = (
-/obj/effect/decal/carpet,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "lPL" = (
 /obj/structure/flora/roguegrass/herb/salvia,
 /turf/open/floor/rogue/grass,
@@ -37895,6 +38054,10 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
+"lRi" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "lRj" = (
 /obj/structure/mineral_door/wood/violet{
 	locked = 1
@@ -37911,6 +38074,17 @@
 "lRv" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"lRy" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "lRB" = (
 /obj/structure/mineral_door/bars,
 /obj/structure/trap/wall_projectile{
@@ -37945,6 +38119,11 @@
 "lRZ" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
+"lSb" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "lSh" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/under/roguetown/chainlegs,
@@ -38052,6 +38231,12 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/beach/forest)
+"lVi" = (
+/obj/structure/flora/newbranch/leafless{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "lVy" = (
 /obj/item/natural/dirtclod,
 /obj/machinery/light/rogue/torchholder/r,
@@ -38063,17 +38248,23 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"lVD" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "lVE" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/town)
 "lVI" = (
-/obj/structure/flora/roguegrass/herb/salvia,
-/obj/effect/decal/mossy{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "lVW" = (
 /obj/structure/stairs{
 	dir = 1
@@ -38086,10 +38277,9 @@
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/bog)
 "lWf" = (
-/obj/structure/hotspring,
-/obj/item/alch/salvia,
+/obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
+/area/rogue/outdoors/river)
 "lWk" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/ruinedwood{
@@ -38175,8 +38365,9 @@
 	},
 /area/rogue/indoors/shelter/woods)
 "lXx" = (
-/turf/closed/wall/shroud,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/hotspring_rocks/small/three,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "lXy" = (
 /obj/structure/closet/dirthole,
 /turf/open/floor/rogue/dirt/road,
@@ -38251,11 +38442,6 @@
 /obj/item/roguegem/random,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave)
-"lZj" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/globe,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "lZu" = (
 /obj/effect/spawner/roguemap/stump,
 /obj/structure/flora/roguegrass,
@@ -38272,10 +38458,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/orcdungeon)
-"lZD" = (
-/obj/structure/flora/rogueshroom/happy/mushroom4,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/woods)
 "lZJ" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -38358,16 +38540,6 @@
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"maO" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield/eora)
 "maZ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -38636,14 +38808,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "mel" = (
-/obj/structure/chair/hotspring_bench{
-	dir = 4
+/obj/structure/roguetent,
+/obj/effect/decal/cobble/mossy{
+	dir = 1
 	},
-/obj/effect/decal/mossy{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "meq" = (
 /obj/effect/decal/mossy{
 	dir = 8
@@ -38771,13 +38941,6 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"mgZ" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch{
-	dir = 4
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "mha" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -38800,11 +38963,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"mhp" = (
-/obj/item/natural/rock,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "mhs" = (
 /obj/structure/fermentation_keg/crafted,
 /obj/machinery/light/rogue/torchholder/l,
@@ -38952,18 +39110,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
-"mkb" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "mkj" = (
 /obj/structure/fluff/wallclock{
 	dir = 3
@@ -38999,6 +39145,11 @@
 /obj/machinery/tanningrack,
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
+"mkI" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/connector,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "mkP" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -39079,14 +39230,9 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/dwarfin)
 "mlR" = (
-/obj/effect/decal/mossy{
-	dir = 8
-	},
-/obj/effect/decal/cobble/mossy{
-	dir = 6
-	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
+/area/rogue/outdoors/woods)
 "mlS" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -39249,12 +39395,6 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"moO" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/bath)
 "moR" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
@@ -39476,10 +39616,6 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
-"msQ" = (
-/obj/structure/fluff/walldeco/rpainting/forest,
-/turf/closed/wall/mineral/rogue/decostone/fluffstone,
-/area/rogue/indoors/town/tavern)
 "mtb" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/wood,
@@ -39494,9 +39630,9 @@
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "mtt" = (
-/obj/machinery/light/rogue/torchholder/hotspring/standing,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
+/obj/item/restraints/legcuffs/beartrap/armed,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "mtv" = (
 /obj/structure/fluff/walldeco/painting,
 /turf/closed/wall/mineral/rogue/decostone,
@@ -39535,15 +39671,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin)
-"mtV" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/closed/wall/mineral/rogue/wooddark{
-	icon_state = "slittedwooddark"
-	},
-/area/rogue/outdoors/woods)
 "mtW" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -39617,15 +39744,6 @@
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave/dukecourt)
-"mvn" = (
-/obj/structure/fluff/railing/border{
-	pixel_y = -7
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 9
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
 "mvr" = (
 /turf/open/water/ocean/deep,
 /area/rogue/outdoors/beach/forest)
@@ -39678,6 +39796,12 @@
 /mob/living/simple_animal/hostile/rogue/dragger,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/scarymaze)
+"mwc" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "mwe" = (
 /obj/structure/closet/crate/chest,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -39762,17 +39886,9 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/shelter/mountains/decap)
 "mxB" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 10
-	},
-/turf/open/floor/rogue/dirt/road,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water/pond,
 /area/rogue/outdoors/woods)
-"mxC" = (
-/obj/structure/spider/stickyweb{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
 "mxK" = (
 /turf/closed/wall/mineral/rogue/stone/red_moss,
 /area/rogue/indoors/shelter/mountains/decap)
@@ -39790,7 +39906,7 @@
 "mxP" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "mxS" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/tile,
@@ -40037,12 +40153,9 @@
 	},
 /area/rogue/indoors/town)
 "mBR" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "mBW" = (
 /obj/structure/flora/roguetree/stump/log{
 	pixel_x = -10
@@ -40089,16 +40202,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/orcdungeon)
-"mCw" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
 "mCR" = (
 /obj/structure/fluff/walldeco/rpainting/crown{
 	pixel_y = 32
@@ -40157,6 +40260,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/mountains/decap)
+"mDZ" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "mEi" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot{
@@ -40213,6 +40320,10 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach)
+"mEz" = (
+/obj/structure/flora/roguegrass/thorn_bush,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/river)
 "mEF" = (
 /obj/structure/table/cooling,
 /obj/structure/bars{
@@ -40223,13 +40334,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"mEG" = (
-/obj/effect/landmark/start/knavewench,
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
 "mEK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -40353,6 +40457,16 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"mGH" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt{
+	pixel_y = -14
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "mGK" = (
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/shelter/woods)
@@ -40367,6 +40481,14 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"mGN" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "mGO" = (
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/ruinedwood/chevron,
@@ -40447,6 +40569,12 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/cave)
+"mHK" = (
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = 5
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "mHL" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -40577,6 +40705,12 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"mKg" = (
+/turf/open/floor/rogue/grass,
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
+	},
+/area/rogue/indoors/shelter/woods)
 "mKz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/tile/masonic{
@@ -40609,9 +40743,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church/chapel)
 "mKO" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
+/obj/item/natural/rock,
+/obj/item/natural/stone,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/indoors/cave)
 "mKP" = (
 /obj/structure/table/wood,
 /obj/item/cooking/platter/gold{
@@ -40746,19 +40881,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/basement)
-"mMD" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "mMF" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -40785,13 +40907,6 @@
 "mMU" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
-"mNc" = (
-/obj/structure/flora/newleaf,
-/obj/structure/closet/crate/roguecloset,
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/flashlight/flare/torch/lantern,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "mNd" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -40832,6 +40947,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
+"mNJ" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/mountains)
 "mNK" = (
 /obj/structure/floordoor/gatehatch/inner{
 	redstone_id = "gatelava"
@@ -40848,13 +40970,6 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/dwarfin)
-"mNN" = (
-/obj/structure/curtain/magenta{
-	color = 54202a;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
 "mNW" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -41079,6 +41194,13 @@
 /obj/structure/flora/roguetree/pine,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains/decap)
+"mRS" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "mRW" = (
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/dirt,
@@ -41146,9 +41268,8 @@
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
-"mSR" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/leafless{
+"mSV" = (
+/obj/structure/flora/newbranch{
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -41353,6 +41474,10 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"mWB" = (
+/obj/item/natural/rock,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "mWD" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
@@ -41491,12 +41616,6 @@
 /obj/structure/fermentation_keg/random/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
-"mYM" = (
-/obj/structure/flora/roguetree/pine{
-	icon_state = "pine2"
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield)
 "mYQ" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -41749,6 +41868,13 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
+"ncW" = (
+/obj/effect/particle_effect/smoke,
+/turf/open/water/river{
+	dir = 1;
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/river)
 "ncY" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -41876,6 +42002,10 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"nez" = (
+/obj/structure/flora/roguegrass/thorn_bush,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "neG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
@@ -41886,10 +42016,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/mazedungeon)
-"neM" = (
-/obj/structure/flora/roguegrass/bush,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "neO" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
@@ -42101,12 +42227,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
-"nhM" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
 "nhU" = (
 /obj/structure/bars/passage/shutter{
 	redstone_id = "golgothaone"
@@ -42332,6 +42452,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
+"nlp" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "nlt" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 1
@@ -42663,13 +42787,16 @@
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"npi" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-e"
+"npJ" = (
+/obj/structure/flora/roguetree/wise{
+	pixel_x = 4
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
+/obj/machinery/light/rogue/firebowl/standing/blue{
+	pixel_y = 5;
+	pixel_x = 15
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "npK" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -42710,6 +42837,10 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"nqA" = (
+/obj/structure/flora/rogueshroom/happy/mushroom5,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "nqN" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -42721,7 +42852,7 @@
 /turf/open/water/river{
 	icon_state = "rockwd"
 	},
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "nqW" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -42885,6 +43016,12 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
+"ntW" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "ntX" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
@@ -42903,15 +43040,19 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/cave/dukecourt)
 "nus" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/closed,
-/area/rogue/indoors/shelter/woods)
+/obj/item/natural/rock,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "nuv" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/rogue/wood/herringbone{
 	smooth_icon = null
 	},
 /area/rogue/indoors/shelter/mountains/decap)
+"nuB" = (
+/obj/structure/roguetent,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/shelter/woods)
 "nuG" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -43004,6 +43145,12 @@
 /obj/effect/landmark/start/wapprentice,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/magician)
+"nwh" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "nwm" = (
 /obj/structure/closet/crate/chest,
 /obj/item/seeds/wheat/oat,
@@ -43094,6 +43241,9 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
+"nxE" = (
+/turf/open/floor/rogue/grassyel,
+/area/rogue/indoors/town)
 "nxH" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -43110,6 +43260,10 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
+"nxP" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "nxV" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -43208,11 +43362,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"nAs" = (
-/turf/closed/wall/mineral/rogue/wooddark{
-	icon_state = "wooddark-k"
-	},
-/area/rogue/outdoors/woods)
 "nAH" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -43246,9 +43395,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "nAQ" = (
-/obj/structure/flora/rogueshroom/happy/mushroom2,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/woods)
+/obj/structure/fermentation_keg/water,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "nAZ" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grassred,
@@ -43393,6 +43542,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"nDo" = (
+/obj/structure/flora/hotspring_rocks,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "nDt" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -43581,6 +43734,16 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/basement)
+"nFE" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/candle/yellow{
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "nFN" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/natural/cloth,
@@ -43608,10 +43771,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/cell)
-"nGj" = (
-/obj/structure/flora/roguegrass/herb/random,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "nGq" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -43738,6 +43897,13 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
+"nIG" = (
+/obj/effect/landmark/start/knavewench,
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "nII" = (
 /obj/structure/roguewindow,
 /obj/structure/fluff/littlebanners/greenwhite{
@@ -43974,11 +44140,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"nMk" = (
-/obj/structure/vine,
-/obj/structure/vine,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/woods)
 "nMB" = (
 /obj/effect/decal/cobbleedge{
 	pixel_y = 1
@@ -43999,10 +44160,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin)
-"nMH" = (
-/obj/structure/flora/hotspring_rocks/small/five,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "nMI" = (
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/wood/herringbone{
@@ -44049,11 +44206,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/mountains/decap)
 "nNP" = (
-/obj/effect/decal/mossy{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
+/obj/effect/decal/carpet,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "nNT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle/alchemical/conpot{
@@ -44074,6 +44229,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/forest)
+"nNZ" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/town)
 "nOc" = (
 /obj/item/bouquet/matricaria,
 /turf/open/floor/carpet/royalblack,
@@ -44286,10 +44445,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
-"nRo" = (
-/obj/structure/fluff/psycross/crafted,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "nRr" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -44340,6 +44495,13 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/sand,
 /area/rogue/outdoors/beach)
+"nRG" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "nRJ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -44380,6 +44542,13 @@
 /obj/effect/landmark/start/loudmouth,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
+"nSf" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch{
+	dir = 4
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "nSj" = (
 /obj/structure/roguemachine/stockpile,
 /turf/open/floor/rogue/cobblerock,
@@ -44443,6 +44612,11 @@
 /obj/item/roguekey/crafterguild,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
+"nSN" = (
+/obj/structure/chair/stool/rogue,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "nSO" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/churchmarble,
@@ -44584,20 +44758,6 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"nUJ" = (
-/obj/structure/table/church{
-	icon_state = "churchtable_end"
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
-/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals{
-	pixel_y = 9;
-	pixel_x = -12
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield/eora)
 "nUP" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1;
@@ -44610,13 +44770,6 @@
 "nUS" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/roofs)
-"nUT" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/shelter/woods)
 "nUZ" = (
 /obj/item/ash,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -44813,15 +44966,11 @@
 "nYS" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/cave/orcdungeon)
-"nYW" = (
-/obj/structure/flora/roguetree/wise{
-	pixel_x = 4
+"nYZ" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
 	},
-/obj/machinery/light/rogue/firebowl/standing/blue{
-	pixel_y = 5;
-	pixel_x = 15
-	},
-/turf/open/floor/rogue/dirt,
+/turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/woods)
 "nZb" = (
 /obj/structure/table/wood{
@@ -44866,12 +45015,6 @@
 "nZr" = (
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"nZu" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 10
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "nZA" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/town/roofs/keep)
@@ -44959,10 +45102,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
-"oaH" = (
-/obj/effect/lily_petal/two,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield/eora)
 "oaL" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -45076,12 +45215,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"ocC" = (
-/obj/structure/roguewindow/harem3{
-	name = "Frosted Glass Window"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
 "ocH" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/blocks,
@@ -45165,9 +45298,8 @@
 	},
 /area/rogue/outdoors/beach/forest)
 "oei" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/river)
 "oek" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/red,
@@ -45434,6 +45566,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"oin" = (
+/obj/structure/flora/newbranch{
+	dir = 4
+	},
+/turf/open/water/pond,
+/area/rogue/outdoors/woods)
 "ois" = (
 /obj/effect/decal/wood/herringbone2{
 	dir = 8
@@ -45454,6 +45592,11 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
+"oiN" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "oiR" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4;
@@ -45509,13 +45652,6 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield)
-"ojF" = (
-/obj/structure/spider/stickyweb{
-	dir = 1;
-	icon_state = "stickyweb2"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "ojI" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -45600,6 +45736,9 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/orcdungeon)
+"olG" = (
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/river)
 "olL" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -45628,6 +45767,10 @@
 /obj/item/clothing/mask/cigarette/pipe,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
+"olV" = (
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "omc" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -45637,12 +45780,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/cave)
-"omv" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/woods)
 "omx" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/grass,
@@ -45690,10 +45827,6 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
-"onU" = (
-/obj/structure/flora/rogueshroom/happy/mushroom5,
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
 "onX" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -45736,6 +45869,15 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave/goblinfort)
+"ooX" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "opb" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/underdark)
@@ -45877,6 +46019,11 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/shelter/mountains/decap)
+"orG" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/rope,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "orM" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -45923,12 +46070,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"orZ" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border,
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
 "osb" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor5-old"
@@ -45974,6 +46115,10 @@
 /obj/item/scomstone,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
+"osr" = (
+/obj/structure/flora/mushroomcluster,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "osu" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/rack/rogue,
@@ -45992,6 +46137,13 @@
 /obj/structure/flora/hotspring_rocks/small,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
+"osM" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "osX" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -46010,25 +46162,27 @@
 "oto" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/cand,
 /area/rogue/indoors/town)
-"otv" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/greenstone/runed,
-/area/rogue/outdoors/woods)
 "otR" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
 	},
 /area/rogue/indoors/town)
+"otW" = (
+/obj/structure/flora/newleaf,
+/obj/structure/spider/stickyweb{
+	dir = 1;
+	icon_state = "stickyweb2"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
+"ouh" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "ouj" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/woods)
@@ -46176,10 +46330,6 @@
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"oxl" = (
-/obj/structure/glowshroom,
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
 "oxo" = (
 /obj/structure/flora/roguegrass,
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
@@ -46301,6 +46451,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
+"oyP" = (
+/obj/machinery/tanningrack,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "oyQ" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grassred,
@@ -46333,12 +46487,6 @@
 "ozr" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/mountains)
-"ozv" = (
-/obj/structure/flora/newbranch{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "ozx" = (
 /obj/effect/decal/carpet/kover_purple{
@@ -46397,17 +46545,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"oAo" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/obj/structure/fluff/railing/border{
-	pixel_y = -6
-	},
-/obj/structure/fluff/statue/pillar{
-	pixel_y = 2;
-	pixel_x = 10
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "oAq" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 8
@@ -46422,10 +46559,6 @@
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
-"oAC" = (
-/obj/structure/flora/mushroomcluster,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/woods)
 "oAD" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -46513,11 +46646,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "oBU" = (
-/obj/structure/flora/newbranch{
-	dir = 1
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/shelter/woods)
 "oBY" = (
 /mob/living/carbon/human/species/dwarfskeleton/ambush/knight/summoned,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -46565,12 +46698,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "oCL" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/river)
 "oCN" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -46584,13 +46714,11 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "oCV" = (
-/obj/effect/decal/carpet/kover_black,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/tavern)
-"oDa" = (
-/obj/structure/vine,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
+/turf/open/water/river{
+	dir = 8;
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/river)
 "oDf" = (
 /obj/structure/rack/rogue,
 /obj/item/flashlight/flare/torch/lantern/copper,
@@ -46658,6 +46786,12 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"oDJ" = (
+/obj/structure/table/church{
+	icon_state = "churchtable_end"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "oDW" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/cell)
@@ -46680,12 +46814,6 @@
 	smooth_icon = null
 	},
 /area/rogue/indoors/town)
-"oEs" = (
-/obj/structure/flora/newbranch{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "oEt" = (
 /mob/living/carbon/human/species/elf/dark/drowraider,
 /turf/open/floor/rogue/blocks/platform,
@@ -46721,6 +46849,23 @@
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/orcdungeon)
+"oFF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/river)
+"oFI" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "oFK" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -46769,6 +46914,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/basement)
+"oGh" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "oGi" = (
 /obj/structure/bars/passage/shutter/open,
 /turf/open/floor/rogue/metal{
@@ -46790,12 +46941,6 @@
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
-"oGr" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/bath)
 "oGu" = (
 /obj/structure/rack/rogue/shelf/big{
 	icon_state = "shelf_biggest";
@@ -46855,6 +47000,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"oHf" = (
+/turf/open/floor/rogue/dirt,
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
+	},
+/area/rogue/indoors/shelter/woods)
 "oHh" = (
 /obj/item/natural/stoneblock{
 	pixel_x = 8;
@@ -46898,12 +47049,6 @@
 "oHH" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors)
-"oHL" = (
-/obj/structure/flora/newbranch{
-	dir = 4
-	},
-/turf/open/water/pond,
-/area/rogue/outdoors/woods)
 "oHM" = (
 /obj/structure/fluff/pillow/magenta{
 	pixel_x = 7
@@ -46963,14 +47108,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
-"oIC" = (
-/obj/structure/flora/hotspring_rocks{
-	pixel_y = -6;
-	icon_state = "bigrock_grass";
-	pixel_x = 6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "oID" = (
 /obj/structure/stairs{
 	dir = 4
@@ -47045,10 +47182,6 @@
 /obj/structure/vine,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/underdark)
-"oJn" = (
-/obj/structure/stairs/stone,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "oJs" = (
 /obj/random/spider,
 /turf/open/floor/rogue/cobblerock,
@@ -47068,6 +47201,15 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"oJD" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "oJE" = (
 /obj/structure/stairs{
 	dir = 8
@@ -47091,19 +47233,6 @@
 "oKc" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/church/chapel)
-"oKj" = (
-/obj/effect/falling_sakura,
-/obj/structure/table/church,
-/obj/item/reagent_containers/glass/bowl{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
-/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals{
-	pixel_y = 6;
-	pixel_x = 11
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield/eora)
 "oKp" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -47214,10 +47343,6 @@
 	},
 /turf/open/water/bloody,
 /area/rogue/indoors/shelter/mountains/decap)
-"oMo" = (
-/obj/item/natural/rock,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "oMA" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/blocks,
@@ -47227,6 +47352,16 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/magician)
+"oMK" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 10;
+	pixel_y = 0
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "oMM" = (
 /obj/structure/table/vtable/v2,
 /obj/item/clothing/neck/roguetown/psicross/malum,
@@ -47339,12 +47474,22 @@
 /obj/structure/fluff/railing/border{
 	pixel_y = -7
 	},
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
 "oOv" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"oOE" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/connector{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "oOH" = (
 /obj/item/chair/stool/bar/rogue,
 /turf/open/floor/rogue/grass,
@@ -47501,11 +47646,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach/forest)
 "oRq" = (
-/obj/structure/curtain/magenta{
-	color = 54202a
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
+/obj/structure/vine,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "oRu" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/item/roguebin/water,
@@ -47522,10 +47665,13 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"oRM" = (
+/obj/structure/flora/hotspring_rocks/grassy,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/river)
 "oRN" = (
-/obj/effect/particle_effect/smoke,
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/river)
 "oRZ" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -47680,15 +47826,14 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/beach/forest)
 "oUJ" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
+/obj/structure/chair/hotspring_bench/right{
+	dir = 4
 	},
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	pixel_y = 2
+/obj/effect/decal/mossy{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "oUR" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -47805,20 +47950,6 @@
 /obj/item/kitchen/spoon/tin,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"oWZ" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/obj/effect/decal/carpet/kover_darkred{
-	pixel_y = -10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-n";
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
 "oXa" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -47915,6 +48046,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"oXZ" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "oYb" = (
 /obj/structure/table/wood,
 /obj/item/candle/candlestick/silver/lit{
@@ -47925,9 +48060,10 @@
 	},
 /area/rogue/indoors/town/manor)
 "oYh" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/dirt,
+/obj/effect/decal/cobble/mossy{
+	dir = 5
+	},
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "oYo" = (
 /obj/item/roguegem/ruby,
@@ -47999,12 +48135,6 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs/keep)
-"oZo" = (
-/turf/open/water/river{
-	dir = 8;
-	icon_state = "rockwd"
-	},
-/area/rogue/outdoors/woods)
 "oZs" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -48160,6 +48290,14 @@
 "pbq" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
+"pbs" = (
+/obj/structure/flora/hotspring_rocks{
+	pixel_y = -6;
+	icon_state = "bigrock_grass";
+	pixel_x = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "pby" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 8;
@@ -48421,13 +48559,6 @@
 /obj/effect/spawner/lootdrop/general_loot_mid/x3,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"pgb" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/connector{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "pgi" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -48538,11 +48669,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"phD" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/glowshroom,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "phE" = (
 /obj/structure/stairs{
 	dir = 1
@@ -48688,6 +48814,10 @@
 	icon_state = "iron_line"
 	},
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"pjL" = (
+/obj/effect/lily_petal/three,
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "pjP" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/naturalstone,
@@ -48707,45 +48837,23 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
-"pkz" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/obj/structure/curtain/green,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "pkE" = (
 /mob/living/carbon/human/species/skeleton/npc/bogguard/master,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"pkK" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
-/obj/machinery/light/rogue/wallfire/candle/floorcandle{
-	pixel_y = -14
-	},
-/obj/item/alch/rosa{
-	pixel_y = -2;
-	pixel_x = -8
-	},
-/obj/item/alch/rosa{
-	pixel_y = -9;
-	pixel_x = 5
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "pkN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/ranged,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
-"pkU" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/hotspring_rocks/small/two,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "pkX" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/underdark)
+"pla" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "plc" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4;
@@ -48798,16 +48906,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
-"plQ" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
 "plY" = (
 /obj/structure/flora/sakura,
 /obj/structure/flora/roguegrass/herb/hypericum,
@@ -48830,10 +48928,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
-"pmv" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/rtfield/eora)
 "pmF" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -48846,13 +48940,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
-"pmJ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
 "pnb" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
@@ -48894,6 +48981,10 @@
 	},
 /turf/open/floor/rogue/blocks/paving/vert,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"pnW" = (
+/obj/machinery/gear_painter,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "poe" = (
 /obj/structure/fluff/walldeco/wantedposter/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -48960,9 +49051,9 @@
 	},
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "ppp" = (
-/obj/structure/vine,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/woods)
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "ppw" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/dirt,
@@ -48987,14 +49078,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/orcdungeon)
 "pqc" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "pqi" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/carpet/royalblack,
@@ -49098,9 +49187,9 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
-"prF" = (
-/obj/structure/flora/roguegrass/thorn_bush,
-/turf/closed/wall/shroud,
+"prW" = (
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
 "psb" = (
 /obj/effect/decal/cobbleedge,
@@ -49170,6 +49259,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
+"ptd" = (
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "ptg" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/table/wood/fancy/black,
@@ -49209,14 +49305,6 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/dwarfin)
-"ptR" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle,
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
-	pixel_x = -3;
-	pixel_y = -12
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "puw" = (
 /obj/structure/flora/roguetree/pine/dead,
 /turf/open/floor/rogue/dirt/road,
@@ -49303,15 +49391,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
 "pvE" = (
-/turf/open/floor/rogue/grass,
-/turf/closed/wall/mineral/rogue/wooddark{
-	icon_state = "slittedwooddark"
-	},
-/area/rogue/indoors/shelter/woods)
-"pvK" = (
-/obj/structure/hotspring/border/two,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield/eora)
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/under/cave/goblindungeon)
 "pvR" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 1
@@ -49325,6 +49406,11 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"pwh" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
+/obj/item/alch/rosa,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "pwi" = (
 /obj/structure/roguemachine/goldface,
 /turf/closed/wall/mineral/rogue/decowood/vert,
@@ -49403,17 +49489,21 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
 "pxl" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
+/obj/item/natural/rock,
+/turf/open/water/river{
+	icon_state = "rockwd"
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
+/area/rogue/outdoors/mountains)
 "pxn" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
+"pxo" = (
+/obj/structure/vine,
+/turf/closed/wall/shroud,
+/area/rogue/outdoors/woods)
 "pxs" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -49538,13 +49628,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"pyX" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "pzb" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/rogueweapon/hoe,
@@ -49733,13 +49816,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"pBi" = (
-/obj/structure/roguemachine/noticeboard{
-	pixel_y = -14;
-	pixel_x = 17
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
 "pBk" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -49769,17 +49845,12 @@
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "pBu" = (
 /obj/structure/hotspring/border/two,
-/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals_dried,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "pBv" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon1/gethsmane)
-"pBz" = (
-/obj/effect/decal/cobble/mossy,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
 "pBB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -49809,6 +49880,10 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"pBM" = (
+/turf/closed/wall/mineral/rogue/craftstone,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "pBN" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/dirt,
@@ -49922,6 +49997,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cave/dukecourt)
+"pDm" = (
+/obj/structure/vine,
+/turf/open/water/river{
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/mountains)
 "pDr" = (
 /obj/item/rogue/instrument/drum,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -50026,6 +50107,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
+"pFz" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "pFA" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -50071,7 +50156,7 @@
 	dir = 4;
 	icon_state = "rockwd"
 	},
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "pGi" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/nitebeast,
@@ -50090,6 +50175,13 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
+"pGJ" = (
+/obj/structure/flora/roguegrass/bush,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "pGL" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/hexstone,
@@ -50110,6 +50202,11 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"pHh" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/globe,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "pHj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/ruinedwood{
@@ -50121,8 +50218,12 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
 "pHp" = (
-/turf/closed/wall/mineral/rogue/stone/moss,
-/area/rogue/outdoors/woods)
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "pHr" = (
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/outdoors/mountains)
@@ -50330,10 +50431,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
-"pKo" = (
-/obj/structure/fluff/walldeco/rpainting/crown,
-/turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/indoors/town/tavern)
 "pKy" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte,
@@ -50368,11 +50465,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement/keep)
-"pKX" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/leafless,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "pKZ" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
@@ -50396,6 +50488,18 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter/mountains/decap)
+"pLo" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "pLp" = (
 /obj/structure/flora/roguegrass,
 /obj/effect/decal/mossy,
@@ -50423,10 +50527,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
-"pLV" = (
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
 "pLW" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
@@ -50605,11 +50705,6 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
-"pPf" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/connector,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "pPg" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/wood{
@@ -50739,10 +50834,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"pRv" = (
-/turf/closed/wall/mineral/rogue/wooddark,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
 "pRw" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -50849,6 +50940,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
+"pTc" = (
+/obj/structure/flora/rogueshroom/happy/mushroom2,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "pTn" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -50925,9 +51020,9 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "pUD" = (
-/obj/structure/flora/newtree,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/torchholder/hotspring,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "pUP" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4;
@@ -51108,6 +51203,12 @@
 "pXv" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/woods)
+"pXx" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "pXF" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -51177,10 +51278,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"pYc" = (
-/turf/open/transparent/openspace,
-/turf/closed/wall/mineral/rogue/wooddark/window,
-/area/rogue/indoors/shelter/woods)
 "pYe" = (
 /obj/structure/rack/rogue/shelf/big{
 	icon_state = "shelf_biggest";
@@ -51372,13 +51469,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
-"qaY" = (
-/obj/structure/hotspring,
-/obj/structure/hotspring/border/seven{
-	pixel_x = -18
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "qbp" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mole,
 /turf/open/floor/rogue/naturalstone,
@@ -51460,9 +51550,10 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
 "qcy" = (
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/obj/effect/lily_petal,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "qcH" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -51570,11 +51661,12 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/town/basement/keep)
 "qdI" = (
-/obj/structure/roguewindow/harem3{
-	name = "Frosted Glass Window"
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = -5;
+	pixel_y = 0
 	},
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/tavern)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "qdJ" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/storage/backpack/rogue/satchel,
@@ -51613,12 +51705,12 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
-"qei" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/leafless,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+"qee" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "qej" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
@@ -51644,6 +51736,10 @@
 /obj/effect/spawner/lootdrop/steel_weapon_spawner,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach/forest)
+"qeA" = (
+/obj/structure/closet/crate/chest/crate,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "qeF" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/item/roguegem/violet,
@@ -51684,6 +51780,12 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"qfS" = (
+/obj/structure/flora/newbranch/connector{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "qfW" = (
 /obj/effect/decal/carpet/kover_purple{
 	pixel_x = 16;
@@ -51720,12 +51822,18 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/magician)
+"qgl" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "qgv" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
 	},
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "qgz" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -51766,6 +51874,15 @@
 "qhh" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
+"qhi" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/floor/rogue/rooftop{
+	icon_state = "roofg"
+	},
+/area/rogue/outdoors/mountains)
 "qhj" = (
 /obj/structure/handcart{
 	dir = 8
@@ -51786,12 +51903,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"qhG" = (
-/turf/closed/wall/mineral/rogue/wooddark{
-	icon_state = "slittedwooddark"
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
 "qhN" = (
 /obj/structure/bars/tough,
 /turf/closed/wall/mineral/rogue/pipe,
@@ -51955,6 +52066,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"qkg" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/rtfield/eora)
 "qki" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -52188,6 +52305,12 @@
 /obj/item/clothing/head/roguetown/helmet/bascinet,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"qnW" = (
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "qnY" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/naturalstone,
@@ -52389,18 +52512,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/church/chapel)
-"qro" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_x = 8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/turf/closed/wall/mineral/rogue/stone/moss,
-/area/rogue/outdoors/woods)
 "qrp" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -52524,6 +52635,14 @@
 "qti" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/beach)
+"qtk" = (
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "qtm" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/wood,
@@ -52892,15 +53011,8 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap)
 "qzF" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/woods)
 "qzN" = (
 /obj/structure/bars/passage{
 	density = 0;
@@ -53035,12 +53147,6 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors)
-"qCf" = (
-/obj/structure/glowshroom{
-	icon_state = "glowshroom2"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "qCg" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -53183,7 +53289,7 @@
 "qDW" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "qDX" = (
 /obj/structure/bars/passage/shutter,
 /turf/closed/wall/mineral/rogue/wooddark/window,
@@ -53255,6 +53361,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"qFv" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "qFy" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/structure/rack/rogue/shelf,
@@ -53292,12 +53405,12 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
-"qFK" = (
+"qFL" = (
 /obj/effect/decal/cobble/mossy{
-	dir = 9
+	dir = 10
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "qFM" = (
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
@@ -53350,17 +53463,15 @@
 /obj/item/roguegem/random,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cave/orcdungeon)
-"qGz" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/yellow{
-	pixel_y = 6
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/tavern)
 "qGH" = (
-/turf/closed/wall/mineral/rogue/decostone/fluffstone,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/rooftop{
+	icon_state = "roofg"
+	},
 /area/rogue/outdoors/mountains)
 "qHa" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
@@ -53384,13 +53495,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"qHr" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "qHt" = (
 /obj/item/storage/bag/tray{
 	pixel_y = 32
@@ -53426,10 +53530,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"qHJ" = (
-/obj/structure/closet/crate/chest/wicker,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "qHN" = (
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -53713,8 +53813,9 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/shelter)
 "qKN" = (
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/under/cave/goblindungeon)
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "qKX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -53728,6 +53829,12 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/river)
+"qLc" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 10
+	},
+/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
 "qLd" = (
 /turf/open/floor/rogue/dirt/road,
@@ -53735,16 +53842,14 @@
 "qLt" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"qLA" = (
-/turf/open/floor/rogue/dirt,
-/turf/closed/wall/mineral/rogue/wooddark{
-	icon_state = "wooddark-k"
-	},
-/area/rogue/indoors/shelter/woods)
 "qLO" = (
 /obj/machinery/light/rogue/wallfire,
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"qLV" = (
+/obj/structure/glowshroom,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "qLZ" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/suit/roguetown/armor/gambeson,
@@ -53752,9 +53857,6 @@
 /obj/item/clothing/suit/roguetown/armor/gambeson,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"qMb" = (
-/turf/closed/wall/mineral/rogue/stone/window/moss,
-/area/rogue/outdoors/woods)
 "qMv" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor6-old"
@@ -53835,6 +53937,15 @@
 /obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"qNG" = (
+/obj/structure/hotspring,
+/obj/effect/lily_petal,
+/obj/structure/hotspring/border/twelve{
+	pixel_y = 13;
+	pixel_x = -13
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "qNH" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -54012,11 +54123,6 @@
 /obj/item/broom,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement/keep)
-"qRm" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "qRn" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -54075,6 +54181,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter)
+"qSf" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "qSm" = (
 /obj/structure/stairs{
 	dir = 1
@@ -54233,6 +54343,13 @@
 "qUs" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"qUz" = (
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "qUA" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grassred,
@@ -54252,11 +54369,6 @@
 "qUM" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/shelter/mountains/decap)
-"qUO" = (
-/obj/structure/hotspring/border/seven,
-/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals_dried,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield/eora)
 "qUQ" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -54307,6 +54419,18 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"qVF" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/turf/closed/wall/mineral/rogue/stone/moss,
+/area/rogue/outdoors/woods)
 "qVU" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -54343,12 +54467,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/tavern)
-"qWI" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "qWJ" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -54499,18 +54617,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"qYS" = (
-/obj/structure/vine,
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
-"qYZ" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
-	pixel_y = -11
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "qZa" = (
 /obj/effect/decal/wood/herringbone2{
 	dir = 8
@@ -54723,15 +54829,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"rcC" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/obj/machinery/light/rogue/torchholder/hotspring/standing,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "rcR" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/blocks/paving,
@@ -54947,6 +55044,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"rfX" = (
+/obj/structure/flora/roguegrass/herb/random,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "rgb" = (
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/rogue/wood,
@@ -55040,12 +55141,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/church/basement)
-"rib" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "ric" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -55059,6 +55154,11 @@
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"ris" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/machinery/light/rogue/torchholder,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "riv" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/grass,
@@ -55115,33 +55215,6 @@
 /obj/structure/telescope,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"rjB" = (
-/obj/structure/closet/crate/chest/wicker,
-/obj/item/seeds/apple,
-/obj/item/seeds/apple,
-/obj/item/seeds/pear,
-/obj/item/seeds/pear,
-/obj/item/seeds/wheat/oat,
-/obj/item/seeds/wheat/oat,
-/obj/item/seeds/tea,
-/obj/item/seeds/tea,
-/obj/item/seeds/tangerine,
-/obj/item/seeds/tangerine,
-/obj/item/seeds/cabbage,
-/obj/item/seeds/cabbage,
-/obj/item/seeds/potato,
-/obj/item/seeds/potato,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/garlick,
-/obj/item/seeds/garlick,
-/obj/item/seeds/strawberry,
-/obj/item/seeds/plum,
-/obj/item/seeds/raspberry,
-/obj/item/seeds/blackberry,
-/obj/item/seeds/berryrogue,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/shelter/woods)
 "rjF" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/tunic,
@@ -55178,23 +55251,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"rjT" = (
-/obj/structure/roguetent,
-/obj/effect/decal/cobble/mossy{
-	dir = 1
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/shelter/woods)
-"rkg" = (
-/obj/structure/hotspring,
-/obj/effect/lily_petal/two,
-/obj/structure/hotspring/border/twelve{
-	icon_state = "hotspring_border_11";
-	pixel_y = 11;
-	pixel_x = 12
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "rkG" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -55202,6 +55258,20 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
+"rkH" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 8;
+	icon_state = "borderfall"
+	},
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "rkL" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/bog)
@@ -55238,9 +55308,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "rlj" = (
-/obj/effect/decal/carpet/square,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "rlk" = (
 /obj/machinery/light/rogue/wallfire/candle/off/r,
 /obj/effect/decal/cobbleedge{
@@ -55293,6 +55365,10 @@
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"rmd" = (
+/obj/structure/flora/rogueshroom/happy/mushroom4,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "rmi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -55369,6 +55445,17 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
+"rmX" = (
+/obj/structure/flora/hotspring_rocks/small{
+	pixel_y = -17;
+	pixel_x = 8
+	},
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/soap/bath,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/woods)
 "rmZ" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/blocks,
@@ -55482,13 +55569,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"rox" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/effect/decal/mossy{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "roJ" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -55706,21 +55786,10 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/sewer)
-"rsD" = (
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "rsI" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/fishmandungeon)
-"rsN" = (
-/obj/structure/fluff/railing/border{
-	dir = 6;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "rsR" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/woodturned,
@@ -55813,6 +55882,19 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
+"rtR" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/greenstone/runed,
+/area/rogue/outdoors/woods)
 "rub" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -55911,6 +55993,15 @@
 /obj/machinery/light/rogue/wallfire/candle/off,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter/woods)
+"rvF" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "rvK" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -55934,9 +56025,11 @@
 /turf/open/water/swamp,
 /area/rogue/under/cave/fishmandungeon)
 "rwq" = (
-/obj/structure/vine,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "rwF" = (
 /obj/structure/chair/wood/rogue/throne,
 /turf/open/floor/rogue/wood,
@@ -55992,21 +56085,6 @@
 /obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
-"rxS" = (
-/obj/item/rogue/instrument/lute,
-/obj/item/rogue/instrument/harp,
-/obj/item/rogue/instrument/guitar,
-/obj/item/rogue/instrument/flute,
-/obj/structure/closet/crate/chest/crate,
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/curtain/magenta{
-	color = 54202a
-	},
-/obj/item/rogue/instrument/harp/handcarved,
-/obj/item/rogue/instrument/viola,
-/obj/item/rogue/instrument/hurdygurdy,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
 "rxV" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/red,
@@ -56082,6 +56160,11 @@
 /obj/item/rogueweapon/woodstaff,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"rzx" = (
+/obj/item/natural/rock,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "rzz" = (
 /obj/effect/decal/cobbleedge,
 /obj/item/cooking/platter/gold,
@@ -56249,6 +56332,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest)
+"rBI" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "rBL" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -56273,6 +56362,13 @@
 "rBR" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter)
+"rBS" = (
+/obj/structure/flora/hotspring_rocks/small,
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "rBY" = (
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
@@ -56415,12 +56511,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
-"rDS" = (
-/obj/structure/flora/newbranch{
-	dir = 4
+"rDU" = (
+/obj/structure/bars,
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
 	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave/goblindungeon)
 "rEl" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/carpet/red,
@@ -56484,6 +56581,10 @@
 /obj/effect/decal/cleanable/blood/puddle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
+"rFr" = (
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "rFB" = (
 /obj/structure/bars/shop,
 /obj/structure/table/wood{
@@ -56496,6 +56597,17 @@
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains/decap)
+"rFN" = (
+/obj/structure/fluff/walldeco/rpainting/forest,
+/turf/closed/wall/mineral/rogue/decostone/fluffstone,
+/area/rogue/indoors/town/tavern)
+"rFR" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "rFT" = (
 /obj/structure/closet/dirthole/closed/loot,
 /obj/structure/gravemarker{
@@ -56530,10 +56642,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
-"rGn" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
 "rGo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/bars/passage{
@@ -56580,32 +56688,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/town/basement/keep)
-"rGN" = (
-/obj/structure/flora/newleaf,
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "rGP" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
-"rGQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1";
-	pixel_y = -4
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "rGS" = (
 /turf/open/floor/rogue/wood/herringbone{
 	smooth_icon = null
@@ -56631,13 +56719,6 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/pond,
 /area/rogue/outdoors/mountains)
-"rHc" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "rHf" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -56750,9 +56831,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "rIw" = (
-/obj/structure/flora/roguegrass/thorn_bush,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
+/obj/structure/vine,
+/turf/open/water/river,
+/area/rogue/outdoors/mountains)
 "rIx" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -56777,13 +56858,6 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/orcdungeon)
-"rJh" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch{
-	dir = 8
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "rJz" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/shelter)
@@ -56796,10 +56870,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"rJH" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "rJQ" = (
 /obj/item/grown/log/tree/stick,
 /mob/living/carbon/human/species/skeleton/npc/ambush,
@@ -56867,6 +56937,10 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/hay,
 /area/rogue/under/cave/orcdungeon)
+"rLa" = (
+/obj/structure/fluff/walldeco/rpainting/crown,
+/turf/closed/wall/mineral/rogue/decowood,
+/area/rogue/indoors/town/tavern)
 "rLb" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/reagent_containers/food/snacks/butter,
@@ -56889,12 +56963,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/under/town/basement/keep)
-"rLo" = (
-/obj/structure/flora/newbranch/connector{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "rLp" = (
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/dirt,
@@ -56972,10 +57040,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/cave)
-"rLY" = (
-/obj/machinery/light/rogue/torchholder/hotspring/standing,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "rMe" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -57070,13 +57134,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"rOc" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "rOd" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/blocks/green,
@@ -57111,15 +57168,6 @@
 /obj/structure/fluff/walldeco/maidensigil/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/mazedungeon)
-"rOR" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "rOV" = (
 /obj/structure/stairs{
 	dir = 1
@@ -57211,17 +57259,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
-"rQG" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/obj/structure/fluff/railing/border{
-	pixel_y = -6
-	},
-/obj/structure/fluff/statue/pillar{
-	pixel_y = 1;
-	pixel_x = -12
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "rQI" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -57289,14 +57326,31 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/cave)
-"rSb" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/glowshroom,
+"rRX" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -16
+	},
+/obj/structure/flora/newbranch/leafless{
+	dir = 8
+	},
+/obj/structure/flora/newbranch/leafless{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/river)
+"rSc" = (
+/obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
 "rSp" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"rSw" = (
+/obj/structure/flora/roguetree/pine{
+	icon_state = "pine2"
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield)
 "rSH" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/silver{
@@ -57463,6 +57517,19 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"rUk" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "rUq" = (
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/carpet/stellar,
@@ -57562,16 +57629,19 @@
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"rWf" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/obj/structure/curtain/green,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "rWg" = (
 /obj/effect/particle_effect/smoke{
 	lifetime = 14400
 	},
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/beach/forest)
-"rWj" = (
-/obj/structure/roguetent,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/indoors/shelter/woods)
 "rWq" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave/dungeon1/gethsmane)
@@ -57678,7 +57748,7 @@
 	dir = 4;
 	icon_state = "rockwd"
 	},
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "rYn" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
@@ -57711,11 +57781,6 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/town)
-"rZa" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/flora/newleaf,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "rZb" = (
 /obj/structure/bars,
 /obj/effect/decal/cobbleedge{
@@ -57787,20 +57852,6 @@
 "rZO" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"rZW" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
-"sad" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 6
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "sai" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt/road,
@@ -57978,15 +58029,6 @@
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
-"sdj" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/item/alch/rosa,
-/obj/item/candle/eora/lit,
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "sdm" = (
 /obj/machinery/light/rogue/wallfire/candle/off/l,
 /obj/structure/rack/rogue/shelf/biggest,
@@ -57998,15 +58040,6 @@
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
-"sdr" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/yellow{
-	pixel_y = 7
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/tavern)
 "sdS" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/blocks,
@@ -58092,10 +58125,10 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
-"sfJ" = (
-/obj/item/natural/rock,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
+"sfL" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "sfM" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -58115,6 +58148,16 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
+"sfX" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "sgd" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/sword,
@@ -58140,13 +58183,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon1/gethsmane)
-"sgq" = (
-/obj/structure/flora/sakura{
-	pixel_x = -57;
-	pixel_y = -3
-	},
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/rtfield/eora)
 "sgr" = (
 /obj/structure/chair/bench/coucha/r{
 	can_buckle = 0
@@ -58270,10 +58306,30 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
+"shM" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 8;
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
+"shO" = (
+/turf/open/floor/rogue/grass,
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "slittedwooddark"
+	},
+/area/rogue/indoors/shelter/woods)
 "shR" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
+"shY" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "sia" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -58290,6 +58346,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"siz" = (
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/bed/rogue/inn/hay,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "siB" = (
 /obj/structure/fluff/statue/astrata,
 /turf/open/floor/rogue/blocks,
@@ -58379,6 +58444,13 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
+"sjG" = (
+/obj/structure/flora/hotspring_rocks/small{
+	pixel_x = -8;
+	pixel_y = 14
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/woods)
 "sjJ" = (
 /obj/structure/bars/passage{
 	density = 0;
@@ -58709,12 +58781,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "snu" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/river)
 "snw" = (
 /obj/structure/bars/steel{
 	color = "#675340";
@@ -58731,6 +58799,10 @@
 /obj/item/clothing/suit/roguetown/armor/plate/blacksteel_full_plate,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/licharena)
+"snA" = (
+/obj/structure/vine,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "snD" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/rogue/dirt,
@@ -58811,6 +58883,13 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"soG" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "soK" = (
 /obj/item/rogueweapon/pick/copper,
 /turf/open/floor/rogue/dirt,
@@ -58858,6 +58937,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
+"spl" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "spt" = (
 /obj/structure/closet/crate/chest/wicker,
 /turf/open/floor/rogue/dirt/road,
@@ -59036,12 +59121,6 @@
 "srn" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"srr" = (
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/flashlight/flare/torch/lantern,
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "srw" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -59081,12 +59160,12 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
 "sse" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch{
-	dir = 4
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "ssj" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -59101,6 +59180,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"sso" = (
+/turf/open/transparent/openspace,
+/turf/closed/wall/mineral/rogue/wooddark/window,
+/area/rogue/indoors/shelter/woods)
 "ssq" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -59161,11 +59244,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"stb" = (
-/obj/item/natural/stone,
-/obj/effect/wisp/prestidigitation,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "stc" = (
 /obj/structure/roguemachine/withdraw{
 	pixel_x = 32;
@@ -59194,12 +59272,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"stY" = (
-/obj/structure/hotspring{
-	icon_state = "lilypetals3"
-	},
-/turf/open/water/pond,
-/area/rogue/outdoors/woods)
 "sua" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/churchmarble,
@@ -59224,6 +59296,15 @@
 "sux" = (
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
+"suB" = (
+/obj/structure/flora/roguetree/stump{
+	pixel_y = 0;
+	pixel_x = -10
+	},
+/obj/structure/table/wood/folding,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
 "suJ" = (
 /obj/effect/decal/cobbleedge{
@@ -59304,6 +59385,13 @@
 "svv" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
+"svy" = (
+/obj/structure/flora/sakura{
+	pixel_x = -57;
+	pixel_y = -3
+	},
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/rtfield/eora)
 "svz" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
@@ -59365,6 +59453,10 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"sws" = (
+/obj/structure/hotspring/border/seven,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "swt" = (
 /turf/open/floor/carpet/red,
 /area/rogue/outdoors/rtfield/eora)
@@ -59529,6 +59621,15 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"syO" = (
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "syR" = (
 /obj/structure/closet/crate/chest{
 	base_icon_state = "woodchestalt";
@@ -59551,6 +59652,11 @@
 /obj/structure/vine,
 /turf/closed,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"szs" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/glowshroom,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "szy" = (
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/rogue/hexstone,
@@ -59646,12 +59752,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center/no_teleport,
 /area/rogue/under/cave/licharena)
-"sBu" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
 "sBx" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/herringbone,
@@ -59677,9 +59777,14 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
 "sCr" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "sCt" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 8
@@ -59781,7 +59886,7 @@
 /turf/open/water/swamp,
 /area/rogue/under/town/sewer)
 "sFs" = (
-/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/vine,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
 "sFt" = (
@@ -59794,6 +59899,10 @@
 "sFF" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave/skeletoncrypt)
+"sFJ" = (
+/obj/effect/wisp/prestidigitation,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "sFR" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -59851,6 +59960,10 @@
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter/mountains/decap)
+"sGV" = (
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "sGY" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 8;
@@ -59934,13 +60047,6 @@
 /obj/item/bedsheet/rogue/wool,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark)
-"sIG" = (
-/obj/structure/vine,
-/obj/structure/glowshroom{
-	icon_state = "glowshroom2"
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "sIJ" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/bush,
@@ -60100,10 +60206,6 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"sLU" = (
-/obj/structure/roguerock,
-/turf/open/water/cleanshallow,
-/area/rogue/under/cave/goblindungeon)
 "sLY" = (
 /obj/structure/table/wood{
 	icon_state = "longtable_mid"
@@ -60289,18 +60391,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "sPd" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 6;
-	pixel_y = 0
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/decal/cobble/mossy{
-	dir = 1
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/mushroomcluster,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/river)
 "sPj" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/underdark)
@@ -60497,6 +60590,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
+"sRs" = (
+/obj/structure/fluff/railing/border{
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "sRv" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/hexstone,
@@ -60570,12 +60669,6 @@
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
-"sSN" = (
-/obj/structure/glowshroom{
-	icon_state = "glowshroom3"
-	},
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/woods)
 "sSO" = (
 /obj/structure/well,
 /obj/item/reagent_containers/glass/bucket{
@@ -60605,10 +60698,6 @@
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
-"sTA" = (
-/obj/effect/lily_petal,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield/eora)
 "sTD" = (
 /obj/structure/closet/crate/chest/gold{
 	locked = 1;
@@ -60745,6 +60834,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cave/dukecourt)
+"sVU" = (
+/obj/structure/flora/hotspring_rocks/small,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "sVY" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/dirt,
@@ -60829,18 +60922,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/church/basement)
-"sXF" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "sXG" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
@@ -60877,12 +60958,19 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "sYb" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/connector{
-	dir = 4
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/table/wood/folding,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "sYi" = (
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
@@ -60911,6 +60999,10 @@
 /obj/item/cooking/platter/aalloy,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains/decap)
+"sYt" = (
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "sYv" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/wood,
@@ -61135,7 +61227,7 @@
 	icon_state = "cobbleedge-e"
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "tcv" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -61189,6 +61281,10 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/magician)
+"tdb" = (
+/obj/structure/flora/newtree,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "tdc" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -61237,11 +61333,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/water/bloody,
 /area/rogue/outdoors/mountains/decap/stepbelow)
-"tdO" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt/pink,
-/obj/effect/lily_petal/three,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield/eora)
 "tdZ" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -61383,12 +61474,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter/mountains/decap)
-"tfT" = (
-/obj/structure/glowshroom{
-	icon_state = "glowshroom3"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "tfW" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/naturalstone,
@@ -61423,10 +61508,6 @@
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/physician)
-"tgG" = (
-/obj/structure/table/church,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/woods)
 "tgR" = (
 /obj/effect/decal/mossy{
 	dir = 1
@@ -61553,12 +61634,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"tjL" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
 "tjV" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -61863,16 +61938,8 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "toh" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_x = 8
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1";
-	pixel_y = -4
-	},
-/obj/item/rogueweapon/huntingknife/stoneknife,
-/turf/open/floor/rogue/twig,
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/closed,
 /area/rogue/indoors/shelter/woods)
 "tok" = (
 /obj/effect/decal/mossy{
@@ -61971,6 +62038,10 @@
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/church/chapel)
+"tpM" = (
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "tpW" = (
 /obj/structure/closet/crate/chest/wicker,
 /turf/open/floor/rogue/grass,
@@ -62089,6 +62160,13 @@
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/woods)
+"tse" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "tsg" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -62106,17 +62184,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
-"tso" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
-	},
-/obj/structure/closet/crate/chest/wicker,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "tsp" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -62152,6 +62219,11 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/sewer)
+"tsK" = (
+/obj/structure/hotspring,
+/obj/item/alch/salvia,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "tsM" = (
 /obj/structure/fluff/walldeco/artificerflag,
 /turf/closed/wall/mineral/rogue/pipe,
@@ -62219,11 +62291,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"ttU" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/roguegrass/thorn_bush,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "ttW" = (
 /obj/item/clothing/neck/roguetown/psicross/silver,
 /obj/structure/closet/crate/coffin,
@@ -62285,6 +62352,13 @@
 /obj/structure/hotspring/border/thirteen,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
+"tvc" = (
+/obj/structure/flora/sakura{
+	pixel_x = -58;
+	pixel_y = -9
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "tvg" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -62308,6 +62382,10 @@
 "tvo" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/basement)
+"tvx" = (
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/woods)
 "tvL" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/dirt,
@@ -62562,12 +62640,6 @@
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
-"tzq" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 10
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "tzs" = (
 /obj/structure/gate/bars/preopen,
 /turf/open/floor/rogue/grass,
@@ -62666,6 +62738,19 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"tAM" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/table/wood/folding,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "tAO" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -62685,17 +62770,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"tBw" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/globe,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
-"tBC" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "tBE" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/swamp/deep,
@@ -62856,12 +62930,6 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"tDB" = (
-/obj/structure/fluff/railing/border{
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "tDH" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -62879,6 +62947,14 @@
 /obj/item/storage/belt/rogue/surgery_bag/full,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"tDN" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/roguemachine/noticeboard{
+	pixel_y = -12;
+	pixel_x = 2
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "tDP" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
@@ -62893,6 +62969,14 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/blocks/paving/vert,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"tEb" = (
+/obj/structure/hotspring,
+/obj/structure/hotspring/border/eight{
+	pixel_y = 0;
+	pixel_x = 14
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "tEd" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
@@ -62959,13 +63043,12 @@
 	},
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
-"tFJ" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch{
-	dir = 1
+"tFD" = (
+/obj/effect/lily_petal/three{
+	icon_state = "lilypetals2"
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/mountains)
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "tFL" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grassyel,
@@ -63079,6 +63162,14 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"tIr" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 10;
+	pixel_y = 0;
+	pixel_x = 7
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "tIs" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/wood,
@@ -63124,11 +63215,11 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
 "tJh" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/effect/lily_petal/three{
+	icon_state = "lilypetals1"
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "tJi" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -63241,13 +63332,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
-"tKY" = (
-/obj/machinery/light/rogue/torchholder/hotspring/standing,
-/obj/effect/decal/mossy{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "tKZ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -63300,6 +63384,13 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
+"tLI" = (
+/obj/structure/curtain/magenta{
+	color = 54202a;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "tLO" = (
 /obj/effect/particle_effect/smoke{
 	lifetime = 14400
@@ -63358,19 +63449,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"tMt" = (
-/obj/structure/flora/roguegrass/bush{
-	pixel_x = -5;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
-"tMy" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "tMN" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -63511,6 +63589,16 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"tOR" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/newtree,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "tPa" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -63529,6 +63617,21 @@
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/under/cave/licharena)
+"tPn" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
+"tPo" = (
+/obj/structure/chair/hotspring_bench/corner{
+	dir = 4
+	},
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "tPB" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -63564,6 +63667,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
+"tPY" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "tQa" = (
 /obj/structure/bars/tough,
 /turf/open/floor/rogue/concrete,
@@ -63618,6 +63725,12 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"tQL" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/river)
 "tQP" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/walldeco/rpainting/forest{
@@ -63647,6 +63760,13 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/basement)
+"tRd" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "tRq" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -63788,17 +63908,6 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/cave)
-"tUg" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_x = 8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "tUu" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/bed/rogue/inn,
@@ -64057,13 +64166,6 @@
 /obj/structure/fluff/walldeco/rpainting/crown,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
-"tXD" = (
-/obj/structure/roguemachine/noticeboard{
-	pixel_y = 7;
-	pixel_x = 15
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "tXL" = (
 /obj/structure/roguewindow,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -64251,6 +64353,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter/woods)
+"tZS" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/woods)
 "tZV" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/fluff/railing/wood{
@@ -64532,6 +64640,11 @@
 /obj/structure/fermentation_keg/water,
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
+"ueJ" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "ueT" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -64723,6 +64836,14 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"uhD" = (
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/obj/effect/decal/cobble/mossy{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "uhG" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/fluff/railing/border{
@@ -64916,11 +65037,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
-"ukO" = (
-/obj/structure/vine,
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "ukX" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -65019,6 +65135,13 @@
 "ume" = (
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"umf" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "umh" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -65068,9 +65191,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
 "umA" = (
-/obj/structure/vine,
-/turf/open/water/river,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "umD" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
@@ -65111,10 +65234,16 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
-"unb" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+"unh" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "unq" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -65133,13 +65262,6 @@
 /obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
-"unz" = (
-/obj/structure/flora/hotspring_rocks/small,
-/obj/effect/decal/mossy{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "unE" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/goblinfort)
@@ -65193,12 +65315,12 @@
 /obj/item/clothing/under/roguetown/loincloth/brown,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/basement)
-"uov" = (
-/obj/structure/stairs{
-	dir = 4
+"uoF" = (
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
 	},
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "uoI" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -65436,6 +65558,13 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
+"urX" = (
+/obj/structure/spider/stickyweb{
+	dir = 1;
+	icon_state = "stickyweb2"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "urY" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -65611,11 +65740,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
-"uuE" = (
-/turf/open/water/river{
-	icon_state = "rockwd"
-	},
-/area/rogue/outdoors/mountains)
 "uuS" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach)
@@ -65665,10 +65789,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
 "uvu" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	pixel_y = -6
-	},
+/obj/structure/flora/newleaf,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
 "uvy" = (
@@ -65741,6 +65862,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"uxf" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 5
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "uxj" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -65904,11 +66031,6 @@
 "uyR" = (
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
-"uyS" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "uyU" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -65994,15 +66116,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/orcdungeon)
-"uAa" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
 "uAh" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -66073,11 +66186,11 @@
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
 "uBd" = (
-/obj/structure/vine,
-/turf/open/water/river{
-	icon_state = "rockwd"
+/turf/open/floor/rogue/twig,
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/shelter/woods)
 "uBe" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
@@ -66163,6 +66276,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"uCt" = (
+/obj/structure/fluff/psycross/crafted,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "uCv" = (
 /obj/machinery/light/rogue/wallfire/candle/off/r,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -66477,6 +66594,9 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"uGQ" = (
+/turf/closed/wall/mineral/rogue/decostone/fluffstone,
+/area/rogue/outdoors/rtfield/eora)
 "uGX" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/shelter)
@@ -66611,14 +66731,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/cave/dukecourt)
-"uJe" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
-/area/rogue/outdoors/mountains)
 "uJk" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -66751,10 +66863,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors)
-"uLg" = (
-/obj/item/natural/rock,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/woods)
 "uLp" = (
 /obj/structure/flora/roguegrass/thorn_bush,
 /obj/structure/fluff/railing/wood{
@@ -66825,6 +66933,10 @@
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
+"uMV" = (
+/obj/structure/flora/roguegrass/thorn_bush,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "uMY" = (
 /obj/structure/roguemachine/scomm/l{
 	scom_tag = "South Gate"
@@ -66861,13 +66973,6 @@
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/sewer)
-"uOG" = (
-/obj/structure/flora/hotspring_rocks/small{
-	pixel_x = -8;
-	pixel_y = 14
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/woods)
 "uOM" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -66900,12 +67005,6 @@
 "uPk" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/goblinfort)
-"uPm" = (
-/obj/structure/glowshroom{
-	icon_state = "glowshroom2"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/woods)
 "uPn" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/rogue/blocks,
@@ -67037,12 +67136,6 @@
 	},
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
-"uQR" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
 "uQS" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -67054,11 +67147,6 @@
 	},
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
-"uRn" = (
-/obj/structure/hotspring/border/five,
-/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals_dried,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "uRv" = (
 /obj/structure/fluff/railing/fence,
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
@@ -67196,13 +67284,6 @@
 	icon_state = "horzw"
 	},
 /area/rogue/outdoors/rtfield)
-"uSZ" = (
-/obj/structure/curtain/magenta{
-	color = 54202a;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
 "uTb" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/floor/rogue/dirt,
@@ -67385,7 +67466,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "uWJ" = (
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
+	},
+/turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/woods)
 "uWO" = (
 /obj/structure/fluff/railing/border{
@@ -67418,14 +67502,6 @@
 /obj/item/book/rogue/naledi4,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
-"uXh" = (
-/obj/structure/flora/newleaf,
-/obj/structure/spider/stickyweb{
-	dir = 1;
-	icon_state = "stickyweb2"
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/shelter/woods)
 "uXk" = (
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/under/cave/goblindungeon)
@@ -67478,6 +67554,18 @@
 "uXU" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblinfort)
+"uXX" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	pixel_y = -4
+	},
+/obj/item/rogueweapon/huntingknife/stoneknife,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "uXY" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4;
@@ -67494,6 +67582,13 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"uYl" = (
+/obj/structure/bars/shop/bronze,
+/turf/open/water/river{
+	dir = 1;
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/woods)
 "uYm" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -67583,11 +67678,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "uZy" = (
-/obj/effect/decal/mossy{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "uZz" = (
 /obj/structure/shisha/hookah{
 	pixel_x = 14;
@@ -67636,6 +67728,14 @@
 "uZT" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter)
+"vac" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "vad" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt/road,
@@ -67841,6 +67941,12 @@
 /obj/item/roguestatue/iron,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"vdw" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/woods)
 "vdA" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -67890,6 +67996,11 @@
 "vek" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
+"veo" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "ves" = (
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/wood,
@@ -67970,11 +68081,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/sewer)
-"vfW" = (
-/obj/item/natural/rock,
-/obj/item/natural/stone,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/woods)
 "vgd" = (
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -68399,6 +68505,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"vnn" = (
+/obj/structure/vine,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/river)
 "vno" = (
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -68460,7 +68570,7 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "vob" = (
 /obj/structure/hotspring/border/seven,
-/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals_dried,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "vod" = (
@@ -68556,6 +68666,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
+"vqf" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "vql" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -68615,8 +68729,14 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
 "vqR" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grassred,
+/obj/item/restraints/legcuffs/beartrap/armed,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/river)
+"vrf" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "vrg" = (
 /obj/structure/table/church{
@@ -68677,6 +68797,14 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/physician)
+"vrQ" = (
+/obj/structure/bed/rogue/inn/hay,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "vrU" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -68730,6 +68858,12 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"vsZ" = (
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/river)
 "vta" = (
 /obj/machinery/light/rogue/oven/north,
 /turf/open/floor/rogue/cobble,
@@ -68744,12 +68878,8 @@
 /turf/open/water/cleanshallow,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "vtD" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/stone/moss,
+/area/rogue/outdoors/woods)
 "vtP" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -68832,6 +68962,11 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblindungeon)
+"vuH" = (
+/obj/structure/vine,
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "vuL" = (
 /obj/item/ash,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -68988,10 +69123,6 @@
 "vxh" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
-"vxu" = (
-/obj/machinery/light/rogue/torchholder/hotspring/standing,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/woods)
 "vxB" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/rogueweapon/sickle{
@@ -69025,6 +69156,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
+"vxZ" = (
+/obj/effect/decal/cobble/mossy,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "vya" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood,
@@ -69105,7 +69240,7 @@
 /area/rogue/indoors/town/tavern)
 "vzE" = (
 /obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/leafless{
+/obj/structure/flora/newbranch{
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -69270,6 +69405,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"vBZ" = (
+/obj/item/natural/rock,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "vCb" = (
 /obj/structure/closet/dirthole/closed/loot,
 /obj/structure/gravemarker,
@@ -69323,6 +69462,12 @@
 /obj/item/rogueweapon/shield/heater,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
+"vDp" = (
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = -5
+	},
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "vDq" = (
 /obj/structure/mineral_door/wood/window{
 	locked = 1;
@@ -69356,11 +69501,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"vDI" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
-/obj/structure/flora/rogueshroom/happy/mushroom4,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/woods)
 "vDJ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/basement)
@@ -69408,10 +69548,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"vEB" = (
-/obj/structure/fluff/statue/knight/interior/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "vEE" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/farmer,
@@ -69514,12 +69650,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"vGk" = (
-/obj/structure/flora/newbranch/connector{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "vGn" = (
 /obj/structure/fluff/psycross{
 	pixel_x = -15;
@@ -69625,11 +69755,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/mountains/decap)
-"vIo" = (
-/obj/machinery/light/rogue/torchholder/hotspring/standing,
-/obj/effect/lily_petal,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "vIp" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -69662,24 +69787,13 @@
 	},
 /area/rogue/outdoors/mountains)
 "vIC" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 8
-	},
+/obj/structure/vine,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "vII" = (
 /obj/structure/fluff/statue/astrata/gold,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"vIK" = (
-/obj/effect/particle_effect/smoke{
-	lifetime = 14400
-	},
-/obj/item/natural/rock,
-/turf/open/water/river{
-	icon_state = "rockwd"
-	},
-/area/rogue/outdoors/woods)
 "vIP" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -69723,6 +69837,16 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"vJt" = (
+/obj/structure/roguemachine/musicbox{
+	pixel_y = 21
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "vJu" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -69950,10 +70074,6 @@
 /obj/item/gavelhammer,
 /turf/open/floor/rogue/carpet,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"vNA" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "vNB" = (
 /obj/structure/fluff/psycross/crafted,
 /turf/open/floor/rogue/dirt/road,
@@ -69964,6 +70084,17 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
+"vND" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/obj/structure/fluff/statue/pillar{
+	pixel_y = 2;
+	pixel_x = 10
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "vNN" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt,
@@ -69972,6 +70103,11 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"vNX" = (
+/obj/effect/falling_sakura,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "vOc" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/cloak/cape/guard,
@@ -70117,6 +70253,17 @@
 /obj/machinery/light/rogue/wallfire/candle/off/l,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
+"vQe" = (
+/obj/structure/flora/hotspring_rocks{
+	pixel_y = -8;
+	pixel_x = -9
+	},
+/obj/machinery/light/rogue/torchholder/hotspring/standing{
+	pixel_y = -1;
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/woods)
 "vQf" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/hexstone,
@@ -70248,12 +70395,13 @@
 /obj/structure/flora/newbranch/leafless,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town/roofs)
-"vSS" = (
-/obj/structure/table/church{
-	icon_state = "churchtable_mid"
+"vSM" = (
+/obj/structure/flora/sakura{
+	pixel_x = -57;
+	pixel_y = -3
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "vSY" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -70332,6 +70480,13 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
+"vUd" = (
+/obj/structure/flora/roguegrass/herb/salvia,
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "vUo" = (
 /obj/item/seeds/apple,
 /obj/item/seeds/apple,
@@ -70396,23 +70551,24 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/woods)
-"vUC" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/obj/structure/table/wood/folding,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "vUD" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
+"vUL" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/obj/effect/decal/carpet/kover_darkred{
+	pixel_y = -10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n";
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "vUV" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -70448,9 +70604,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "vVH" = (
-/obj/structure/flora/newbranch,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
+/obj/structure/curtain/green,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "vVK" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/rogue/greenstone,
@@ -70632,6 +70788,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"vXW" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "vYb" = (
 /obj/structure/table/wood,
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -70777,6 +70937,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"vZO" = (
+/obj/item/natural/stone,
+/obj/effect/wisp/prestidigitation,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "vZU" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -70792,13 +70957,17 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
-"waj" = (
-/obj/structure/roguewindow,
-/obj/structure/bars/passage/shutter{
-	redstone_id = "trader_stock_shutter"
+"wai" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
+"waC" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
 	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/shop)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "waG" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/dirt,
@@ -70817,6 +70986,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"waT" = (
+/obj/structure/vine,
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/goblindungeon)
 "waU" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/dirt,
@@ -70837,14 +71010,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
-"wbv" = (
-/obj/structure/table/church/m,
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
-	pixel_x = -5;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield/eora)
 "wbC" = (
 /obj/effect/decal/cleanable/debris/stony,
 /obj/effect/decal/cleanable/debris/stony{
@@ -70855,6 +71020,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"wbG" = (
+/obj/structure/hotspring{
+	icon_state = "lilypetals1"
+	},
+/turf/open/water/pond,
+/area/rogue/outdoors/woods)
 "wcb" = (
 /obj/structure/bars/tough,
 /turf/open/floor/rogue/concrete,
@@ -71005,21 +71176,14 @@
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"wef" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "weg" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"wem" = (
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "wet" = (
 /mob/living/simple_animal/hostile/rogue/skeleton,
 /turf/open/floor/rogue/tile/bfloorz,
@@ -71067,13 +71231,6 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
-"wfc" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "wfo" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/rope/chain,
@@ -71089,9 +71246,8 @@
 	},
 /area/rogue/under/cave/dukecourt)
 "wfE" = (
-/obj/item/natural/rock,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
+/turf/open/water/river,
+/area/rogue/outdoors/mountains)
 "wfG" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/rogueweapon/hoe/stone,
@@ -71405,6 +71561,20 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/beach)
+"wjp" = (
+/obj/structure/table/church{
+	icon_state = "churchtable_end"
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals{
+	pixel_y = 9;
+	pixel_x = -12
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "wjv" = (
 /obj/item/candle/candlestick/silver/lit{
 	pixel_y = 9
@@ -71494,12 +71664,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
-"wkq" = (
-/turf/closed/wall/mineral/rogue/wooddark{
-	icon_state = "wooddark-k"
+"wku" = (
+/obj/structure/flora/sakura{
+	pixel_x = -54;
+	pixel_y = 0
 	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/rtfield/eora)
 "wkv" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -71529,12 +71700,6 @@
 /mob/living/carbon/human/species/human/northern/highwayman,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/mountains/decap)
-"wkM" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
 "wkO" = (
 /obj/structure/mineral_door/wood/deadbolt/shutter{
 	dir = 8
@@ -71648,6 +71813,10 @@
 /obj/item/clothing/neck/roguetown/psicross,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"wmq" = (
+/obj/structure/flora/newbranch,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "wmx" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
@@ -71750,16 +71919,12 @@
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"wnN" = (
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
-	pixel_x = -5;
-	pixel_y = 0
+"wob" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
 	},
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt{
-	pixel_y = -14
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "woi" = (
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/carpet/royalblack,
@@ -71800,18 +71965,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"woL" = (
-/obj/structure/stairs,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/woods)
 "woN" = (
 /obj/structure/table/vtable/v2,
 /obj/item/candle/eora/lit,
@@ -71871,6 +72024,14 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs/keep)
+"wpQ" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/curtain/magenta{
+	color = 54202a;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "wpV" = (
 /obj/structure/chair/wood/rogue/fancy,
 /obj/effect/landmark/start/wapprentice,
@@ -71956,6 +72117,16 @@
 /obj/structure/vine,
 /turf/open/water/swamp,
 /area/rogue/indoors/cave)
+"wrn" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot/stone,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
+"wrK" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
+/obj/structure/flora/rogueshroom/happy/mushroom4,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave)
 "wrP" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -72034,7 +72205,7 @@
 	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "wsN" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -72129,14 +72300,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "wuP" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield/eora)
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "wuZ" = (
 /obj/structure/closet/crate/chest/gold{
 	locked = 1;
@@ -72156,13 +72322,6 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"wvi" = (
-/obj/structure/bed/rogue/bedroll,
-/obj/effect/landmark/start/druid{
-	dir = 1
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "wvj" = (
 /obj/structure/mannequin/male,
 /obj/item/clothing/suit/roguetown/shirt/tunic/silktunic,
@@ -72212,6 +72371,24 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"wwE" = (
+/obj/item/clothing/neck/roguetown/psicross/eora{
+	pixel_y = 4
+	},
+/obj/item/candle/eora/lit{
+	pixel_y = -2;
+	pixel_x = 13
+	},
+/obj/item/candle/eora/lit{
+	pixel_y = -2;
+	pixel_x = -14
+	},
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_x = -1;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "wwG" = (
 /obj/effect/landmark/start/magician,
 /turf/open/floor/rogue/herringbone,
@@ -72305,6 +72482,10 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"wxy" = (
+/obj/structure/flora/rogueshroom/happy/mushroom2,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/river)
 "wxD" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -72470,6 +72651,18 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"wAa" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "wAf" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/farmer{
@@ -72589,13 +72782,6 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
-"wCu" = (
-/obj/structure/hotspring,
-/obj/structure/hotspring/border/two{
-	pixel_y = -20
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "wCB" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -72677,9 +72863,9 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/cell)
 "wDS" = (
-/obj/machinery/tanningrack,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/rogueshroom/happy/mushroom5,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/river)
 "wEc" = (
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32
@@ -72789,6 +72975,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc2,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/orcdungeon)
+"wFy" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "wFB" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -72852,6 +73042,12 @@
 	smooth_icon = null
 	},
 /area/rogue/indoors/town/church/chapel)
+"wFV" = (
+/obj/structure/table/church{
+	icon_state = "churchtable_mid"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "wFW" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/shelter/mountains/decap)
@@ -72871,13 +73067,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"wGa" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
 "wGh" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/newleaf,
@@ -72937,6 +73126,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"wGZ" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/leafless{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "wHb" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
@@ -72976,6 +73172,17 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
+"wHN" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
+	},
+/obj/structure/hotspring{
+	icon_state = "bigrock_grass";
+	pixel_x = 13;
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/woods)
 "wHW" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia{
 	dir = 4
@@ -73002,6 +73209,12 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
+"wIv" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "wIx" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -73064,6 +73277,10 @@
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/underdark)
+"wJA" = (
+/obj/effect/lily_petal/two,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "wJD" = (
 /obj/effect/landmark/events/testportal{
 	aportalloc = "bog"
@@ -73251,6 +73468,10 @@
 /mob/living/simple_animal/hostile/rogue/deepone,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet/bogcaves)
+"wMu" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "wMx" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/dirt/road,
@@ -73278,6 +73499,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"wMQ" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "wMR" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -73443,6 +73670,11 @@
 /obj/structure/bars,
 /turf/open/water/swamp,
 /area/rogue/under/cave/dungeon1/gethsmane)
+"wPC" = (
+/obj/structure/vine,
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "wPD" = (
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -73453,6 +73685,17 @@
 /obj/structure/plasticflaps,
 /turf/open/water/ocean,
 /area/rogue/outdoors/beach)
+"wPT" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/obj/structure/fluff/statue/pillar{
+	pixel_y = 1;
+	pixel_x = -12
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "wQd" = (
 /obj/structure/fluff/railing/border{
 	dir = 10;
@@ -73544,6 +73787,13 @@
 /obj/item/rogueore/coal,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"wRt" = (
+/obj/structure/hotspring,
+/obj/structure/hotspring/border/two{
+	pixel_y = -20
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "wRu" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -73598,13 +73848,6 @@
 	},
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
-"wSb" = (
-/obj/structure/bearpelt{
-	pixel_y = -16;
-	pixel_x = -13
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
 "wSh" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -73638,10 +73881,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"wSG" = (
-/obj/effect/lily_petal/three,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield/eora)
 "wSO" = (
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/pink,
 /turf/open/floor/rogue/churchbrick,
@@ -73737,16 +73976,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/mountains/decap/stepbelow)
-"wUE" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 10;
-	pixel_y = 0
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
 "wUI" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -73754,10 +73983,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"wUK" = (
-/obj/structure/flora/roguegrass/herb/rosa,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield/eora)
 "wUO" = (
 /obj/structure/fluff/walldeco/innsign{
 	pixel_x = -32
@@ -73768,11 +73993,6 @@
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/sewer)
-"wUZ" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/roguegrass/bush,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "wVu" = (
 /obj/structure/fluff/walldeco/chains{
 	icon_state = "chains8"
@@ -73800,6 +74020,12 @@
 /obj/effect/decal/cleanable/debris/stony,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"wVJ" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "wVU" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -73866,10 +74092,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"wWD" = (
-/obj/item/natural/stone,
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/woods)
 "wWG" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -73985,6 +74207,10 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/cell)
+"wYz" = (
+/obj/structure/roguerock,
+/turf/open/water/cleanshallow,
+/area/rogue/under/cave/goblindungeon)
 "wYA" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/manorguardsman,
@@ -74170,6 +74396,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
+"xaK" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "xaY" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/shelter)
@@ -74216,15 +74448,6 @@
 /obj/structure/glowshroom,
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
-"xbM" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = 7
-	},
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "xbS" = (
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/dirt,
@@ -74337,14 +74560,18 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xdh" = (
-/obj/structure/glowshroom{
-	icon_state = "glowshroom2"
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/river)
 "xdi" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town)
+"xdl" = (
+/obj/structure/flora/newbranch{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "xdq" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/grassyel,
@@ -74413,6 +74640,19 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"xep" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
+"xey" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/globe,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "xeA" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -74443,14 +74683,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/cave/goblinfort)
-"xeJ" = (
-/obj/structure/hotspring,
-/obj/structure/hotspring/border/eight{
-	pixel_y = 0;
-	pixel_x = 14
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "xeW" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/blocks,
@@ -74586,6 +74818,15 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"xhs" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/yellow{
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/tavern)
 "xhy" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/hexstone,
@@ -74744,12 +74985,6 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
-"xkz" = (
-/obj/effect/decal/cobble/mossy{
-	dir = 6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "xkB" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -74986,6 +75221,16 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"xmS" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "xmX" = (
 /obj/structure/mineral_door/wood/fancywood{
 	dir = 1;
@@ -75020,13 +75265,6 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
-"xnn" = (
-/obj/structure/flora/roguegrass,
-/obj/effect/decal/mossy{
-	dir = 8
-	},
-/turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield/eora)
 "xnr" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /turf/open/floor/rogue/wood,
@@ -75071,6 +75309,10 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/dukecourt)
+"xnW" = (
+/obj/structure/vine,
+/turf/open/water/cleanshallow,
+/area/rogue/under/cave)
 "xnZ" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -75079,9 +75321,8 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield/eora)
 "xoi" = (
-/obj/structure/flora/roguegrass/thorn_bush,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
+/turf/closed/wall/mineral/rogue/wooddark/slitted,
+/area/rogue/outdoors/river)
 "xol" = (
 /obj/machinery/light/rogue/hearth,
 /obj/machinery/light/rogue/oven{
@@ -75098,6 +75339,11 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town)
+"xoo" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/glowshroom,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "xor" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -75156,23 +75402,10 @@
 "xpH" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town/roofs/keep)
-"xpJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	pixel_x = -4;
-	pixel_y = 0
-	},
-/obj/machinery/light/rogue/torchholder/hotspring/standing,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "xpO" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
-"xpP" = (
-/obj/item/restraints/legcuffs/beartrap/armed,
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
 "xpQ" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/flora/roguegrass,
@@ -75266,10 +75499,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
-"xrP" = (
-/obj/structure/flora/hotspring_rocks/small/five,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "xrQ" = (
 /obj/structure/roguemachine/withdraw,
 /obj/machinery/light/rogue/torchholder/l,
@@ -75312,14 +75541,6 @@
 /obj/item/clothing/ring/silver,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/exposed/bath/vault)
-"xsx" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/structure/roguetent,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
 "xsz" = (
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/greenstone,
@@ -75373,6 +75594,12 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
+"xtv" = (
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "xtD" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -75544,8 +75771,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
 "xyi" = (
-/obj/structure/vine,
-/turf/open/floor/rogue/naturalstone,
+/obj/effect/decal/cobble/mossy{
+	dir = 10;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
 "xyq" = (
 /obj/structure/chair/bench{
@@ -75651,12 +75881,8 @@
 /turf/open/floor/carpet/stellar,
 /area/rogue/outdoors/beach)
 "xAh" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/river)
 "xAk" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/tile,
@@ -75682,10 +75908,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
-"xAI" = (
-/obj/structure/flora/rogueshroom/happy/mushroom5,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/woods)
 "xAN" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 4;
@@ -75748,12 +75970,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement/keep)
-"xBr" = (
-/obj/structure/table/church{
-	icon_state = "churchtable_end"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "xBE" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder/spear,
 /turf/open/floor/rogue/church,
@@ -75803,13 +76019,6 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet/bogcaves)
-"xCw" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	pixel_y = -6
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
 "xCx" = (
 /turf/closed/wall/mineral/rogue/wooddark/slitted,
 /area/rogue/outdoors/mountains)
@@ -75829,15 +76038,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"xCH" = (
-/obj/structure/flora/roguetree/stump{
-	pixel_y = 0;
-	pixel_x = -10
-	},
-/obj/structure/table/wood/folding,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
 "xCK" = (
 /turf/open/water/swamp,
 /area/rogue/under/town/sewer)
@@ -76052,7 +76252,7 @@
 	icon_state = "cobbleedge-e"
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 "xFX" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 1
@@ -76121,10 +76321,6 @@
 /obj/structure/flora/roguetree/pine,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
-"xGB" = (
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/woods)
 "xGD" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 2
@@ -76150,15 +76346,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
-"xGW" = (
-/obj/effect/decal/mossy{
-	dir = 4
-	},
-/obj/effect/decal/cobble/mossy{
-	dir = 10
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
 "xHb" = (
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/rogue/wood,
@@ -76183,24 +76370,6 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"xHC" = (
-/obj/item/clothing/neck/roguetown/psicross/eora{
-	pixel_y = 4
-	},
-/obj/item/candle/eora/lit{
-	pixel_y = -2;
-	pixel_x = 13
-	},
-/obj/item/candle/eora/lit{
-	pixel_y = -2;
-	pixel_x = -14
-	},
-/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
-	pixel_x = -1;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "xHF" = (
 /obj/structure/closet/crate/chest/lootbox,
 /obj/item/scomstone,
@@ -76301,6 +76470,12 @@
 	icon_state = "plating2"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"xKg" = (
+/obj/structure/flora/newbranch{
+	dir = 8
+	},
+/turf/open/water/pond,
+/area/rogue/outdoors/woods)
 "xKi" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -76444,12 +76619,6 @@
 "xMv" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"xMz" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
 "xMP" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/fluff/littlebanners{
@@ -76483,16 +76652,6 @@
 /obj/structure/flora/roguegrass/herb/rosa,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
-"xNG" = (
-/obj/structure/roguemachine/musicbox{
-	pixel_y = 21
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1";
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
 "xNH" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -76627,6 +76786,12 @@
 /obj/item/reagent_containers/glass/bowl/gold,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"xOD" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/leafless,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "xOE" = (
 /obj/structure/fluff/walldeco/chains{
 	icon_state = "chains5"
@@ -76806,6 +76971,13 @@
 /obj/machinery/light/rogue/firebowl/off,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/woods)
+"xRM" = (
+/obj/structure/closet/dirthole/grave,
+/obj/item/alch/rosa,
+/obj/effect/landmark/start/orphan,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "xRV" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /obj/structure/fluff/railing/wood{
@@ -76929,18 +77101,12 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/shop)
 "xTn" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -8
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch{
+	dir = 8
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/greenstone/runed,
-/area/rogue/outdoors/woods)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "xTs" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -76995,11 +77161,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"xVA" = (
-/obj/structure/chair/stool/rogue,
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
 "xVD" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -77056,17 +77217,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town)
-"xWb" = (
-/obj/structure/glowshroom{
-	icon_state = "glowshroom3"
-	},
-/obj/structure/hotspring{
-	icon_state = "bigrock_grass";
-	pixel_x = 13;
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/woods)
 "xWd" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 8
@@ -77126,12 +77276,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter)
 "xXw" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "xXA" = (
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -77151,13 +77297,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "xYg" = (
-/obj/structure/vine,
-/obj/structure/glowshroom{
-	icon_state = "glowshroom3"
+/obj/structure/roguemachine/noticeboard{
+	pixel_y = -14;
+	pixel_x = 17
 	},
-/obj/structure/plasticflaps,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cave/goblindungeon)
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "xYj" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
@@ -77190,6 +77335,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
+"xYC" = (
+/obj/structure/flora/rogueshroom/happy/mushroom4,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave)
 "xYI" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/carpet/red,
@@ -77236,11 +77385,10 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/cave)
 "xYX" = (
-/obj/structure/flora/newbranch{
-	dir = 1
-	},
-/turf/open/water/pond,
-/area/rogue/outdoors/woods)
+/obj/structure/flora/newleaf,
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "xZb" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/naturalstone,
@@ -77276,10 +77424,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
-"xZJ" = (
-/obj/structure/closet/crate/chest/crate,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/shelter/woods)
 "xZK" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
@@ -77502,12 +77646,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter)
-"ycv" = (
-/obj/structure/flora/newbranch/leafless{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "ycA" = (
 /obj/item/natural/bone,
 /turf/open/water/swamp/deep,
@@ -77577,6 +77715,10 @@
 /obj/structure/fluff/canopy/green,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"ydi" = (
+/obj/machinery/tanningrack,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "ydr" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	icon_state = "iron_corner"
@@ -77592,6 +77734,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"ydz" = (
+/turf/open/water/river{
+	dir = 1;
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/river)
 "ydT" = (
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /obj/structure/bed/rogue/shit,
@@ -77676,6 +77824,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"yeP" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/hotspring_rocks/small/two,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "yeZ" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/cobblerock,
@@ -77730,6 +77883,12 @@
 /obj/structure/flora/roguegrass/herb/hypericum,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/beach/forest)
+"yfv" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "yfw" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -77776,6 +77935,12 @@
 /obj/effect/spawner/lootdrop/potion_stats,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave/skeletoncrypt)
+"ygc" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 10
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "ygd" = (
 /obj/structure/fluff/walldeco/bigpainting/lake,
 /turf/open/floor/rogue/tile/bfloorz,
@@ -77833,6 +77998,10 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/goblinfort)
+"ygS" = (
+/obj/structure/vine,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "ygY" = (
 /obj/structure/fluff/walldeco/rpainting/crown,
 /turf/closed/wall/mineral/rogue/decostone/long{
@@ -77873,11 +78042,6 @@
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
-"yhT" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
-/obj/structure/vine,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/woods)
 "yhV" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grass,
@@ -77897,10 +78061,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"yim" = (
-/obj/structure/flora/hotspring_rocks/small,
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/woods)
 "yix" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -77922,13 +78082,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
-"yiG" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "yiT" = (
 /obj/item/grown/log/tree/small{
 	pixel_x = -11;
@@ -77940,6 +78093,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/skeletoncrypt)
+"yiY" = (
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "yjd" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/hexstone,
@@ -78094,6 +78251,13 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/spider,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"ylr" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "ylz" = (
 /obj/effect/decal/mossy{
 	dir = 1
@@ -78109,12 +78273,16 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"ymb" = (
+/obj/structure/vine,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "ymd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/river)
 
 (1,1,1) = {"
 tYq
@@ -139349,12 +139517,12 @@ brW
 iSu
 kjb
 thH
-sdj
+doN
 mri
-wfc
+ylr
 iSu
-oGr
-moO
+lcb
+bZR
 brW
 rqY
 rqY
@@ -139796,17 +139964,17 @@ qcr
 thH
 brW
 brW
-gry
-fMu
+iWu
+bnB
 iSu
 eXt
 haH
-cSM
+ppp
 haH
 wTp
 iSu
 evs
-euz
+hSV
 brW
 brW
 egF
@@ -140248,16 +140416,16 @@ qcr
 olQ
 brW
 brW
-rJH
+wFy
 pkw
-hEi
+tJh
 haH
 haH
 haH
-cSM
+ppp
 haH
 haH
-wnN
+mGH
 qDj
 brW
 brW
@@ -140700,16 +140868,16 @@ qcr
 mri
 brW
 brW
-qYZ
-cSM
-bAZ
-cSM
+amZ
+ppp
+bzF
+ppp
 haH
 haH
 haH
-bAZ
+bzF
 haH
-cSM
+ppp
 qDj
 brW
 brW
@@ -141152,17 +141320,17 @@ rqY
 qcr
 brW
 brW
-cKI
+shM
 haH
 haH
-hHG
+tFD
 haH
-cGO
-cSM
-grz
-cSM
+dnc
+ppp
+pjL
+ppp
 haH
-hqA
+ouh
 brW
 brW
 egF
@@ -141608,9 +141776,9 @@ wFh
 haH
 haH
 haH
-dZH
+pwh
 dWg
-xHC
+wwE
 haH
 haH
 haH
@@ -142058,10 +142226,10 @@ brW
 brW
 mri
 haH
-cSM
+ppp
 haH
 haH
-pkK
+bkc
 haH
 haH
 haH
@@ -142508,15 +142676,15 @@ qcr
 thH
 brW
 brW
-ptR
-hHG
-hEi
-cSM
+dqy
+tFD
+tJh
+ppp
 haH
 haH
-bAZ
-hHG
-cSM
+bzF
+tFD
+ppp
 haH
 qDj
 brW
@@ -142960,16 +143128,16 @@ qcr
 olQ
 brW
 brW
-rJH
+wFy
 evs
 haH
-bAZ
+bzF
 haH
-cSM
+ppp
 haH
-cSM
+ppp
 haH
-cnp
+hrV
 qDj
 brW
 srz
@@ -143412,17 +143580,17 @@ qcr
 gZo
 brW
 brW
-bIK
-rOc
+xep
+pqc
 iSu
 hyA
-cSM
+ppp
 haH
 haH
 wTp
 iSu
 pkw
-euz
+hSV
 brW
 egF
 wLu
@@ -143871,10 +144039,10 @@ nrq
 mri
 wFh
 gZo
-qHr
+eGR
 iSu
-frL
-dgI
+lVI
+pXx
 brW
 egF
 haH
@@ -207280,29 +207448,29 @@ rXo
 xRL
 dXq
 dXq
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-niV
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+oei
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
 xkH
 xkH
 xkH
@@ -207698,15 +207866,15 @@ rpv
 bhJ
 bhJ
 toJ
-ixl
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
+snu
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
 xkH
 wph
 wRg
@@ -207722,41 +207890,41 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-elL
-eXH
-eXH
-xkH
-xkH
-xkH
-xkH
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+xdh
+uZy
+uZy
+dsA
+dsA
+dsA
+dsA
 xkH
 xkH
 xkH
@@ -207798,14 +207966,14 @@ jFA
 xkH
 xkH
 niV
-xoi
-hlK
-hlK
+iVD
+aWl
+aWl
 cAO
 cAO
-hlK
-dpQ
-dpQ
+aWl
+aAv
+aAv
 xkH
 jFA
 jFA
@@ -208150,15 +208318,22 @@ rpv
 bhJ
 bhJ
 bhJ
-eXH
-eXH
-eXH
-eXH
-elL
-eXH
-eXH
-eXH
-eXH
+uZy
+uZy
+uZy
+uZy
+xdh
+uZy
+uZy
+uZy
+uZy
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
 xkH
 xkH
 xkH
@@ -208166,27 +208341,20 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-eXH
-eXH
-eXH
-eXH
+dsA
+dsA
+uZy
+uZy
+uZy
+uZy
 sux
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
@@ -208204,13 +208372,13 @@ fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-eXH
+uZy
+uZy
+uZy
 sux
-xkH
-xkH
-xkH
+dsA
+dsA
+dsA
 xkH
 xkH
 jFA
@@ -208250,14 +208418,14 @@ jFA
 xkH
 niV
 niV
-prF
+ggv
 cAO
 cAO
 cAO
 cAO
 cAO
-hlK
-hlK
+aWl
+aWl
 xkH
 jFA
 jFA
@@ -208602,31 +208770,31 @@ rpv
 bhJ
 bhJ
 bhJ
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
 gwq
-eXH
+uZy
 fjG
 fjG
 fjG
@@ -208659,12 +208827,12 @@ fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-eXH
-xkH
-xkH
-xkH
+uZy
+uZy
+uZy
+dsA
+dsA
+dsA
 xkH
 xkH
 xkH
@@ -208710,7 +208878,7 @@ uLV
 uLV
 cAO
 cAO
-hlK
+aWl
 jFA
 jFA
 jFA
@@ -208722,8 +208890,8 @@ jFA
 sZa
 jFA
 jFA
-rIw
-dpQ
+uMV
+aAv
 xkH
 eTA
 jFA
@@ -209066,17 +209234,17 @@ fjG
 nqS
 fjG
 fjG
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
@@ -209090,36 +209258,36 @@ fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
 fjG
-eXH
-elL
-eXH
-xkH
-xkH
-xkH
-xkH
+uZy
+xdh
+uZy
+dsA
+dsA
+dsA
+dsA
 xkH
 jFA
 jFA
@@ -209153,7 +209321,7 @@ xkH
 niV
 xkH
 niV
-dIr
+dfN
 cAO
 cAO
 uLV
@@ -209162,19 +209330,19 @@ uLV
 uLV
 cAO
 cAO
-hlK
-hlK
+aWl
+aWl
 xkH
-eGq
-xkH
-jFA
-jFA
-jFA
+bjV
 xkH
 jFA
 jFA
-hlK
-hlK
+jFA
+xkH
+jFA
+jFA
+aWl
+aWl
 cAO
 cAO
 xkH
@@ -209530,48 +209698,48 @@ fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
 gwq
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-eXH
-eXH
-eXH
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
-eXH
-eXH
-eXH
-eXH
-xkH
+uZy
+uZy
+uZy
+uZy
+dsA
 xkH
 jFA
 jFA
@@ -209605,8 +209773,8 @@ jFA
 xkH
 xkH
 niV
-bDu
-hlK
+nwh
+aWl
 cAO
 uLV
 uLV
@@ -209618,18 +209786,18 @@ cAO
 cAO
 cAO
 cAO
-xdh
+fAa
 xkH
 xkH
 xkH
 xkH
-hlK
-hlK
+aWl
+aWl
 cAO
 cAO
 cAO
 cAO
-dpQ
+aAv
 niV
 xkH
 jFA
@@ -209980,22 +210148,22 @@ fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-eXH
-qUf
-xkH
-xkH
-xkH
-qUf
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
+uZy
+uZy
+uZy
+xoi
+dsA
+dsA
+dsA
+xoi
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -210012,21 +210180,21 @@ jFA
 sZa
 sZa
 xkH
-xkH
-xkH
+dsA
+dsA
 jxj
-eXH
-eXH
-eXH
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-xkH
-jFA
-jFA
+uZy
+uZy
+dsA
+xAh
+xAh
 jFA
 jFA
 jFA
@@ -210057,8 +210225,8 @@ jFA
 jFA
 jFA
 niV
-bDu
-hlK
+nwh
+aWl
 cAO
 uLV
 uLV
@@ -210066,15 +210234,15 @@ uLV
 uLV
 uLV
 uLV
-aWh
+buO
 uLV
 uLV
 cAO
 cAO
-xdh
-eGq
+fAa
+bjV
 xkH
-hlK
+aWl
 cAO
 cAO
 cAO
@@ -210410,32 +210578,32 @@ toJ
 toJ
 bhJ
 bhJ
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-elL
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-xkH
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+xdh
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+dsA
 jFA
 jFA
 jFA
@@ -210465,20 +210633,20 @@ sZa
 sZa
 eTA
 xkH
-xkH
-xkH
-xkH
-xkH
-eXH
-eXH
-eXH
-eXH
+dsA
+dsA
+dsA
+dsA
+uZy
+uZy
+uZy
+uZy
 fjG
 fjG
-eXH
-eXH
-eXH
-xkH
+uZy
+uZy
+uZy
+dsA
 xkH
 xkH
 xkH
@@ -210509,16 +210677,16 @@ jFA
 sZa
 jFA
 niV
-bDu
-hlK
+nwh
+aWl
 cAO
 hBS
 uLV
 uLV
 uLV
 uLV
-ixl
-ixl
+fnC
+fnC
 uLV
 uLV
 uLV
@@ -210526,7 +210694,7 @@ cAO
 cAO
 cAO
 cAO
-hlK
+aWl
 cAO
 cAO
 cAO
@@ -210862,32 +211030,32 @@ toJ
 toJ
 toJ
 bhJ
-xkH
-xkH
-eXH
-eXH
-elL
-eXH
-eXH
-eXH
-eXH
-eXH
-elL
-xkH
-xkH
-xkH
-xkH
-xkH
-niV
-niV
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
+dsA
+dsA
+uZy
+uZy
+xdh
+uZy
+uZy
+uZy
+uZy
+uZy
+xdh
+dsA
+dsA
+dsA
+dsA
+dsA
+oei
+oei
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -210920,21 +211088,21 @@ jFA
 jFA
 jFA
 jFA
-jFA
-jFA
-jFA
-xkH
-eXH
-eXH
-eXH
+xAh
+xAh
+xAh
+dsA
+uZy
+uZy
+uZy
 fjG
 fjG
-eXH
-eXH
+uZy
+uZy
 gwq
-xkH
-xkH
-xkH
+dsA
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -210967,12 +211135,12 @@ cAO
 hBS
 hBS
 hBS
-ixl
-ixl
-ixl
-ixl
-ixl
-ixl
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
 uLV
 uLV
 uLV
@@ -211314,22 +211482,22 @@ bhJ
 bhJ
 toJ
 toJ
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-wRg
-xkH
-xkH
-xkH
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+bAZ
+dsA
+dsA
+dsA
 niV
 xkH
 jFA
@@ -211375,21 +211543,21 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-xkH
-xkH
-eXH
+dsA
+dsA
+dsA
+dsA
+uZy
 fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-eXH
-xkH
-xkH
-xkH
+uZy
+uZy
+uZy
+dsA
+dsA
+dsA
 xkH
 xkH
 eTA
@@ -211414,18 +211582,18 @@ jFA
 jFA
 niV
 niV
-hlK
+aWl
 cAO
 hBS
 hBS
-ixl
-ixl
-ixl
-ixl
-ixl
-ixl
-ixl
-ixl
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
 uLV
 uLV
 cAO
@@ -211830,25 +211998,25 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-eXH
+dsA
+dsA
+uZy
+uZy
 fjG
 fjG
 fjG
 nqS
-eXH
-eXH
-eXH
-xkH
-xkH
-xkH
-eTA
-xkH
-xkH
-qCl
-fHv
+uZy
+uZy
+uZy
+dsA
+dsA
+dsA
+oCL
+dsA
+dsA
+vsZ
+gBo
 xkH
 jFA
 jFA
@@ -211865,32 +212033,32 @@ jFA
 xkH
 xkH
 niV
-hlK
+aWl
 cAO
 cAO
 hBS
-xyi
-ixl
-ixl
-ixl
+que
+fnC
+fnC
+fnC
 hBS
-ixl
-ixl
-ixl
-ixl
-aWh
+fnC
+fnC
+fnC
+fnC
+buO
 uLV
 cAO
 sMc
-lpW
-lpW
+waT
+waT
 qvT
 cAO
 cAO
 cAO
 cAO
 cAO
-dIr
+dfN
 xkH
 jFA
 jFA
@@ -212284,24 +212452,24 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
+dsA
+dsA
+uZy
 fjG
 fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-eXH
-eXH
-xkH
-xkH
+uZy
+uZy
+uZy
+uZy
+dsA
+dsA
 wsL
 dQc
 qKZ
-xkH
+dsA
 jFA
 jFA
 jFA
@@ -212316,20 +212484,20 @@ sZa
 jFA
 xkH
 xkH
-xoi
+iVD
 cAO
 cAO
 cAO
 hBS
-eXH
-ixl
-ixl
+mlk
+fnC
+fnC
 hBS
 hBS
-ixl
-ixl
-ixl
-ixl
+fnC
+fnC
+fnC
+fnC
 hBS
 uLV
 cAO
@@ -212341,7 +212509,7 @@ cAO
 cAO
 cAO
 cAO
-bDu
+nwh
 niV
 xkH
 jFA
@@ -212737,10 +212905,10 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-eXH
+dsA
+dsA
+uZy
+uZy
 fjG
 fjG
 fjG
@@ -212748,12 +212916,12 @@ fjG
 fjG
 fjG
 fjG
-eXH
-eXH
+uZy
+uZy
 sux
-tUT
+itZ
 qKZ
-xkH
+dsA
 xkH
 xkH
 wRg
@@ -212768,20 +212936,20 @@ jFA
 jFA
 xkH
 xkH
-xoi
+iVD
 cAO
 cAO
 cAO
 hBS
-aWh
-ixl
-xyi
+buO
+fnC
+que
 hBS
 hBS
-ixl
-ixl
-ixl
-ixl
+fnC
+fnC
+fnC
+fnC
 hBS
 hBS
 cAO
@@ -212792,7 +212960,7 @@ sMc
 cAO
 cAO
 sni
-bDu
+nwh
 xPA
 niV
 jFA
@@ -213191,11 +213359,11 @@ jFA
 eTA
 eTA
 cmd
-xkH
-xkH
-eXH
-eXH
-eXH
+dsA
+dsA
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
@@ -213203,15 +213371,15 @@ fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-elL
-xkH
-xkH
-wRg
-wRg
-xkH
-jFA
+uZy
+uZy
+xdh
+dsA
+dsA
+bAZ
+bAZ
+dsA
+xAh
 jFA
 xkH
 jFA
@@ -213221,29 +213389,29 @@ jFA
 xkH
 niV
 niV
-hlK
+aWl
 cAO
 cAO
 moj
-eXH
-ixl
-eXH
+mlk
+fnC
+mlk
 moj
 hBS
 hBS
 hBS
-ixl
-ixl
+fnC
+fnC
 hBS
 cAO
 cAO
 qvT
-gbd
-xYg
+rDU
+ikY
 qvT
 cAO
 cAO
-bDu
+nwh
 niV
 niV
 xkH
@@ -213646,55 +213814,55 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-eXH
-eXH
-eXH
+dsA
+dsA
+uZy
+uZy
+uZy
+uZy
 fjG
 nqS
 fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-eXH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
+uZy
+uZy
+uZy
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
 xkH
 jFA
 jFA
 jFA
 niV
 niV
-hlK
-pHp
+aWl
+vtD
 moj
 moj
-xyi
-eXH
-eXH
+que
+mlk
+mlk
 moj
 moj
 moj
-aWh
-ixl
+buO
+fnC
 hBS
 hBS
 cAO
-qKN
-fdJ
+pvE
+feq
 pdH
 nSB
 qvT
-nAs
-bcv
+brh
+ymb
 xPA
 niV
 xkH
@@ -214100,33 +214268,33 @@ eTA
 eTA
 eTA
 xkH
-xkH
-xkH
-xkH
-xkH
-eXH
-eXH
-eXH
+dsA
+dsA
+dsA
+dsA
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-eXH
-eXH
-eXH
-xkH
-xkH
+uZy
+uZy
+uZy
+uZy
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
 niV
 xkH
 xkH
-pHp
+vtD
 moj
 moj
 moj
@@ -214135,8 +214303,8 @@ moj
 moj
 moj
 moj
-ixl
-ixl
+fnC
+fnC
 moj
 moj
 cAO
@@ -214144,7 +214312,7 @@ sMc
 fSn
 nSB
 nSB
-sLU
+wYz
 eXH
 eXH
 niV
@@ -214556,12 +214724,12 @@ sZa
 jFA
 jFA
 jFA
-xkH
-xkH
+dsA
+dsA
 lit
-eXH
-eXH
-eXH
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
@@ -214570,15 +214738,15 @@ fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-xkH
-xkH
-xkH
+uZy
+uZy
+dsA
+dsA
+dsA
 xkH
 xkH
 xbS
-pHp
+vtD
 moj
 moj
 moj
@@ -214587,8 +214755,8 @@ moj
 moj
 moj
 moj
-ixl
-ixl
+fnC
+fnC
 moj
 moj
 cAO
@@ -214597,7 +214765,7 @@ fSn
 nSB
 nSB
 sAu
-bcv
+ymb
 eXH
 niV
 niV
@@ -215009,14 +215177,14 @@ jFA
 jFA
 jFA
 xkH
-xkH
+dsA
 xFU
 tcq
 qgv
-xkH
-eXH
-eXH
-eXH
+dsA
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
@@ -215024,13 +215192,13 @@ fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-xkH
-xkH
-xkH
-hlK
-hlK
+uZy
+uZy
+dsA
+dsA
+dsA
+aWl
+aWl
 moj
 moj
 moj
@@ -215039,18 +215207,18 @@ moj
 moj
 moj
 moj
-xyi
-mxP
+que
+eMB
 moj
 moj
 cAO
-qKN
-fdJ
+pvE
+feq
 nSB
 sAu
 sAu
-nAs
-bcv
+brh
+ymb
 niV
 xkH
 xkH
@@ -215465,12 +215633,12 @@ xkH
 bBz
 bBz
 ymd
-xkH
-xkH
-xkH
-xkH
-eXH
-eXH
+dsA
+dsA
+dsA
+dsA
+uZy
+uZy
 fjG
 fjG
 fjG
@@ -215478,32 +215646,32 @@ fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-eXH
-eXH
-hlK
-nAQ
+uZy
+uZy
+uZy
+uZy
+jIP
+pTc
 ixl
 moj
 moj
-oAC
-xyi
-yhT
-nAQ
-ixl
-ixl
-ixl
-ixl
-xyi
-xyi
-ixl
-ixl
-eXH
+osr
+oRq
+klH
+imP
+toJ
+toJ
+toJ
+toJ
+uHQ
+uHQ
+toJ
+toJ
+ixP
 cAO
 cAO
-oDa
-dIr
+vIC
+dfN
 xkH
 jFA
 sZa
@@ -215921,12 +216089,12 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-eXH
-eXH
-eXH
+dsA
+dsA
+uZy
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
@@ -215934,27 +216102,27 @@ fjG
 fjG
 fjG
 fjG
-eXH
-eXH
-eXH
-ixl
-ixl
-ixl
-eXH
-eXH
-eXH
+uZy
+uZy
+uZy
+snu
+snu
+snu
+uZy
+uZy
+uZy
 gwq
-eXH
-eXH
-eXH
-vDI
-eXH
-eXH
-bcv
-eXH
-nAs
+uZy
+uZy
+ixP
+wrK
+ixP
+ixP
+xnW
+ixP
+brh
 sni
-cML
+rTB
 niV
 xkH
 jFA
@@ -216376,11 +216544,11 @@ eTA
 xkH
 xkH
 niV
-jFA
-jFA
-jFA
-eXH
-eXH
+xAh
+xAh
+xAh
+uZy
+uZy
 fjG
 fjG
 fjG
@@ -216389,25 +216557,25 @@ fjG
 fjG
 fjG
 nqS
-eXH
-eXH
-eXH
-eHC
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-ixl
-eXH
-eXH
-eXH
-bcv
-niV
-niV
-dIr
+uZy
+uZy
+uZy
+fuA
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+toJ
+ixP
+ixP
+ixP
+xnW
+htN
+htN
+dfN
 xkH
 xkH
 sZa
@@ -216829,38 +216997,38 @@ xkH
 xkH
 xkH
 niV
-jFA
-jFA
-jFA
-jFA
-eXH
-eXH
-eXH
-eXH
-eXH
+xAh
+xAh
+xAh
+xAh
+uZy
+oCV
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
 fjG
-eXH
-oxl
-eXH
-eXH
-eHC
-eXH
-pHp
-pHp
-eXH
-eXH
-pHp
-pHp
-ixl
-ixl
-xyi
-hrm
+uZy
+qLV
+uZy
+uZy
+fuA
+uZy
+eEM
+eEM
+uZy
+uZy
+qzO
+qzO
+toJ
+toJ
+uHQ
+fJf
 eTA
-dDi
-xdh
+daR
+fAa
 xkH
 jFA
 jFA
@@ -217285,32 +217453,32 @@ jFA
 niV
 jFA
 jFA
-jFA
-jFA
-jFA
-jFA
-xkH
-eXH
-eXH
+uZy
+oCV
+uZy
+xAh
+dsA
+uZy
+uZy
 fjG
 fjG
-elL
-eXH
-eXH
-eXH
-eHC
-lKJ
+xdh
+uZy
+uZy
+uZy
+fuA
+hgj
 qDW
-eXH
-eXH
-eXH
+uZy
+uZy
+uZy
 gwq
-xyi
-xyi
-ixl
-ixl
-cAO
-cAO
+vnn
+vnn
+snu
+snu
+lpW
+lpW
 lue
 xkH
 xkH
@@ -217737,49 +217905,49 @@ jFA
 niV
 jFA
 jFA
-jFA
-jFA
-xkH
-xpP
-xkH
+uZy
+oCV
+oCV
+mtt
+dsA
 ixl
 ixl
 eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-lKJ
-eQi
-lKJ
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
+uZy
+uZy
+uZy
+uZy
+uZy
+hgj
+rmd
+hgj
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
 xkH
 xkH
 xkH
 eTA
 xkH
-niV
-ixl
+oei
+snu
 bhJ
 ogs
 ogs
@@ -218189,50 +218357,50 @@ xkH
 niV
 jFA
 sZa
-jFA
-jFA
-jFA
-eXH
-eXH
-oRN
+xAh
+uZy
+oCV
+uZy
+uZy
+gUd
 moj
 ixl
-nAQ
-ixl
-eXH
-eXH
-eXH
-eXH
-lKJ
-eHC
-eXH
-eXH
-eXH
-eXH
+wxy
+snu
+uZy
+uZy
+uZy
+uZy
+hgj
+fuA
+uZy
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
 fjG
 fjG
 nqS
-bmi
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
+iXm
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
 gwq
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-ixl
-oNG
-oNG
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+snu
+olG
+olG
 ogs
 ogs
 ogs
@@ -218640,33 +218808,33 @@ xkH
 xkH
 xkH
 xkH
-sZa
 jFA
-jFA
-jFA
-ngr
-ngr
-kZX
+lWf
+xAh
+uZy
+ydz
+ydz
+ncW
 moj
 moj
-moj
-oAC
-oxl
-eXH
-eXH
-elL
-eXH
-oxl
+gDq
+sPd
+qLV
+uZy
+uZy
+xdh
+uZy
+qLV
 gwq
-elL
-eXH
-onU
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
+xdh
+uZy
+nqA
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
@@ -218676,16 +218844,16 @@ fjG
 fjG
 fjG
 fjG
-bmi
-eXH
-eXH
-elL
-xkH
-xkH
-xkH
-ixl
-ixl
-ixl
+iXm
+uZy
+uZy
+xdh
+dsA
+dsA
+dsA
+snu
+snu
+snu
 ogs
 ogs
 "}
@@ -219093,41 +219261,41 @@ xkH
 niV
 xkH
 jFA
-sZa
 jFA
 jFA
-eXH
-eXH
-oRN
+jFA
+uZy
+uZy
+gUd
 moj
 moj
 moj
-xyi
-klH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-oAC
-ixl
-ixl
-ixl
-ixl
-ixl
-xkH
-eTA
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
+vnn
+koa
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+sPd
+snu
+snu
+snu
+snu
+snu
+dsA
+oCL
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
 nqS
 fjG
 fjG
@@ -219136,8 +219304,8 @@ fjG
 fjG
 fjG
 fjG
-eMx
-eMx
+oRN
+oRN
 ogs
 ogs
 "}
@@ -219556,40 +219724,40 @@ hBS
 moj
 moj
 moj
-xyi
-nMk
-ixl
-eXH
-eXH
-eXH
-ixl
-ixl
-xyi
+oRq
+bmR
+snu
+uZy
+uZy
+uZy
+snu
+toJ
+uHQ
 cAO
-xyi
+uHQ
 cAO
 cAO
-oDa
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-eXH
-eXH
-eXH
-eXH
+vIC
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+uZy
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
 fjG
-eMx
-eMx
+oRN
+oRN
 ogs
 ogs
 "}
@@ -220000,7 +220168,7 @@ xkH
 xkH
 jFA
 niV
-hlK
+aWl
 cAO
 cAO
 hBS
@@ -220010,38 +220178,38 @@ moj
 moj
 moj
 moj
-vDI
-eXH
-eXH
-eXH
-ixl
-xyi
+cwj
+uZy
+uZy
+uZy
+snu
+uHQ
 cAO
 cAO
 cAO
 cAO
-oDa
+vIC
 niV
 xkH
 jFA
-xkH
-xkH
-xkH
-sZa
-jFA
-jFA
-xkH
-xkH
-jFA
-jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-ixl
-ixl
-ixl
+dsA
+dsA
+dsA
+lWf
+xAh
+xAh
+dsA
+dsA
+xAh
+xAh
+xAh
+xAh
+xAh
+dsA
+dsA
+snu
+snu
+snu
 ogs
 ogs
 "}
@@ -220462,12 +220630,12 @@ hBS
 moj
 moj
 moj
-ixl
-eXH
-eXH
-eXH
+snu
+uZy
+uZy
+uZy
 mxP
-cAO
+ogs
 cAO
 cAO
 cAO
@@ -220490,9 +220658,9 @@ jFA
 jFA
 jFA
 xkH
-xkH
-oNG
-oNG
+dsA
+olG
+olG
 ogs
 ogs
 ogs
@@ -220912,19 +221080,19 @@ hBS
 hBS
 hBS
 hBS
-vfW
-ixl
+mKO
+fnC
 mxP
-eXH
-eXH
-eXH
-ixl
-ixl
+uZy
+uZy
+uZy
+snu
+toJ
 cAO
 cAO
 cAO
 cAO
-hlK
+aWl
 niV
 xkH
 xkH
@@ -221366,18 +221534,18 @@ hBS
 hBS
 hBS
 moj
-xyi
-eXH
-bmi
-bmi
-eXH
-ixl
+vnn
+uZy
+iXm
+iXm
+uZy
+snu
 cAO
 cAO
 cAO
 cAO
-hlK
-xoi
+aWl
+iVD
 niV
 eTA
 jFA
@@ -221818,19 +221986,19 @@ hBS
 hBS
 moj
 moj
-xyi
-ixl
-eXH
-bmi
-bmi
-eXH
-ixl
-xAI
+vnn
+snu
+uZy
+iXm
+iXm
+uZy
+snu
+wDS
 cAO
 cAO
 cAO
 cAO
-xoi
+iVD
 niV
 xkH
 jFA
@@ -222271,13 +222439,13 @@ hBS
 cAO
 cAO
 cAO
-ixl
-eXH
-bmi
-bmi
-eXH
-cAO
-ixl
+toJ
+uZy
+iXm
+iXm
+uZy
+lpW
+snu
 cAO
 cAO
 cAO
@@ -222723,20 +222891,20 @@ moj
 cAO
 cAO
 cAO
-ixl
-cAO
-eXH
-bmi
-bmi
-eXH
-ixl
-cAO
-cAO
+toJ
+lpW
+uZy
+iXm
+iXm
+uZy
+snu
 cAO
 cAO
 cAO
 cAO
-hlK
+cAO
+cAO
+aWl
 xkH
 xkH
 jFA
@@ -223175,14 +223343,14 @@ moj
 cAO
 cAO
 cAO
-lZD
-ixl
-ixl
-eXH
-bmi
-bmi
-eXH
-ixl
+xYC
+snu
+snu
+uZy
+iXm
+iXm
+uZy
+snu
 cAO
 cAO
 cAO
@@ -223616,25 +223784,25 @@ xkH
 jFA
 niV
 niV
-pHp
+vtD
 cAO
 moj
-pHp
+vtD
 eTA
-dwp
+sFs
 sZa
-tfT
-hlK
-hlK
+wob
+aWl
+aWl
 cAO
 cAO
 cAO
-ixl
-eXH
-bmi
-bmi
-eXH
-ixl
+snu
+uZy
+iXm
+iXm
+uZy
+snu
 cAO
 cAO
 cAO
@@ -224069,29 +224237,29 @@ xkH
 niV
 niV
 vWm
-pHp
+vtD
 moj
 lue
 jFA
 jFA
-rIw
-dpQ
+uMV
+aAv
 mHL
-hlK
+aWl
 cAO
 cAO
 cAO
-ixl
-eXH
-bmi
-bmi
-eXH
-ixl
+snu
+uZy
+iXm
+iXm
+uZy
+snu
 cAO
 cAO
 cAO
 cAO
-hlK
+aWl
 xkH
 jFA
 jFA
@@ -224521,29 +224689,29 @@ niV
 niV
 niV
 niV
-bDu
+nwh
 xPA
 niV
 niV
 niV
 niV
-bDu
+nwh
 jVX
 cAO
 cAO
 cAO
 cAO
-ixl
-eXH
-bmi
-bmi
-eXH
-ixl
+snu
+uZy
+iXm
+iXm
+uZy
+snu
 cAO
 cAO
 cAO
 cAO
-hlK
+aWl
 eTA
 jFA
 xkH
@@ -224985,12 +225153,12 @@ cAO
 cAO
 cAO
 cAO
-ixl
-eXH
-bmi
-bmi
-eXH
-ixl
+snu
+uZy
+iXm
+iXm
+uZy
+snu
 cAO
 cAO
 cAO
@@ -225428,21 +225596,21 @@ niV
 niV
 niV
 niV
-dIr
+dfN
 xkH
 xkH
-dpQ
-xdh
+aAv
+fAa
 cAO
 cAO
 cAO
 cAO
-ixl
-eXH
-bmi
-bmi
-eXH
-ixl
+snu
+uZy
+iXm
+iXm
+uZy
+snu
 cAO
 cAO
 cAO
@@ -225880,24 +226048,24 @@ niV
 niV
 niV
 niV
-xoi
-xoi
+iVD
+iVD
 sZa
-dSw
+hLJ
 eTA
 cAO
 cAO
 cAO
 cAO
-ixl
-eXH
-bmi
-bmi
-eXH
-ixl
+snu
+uZy
+iXm
+iXm
+uZy
+snu
+lpW
 cAO
-cAO
-xoi
+iVD
 niV
 eTA
 jFA
@@ -226334,21 +226502,21 @@ xkH
 xkH
 niV
 eTA
-ojF
-dwp
+urX
+sFs
 cAO
 cAO
 cAO
 cAO
 cAO
-ixl
-eXH
-bmi
-lal
-eXH
-ixl
-cAO
-hlK
+snu
+uZy
+iXm
+hyg
+uZy
+snu
+lpW
+jIP
 niV
 xkH
 xkH
@@ -226781,7 +226949,7 @@ xkH
 xkH
 xkH
 xkH
-dpQ
+aAv
 xkH
 xkH
 xkH
@@ -226793,14 +226961,14 @@ cAO
 cAO
 cAO
 cAO
-ixl
-eXH
-bmi
-bmi
-bmi
-eXH
-hlK
-sni
+snu
+uZy
+iXm
+iXm
+iXm
+uZy
+jIP
+imi
 wZR
 xkH
 jFA
@@ -227234,7 +227402,7 @@ xkH
 xkH
 xkH
 eTA
-dpQ
+aAv
 xkH
 xkH
 xkH
@@ -227244,15 +227412,15 @@ cAO
 cAO
 cAO
 cAO
-xAI
-ixl
-cAO
-eXH
-bmi
-bmi
-eXH
-hlK
-niV
+wDS
+snu
+lpW
+uZy
+iXm
+iXm
+uZy
+jIP
+oei
 xkH
 xkH
 jFA
@@ -227696,15 +227864,15 @@ cAO
 cAO
 cAO
 cAO
-ixl
-ixl
-cAO
-eXH
-bmi
-bmi
-eXH
-dpQ
-xkH
+snu
+snu
+lpW
+uZy
+iXm
+iXm
+uZy
+mEz
+dsA
 xkH
 jFA
 xkH
@@ -228147,16 +228315,16 @@ jFA
 jFA
 cAO
 cAO
-dpQ
-xkH
-cAO
-cAO
-eXH
-lal
-bmi
-eXH
-xkH
-xbS
+aAv
+dsA
+lpW
+lpW
+uZy
+hyg
+iXm
+uZy
+dsA
+vqR
 xkH
 xkH
 eTA
@@ -228597,18 +228765,18 @@ xkH
 xkH
 niV
 niV
-hlK
-hlK
+aWl
+aWl
 jFA
 smb
-hlK
-eTA
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+jIP
+oCL
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 xkH
 xkH
 niV
@@ -229053,14 +229221,14 @@ xkH
 xkH
 xkH
 xkH
-dpQ
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+mEz
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 xkH
 xkH
 xkH
@@ -229505,14 +229673,14 @@ xkH
 xkH
 xkH
 xkH
-xbS
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+vqR
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 eTA
 xkH
 jFA
@@ -229957,14 +230125,14 @@ xkH
 xkH
 eTA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 xkH
 xkH
 jFA
@@ -230409,14 +230577,14 @@ xkH
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -230861,14 +231029,14 @@ xkH
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -231313,14 +231481,14 @@ uDZ
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -231765,14 +231933,14 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -232217,14 +232385,14 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-lal
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+hyg
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -232669,14 +232837,14 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 eTA
@@ -233121,14 +233289,14 @@ jFA
 sZa
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 xkH
 xkH
@@ -233573,14 +233741,14 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 xkH
 xkH
@@ -234025,14 +234193,14 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 xkH
 xkH
@@ -234477,14 +234645,14 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -234929,14 +235097,14 @@ sZa
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -235381,14 +235549,14 @@ jFA
 jFA
 sZa
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 eTA
@@ -235833,14 +236001,14 @@ xkH
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -236285,14 +236453,14 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-lal
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+hyg
+uZy
+dsA
+dsA
 jFA
 jFA
 uDZ
@@ -236737,14 +236905,14 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -237189,14 +237357,14 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -237641,14 +237809,14 @@ jFA
 jFA
 jFA
 jFA
-eTA
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+oCL
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -238093,14 +238261,14 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -238545,14 +238713,14 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 sZa
@@ -238997,14 +239165,14 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -239449,14 +239617,14 @@ jFA
 jFA
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -239901,14 +240069,14 @@ jFA
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -240353,14 +240521,14 @@ jFA
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
+dsA
+dsA
+uZy
 rYk
-bmi
-eXH
-xkH
-xkH
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -240805,15 +240973,15 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
-jFA
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
+xAh
 jFA
 jFA
 xkH
@@ -241257,15 +241425,15 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -241709,15 +241877,15 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -241973,7 +242141,7 @@ pSg
 pSg
 pSg
 pSg
-mYM
+rSw
 fVo
 crw
 fVo
@@ -242161,15 +242329,15 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -242613,15 +242781,15 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -243065,15 +243233,15 @@ jFA
 xkH
 eTA
 xkH
-xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 eTA
 xkH
@@ -243320,7 +243488,7 @@ pSg
 pSg
 pSg
 pSg
-mYM
+rSw
 pxF
 rZO
 rZO
@@ -243518,14 +243686,14 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -243767,7 +243935,7 @@ pSg
 pSg
 pSg
 pSg
-hon
+dgQ
 faM
 pxF
 pxF
@@ -243970,14 +244138,14 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -244422,14 +244590,14 @@ jFA
 jFA
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -244874,14 +245042,14 @@ jFA
 jFA
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -245326,14 +245494,14 @@ jFA
 jFA
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 sZa
@@ -245778,14 +245946,14 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -246230,14 +246398,14 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -246682,14 +246850,14 @@ jFA
 jFA
 jFA
 eTA
-xkH
-xkH
-eXH
-lal
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+hyg
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -247134,14 +247302,14 @@ jFA
 xkH
 eTA
 eTA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 xkH
 xkH
@@ -247586,14 +247754,14 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 xkH
 xkH
@@ -248038,14 +248206,14 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 xkH
 xkH
@@ -248490,14 +248658,14 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 xkH
 eTA
@@ -248942,14 +249110,14 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -249394,14 +249562,14 @@ xkH
 xkH
 xkH
 eTA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -249846,14 +250014,14 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -250298,14 +250466,14 @@ xkH
 xkH
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 dyg
@@ -250750,14 +250918,14 @@ jFA
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -251202,14 +251370,14 @@ jFA
 jFA
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-lal
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+hyg
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -251654,14 +251822,14 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -251913,7 +252081,7 @@ gkv
 pLh
 phl
 phl
-gYo
+nxE
 ibp
 ibp
 ibp
@@ -252106,14 +252274,14 @@ jFA
 sZa
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -252349,14 +252517,14 @@ pLh
 pLh
 gkv
 gkv
-iAh
+nNZ
 gkv
 gkv
 gkv
 gkv
-gYo
-gYo
-gYo
+nxE
+nxE
+nxE
 gkv
 gkv
 gkv
@@ -252366,7 +252534,7 @@ pLh
 phl
 phl
 phl
-aQJ
+dre
 bQc
 pxF
 aXW
@@ -252558,14 +252726,14 @@ jFA
 jFA
 sZa
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 xkH
 sZa
 xkH
@@ -252820,9 +252988,9 @@ phl
 phl
 phl
 rDI
-hjL
-hjL
-hjL
+wuP
+wuP
+wuP
 uBc
 cDX
 nok
@@ -253010,14 +253178,14 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 sZa
 jFA
 xkH
@@ -253462,14 +253630,14 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 jFA
 eTA
@@ -253914,14 +254082,14 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 jFA
 jFA
@@ -254366,14 +254534,14 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 eTA
 xkH
 jFA
@@ -254818,14 +254986,14 @@ xkH
 jFA
 sZa
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 xkH
 xkH
 jFA
@@ -255270,14 +255438,14 @@ xkH
 jFA
 sZa
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 xkH
 xkH
 xkH
@@ -255722,14 +255890,14 @@ xkH
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 xkH
 jFA
 jFA
@@ -256174,15 +256342,15 @@ xkH
 jFA
 jFA
 jFA
-xkH
-xkH
+dsA
+dsA
 gwq
-bmi
-bmi
-eXH
-xkH
-xkH
-xkH
+iXm
+iXm
+uZy
+dsA
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -256420,7 +256588,7 @@ taS
 sfa
 taS
 sfa
-arS
+pBM
 sfa
 taS
 taS
@@ -256626,15 +256794,15 @@ xkH
 xkH
 xkH
 eTA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
+dsA
 sZa
 jFA
 jFA
@@ -256865,14 +257033,14 @@ dJN
 yjS
 taS
 nmH
-kDA
+hwf
 taS
 fKH
-qGz
+xhs
 oZH
-ocC
+kZU
 fKH
-sdr
+hwV
 oZH
 taS
 dJN
@@ -257078,15 +257246,15 @@ wRg
 xkH
 xkH
 eTA
-xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -257319,13 +257487,13 @@ sPX
 rbu
 nmH
 taS
-oRq
-oRq
-oRq
-ocC
-oRq
-oRq
-oRq
+bAD
+bAD
+bAD
+kZU
+bAD
+bAD
+bAD
 taS
 dJN
 hie
@@ -257532,13 +257700,13 @@ xkH
 eTA
 xkH
 xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -257765,7 +257933,7 @@ oae
 fmy
 oYq
 ybz
-fLM
+osM
 rbu
 taS
 mCR
@@ -257984,13 +258152,13 @@ xkH
 jFA
 jFA
 jFA
-jFA
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+xAh
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 xkH
 eTA
 jFA
@@ -258228,8 +258396,8 @@ rbu
 rbu
 rbu
 rbu
-cGN
-cGN
+fLM
+fLM
 rbu
 dJN
 anR
@@ -258436,13 +258604,13 @@ xkH
 jFA
 jFA
 jFA
-jFA
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+xAh
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 jFA
 jFA
@@ -258669,7 +258837,7 @@ sns
 sns
 oYq
 tYE
-cGN
+fLM
 rbu
 taS
 qXx
@@ -258680,7 +258848,7 @@ icb
 rbu
 rbu
 mrF
-bSd
+lAP
 elw
 yhL
 dJN
@@ -258888,13 +259056,13 @@ xkH
 jFA
 jFA
 jFA
-jFA
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+xAh
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 sZa
 jFA
@@ -259124,17 +259292,17 @@ ozR
 rbu
 rbu
 scj
-nhM
+gZY
 fRW
 bPF
 ezW
 rHR
 rbu
-cGN
+fLM
 lIR
-pmJ
-pmJ
-pmJ
+lVD
+lVD
+lVD
 rKo
 hie
 hie
@@ -259341,12 +259509,12 @@ jFA
 jFA
 jFA
 jFA
-eXH
-lal
-bmi
-eXH
-xkH
-jFA
+uZy
+hyg
+iXm
+uZy
+dsA
+xAh
 jFA
 sZa
 xkH
@@ -259573,19 +259741,19 @@ rUQ
 qfA
 oYq
 ePn
-fLM
+osM
 rbu
 taS
-bYj
+wpQ
 iaa
-aAv
+hmP
 aLh
 aLh
 rbu
-cGN
+fLM
 lIR
 gOz
-wSb
+hMt
 hie
 pVk
 jPH
@@ -259793,12 +259961,12 @@ jFA
 jFA
 jFA
 jFA
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 jFA
 xkH
@@ -260027,14 +260195,14 @@ oYq
 tYE
 tSq
 rbu
-qdI
-sCr
-uSZ
-aAv
-npi
-npi
+gpd
+bLH
+cqv
+hmP
+mRS
+mRS
 rbu
-cGN
+fLM
 lIR
 hie
 hie
@@ -260245,12 +260413,12 @@ xkH
 xkH
 xkH
 xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 jFA
 jFA
@@ -260477,17 +260645,17 @@ ntM
 qfA
 oYq
 eur
-xAh
+cGN
 rbu
-qdI
-xNG
-uSZ
-aAv
-dcl
+gpd
+vJt
+cqv
+hmP
+aAT
 taS
-oWZ
+vUL
 rbu
-eGU
+nFE
 hie
 hie
 bJd
@@ -260697,12 +260865,12 @@ jFA
 sZa
 jFA
 xkH
-eXH
-bmi
-bmi
+uZy
+iXm
+iXm
 gwq
-xkH
-xkH
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -260931,22 +261099,22 @@ oYq
 ybz
 rbu
 rbu
-qdI
-sCr
-uSZ
-aAv
-fWu
-fWu
+gpd
+bLH
+cqv
+hmP
+hWB
+hWB
 rbu
-cGN
+fLM
 lIR
 hie
-oOu
+sRs
 akK
 mrF
 weI
-mEG
-tJh
+nIG
+qnW
 pvx
 hSO
 nlW
@@ -261149,12 +261317,12 @@ sZa
 jFA
 jFA
 xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -261381,19 +261549,19 @@ qfA
 qfA
 oYq
 cns
-cGN
+fLM
 rbu
 taS
-rxS
-mNN
-aAv
+bYj
+tLI
+hmP
 icb
 icb
 rbu
-cGN
+fLM
 lIR
 hie
-oOu
+sRs
 ogL
 mrF
 awF
@@ -261601,12 +261769,12 @@ jFA
 jFA
 jFA
 xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -261836,16 +262004,16 @@ tYE
 tSq
 rbu
 scj
-kjw
+rkH
 jmL
 pia
 ezW
 hBH
 rbu
-cGN
+fLM
 lIR
-xXw
-mvn
+qFv
+oOu
 ayw
 tvR
 yfc
@@ -261936,10 +262104,10 @@ bhJ
 bhJ
 bhJ
 bhJ
-xkH
-nMH
-uDZ
-jFA
+dsA
+lpK
+hFC
+xAh
 xkH
 xkH
 jFA
@@ -262053,12 +262221,12 @@ jFA
 jFA
 jFA
 xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
 jFA
 jFA
 jFA
@@ -262285,7 +262453,7 @@ sns
 sns
 hpr
 cns
-xAh
+cGN
 rbu
 taS
 kYZ
@@ -262388,10 +262556,10 @@ bhJ
 bhJ
 bhJ
 bhJ
-eXH
-eXH
-kVg
-sZa
+uZy
+uZy
+nDo
+lWf
 eTA
 xkH
 jFA
@@ -262505,12 +262673,12 @@ jFA
 sZa
 jFA
 xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
 jFA
 jFA
 sZa
@@ -262748,8 +262916,8 @@ rbu
 rbu
 rbu
 rbu
-cGN
-cGN
+fLM
+fLM
 rbu
 taS
 mWD
@@ -262840,12 +263008,12 @@ bhJ
 bhJ
 bhJ
 bhJ
-dFv
+jSF
 fjG
 fjG
-yim
-xkH
-xkH
+sVU
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -262957,13 +263125,13 @@ jFA
 jFA
 jFA
 xkH
-xkH
-eXH
-lal
-bmi
-eXH
-xkH
-jFA
+dsA
+uZy
+hyg
+iXm
+uZy
+dsA
+xAh
 jFA
 jFA
 jFA
@@ -263292,12 +263460,12 @@ bhJ
 bhJ
 bhJ
 bhJ
-vIK
+iAh
 fjG
 fjG
 fjG
-iiC
-jFA
+lXx
+xAh
 jFA
 jFA
 jFA
@@ -263409,13 +263577,13 @@ jFA
 jFA
 jFA
 xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 jFA
 jFA
@@ -263651,7 +263819,7 @@ nXL
 nXL
 rbu
 gzY
-tBw
+xey
 taS
 gSU
 rbu
@@ -263744,12 +263912,12 @@ bhJ
 bhJ
 bhJ
 bhJ
-eXH
-eXH
-eXH
-bmi
-bmi
-eXH
+uZy
+uZy
+uZy
+iXm
+iXm
+uZy
 jFA
 jFA
 sZa
@@ -263861,13 +264029,13 @@ jFA
 jFA
 jFA
 xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 jFA
 jFA
@@ -264196,12 +264364,12 @@ bhJ
 bhJ
 bhJ
 bhJ
-xkH
-bbQ
-eXH
-bmi
-bmi
-eXH
+dsA
+oRM
+uZy
+iXm
+iXm
+uZy
 uDZ
 jFA
 xkH
@@ -264313,13 +264481,13 @@ sZa
 sZa
 jFA
 xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -264648,12 +264816,12 @@ bhJ
 bhJ
 bhJ
 bhJ
-xrP
+bVk
 xkH
-qcy
-bmi
-bmi
-eXH
+umA
+iXm
+iXm
+uZy
 jFA
 xkH
 xkH
@@ -264765,13 +264933,13 @@ jFA
 jFA
 jFA
 xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -265102,12 +265270,12 @@ bhJ
 bhJ
 bhJ
 xkH
-eXH
-eXH
-bmi
-qcy
+uZy
+uZy
+iXm
+umA
 jFA
-jST
+pUD
 xkH
 niV
 jFA
@@ -265217,13 +265385,13 @@ jFA
 jFA
 jFA
 eTA
-xkH
-eXH
-bmi
-bmi
-elL
-xkH
-xkH
+dsA
+uZy
+iXm
+iXm
+xdh
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -265554,10 +265722,10 @@ bhJ
 bhJ
 bhJ
 xkH
-jFA
-eXH
-bmi
-eXH
+xAh
+uZy
+iXm
+uZy
 jFA
 xkH
 xkH
@@ -265669,13 +265837,13 @@ jFA
 jFA
 jFA
 xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -266006,10 +266174,10 @@ bhJ
 bhJ
 bhJ
 xkH
-mtt
-eXH
-bmi
-eXH
+prW
+uZy
+iXm
+uZy
 sZa
 xkH
 niV
@@ -266121,14 +266289,14 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 jFA
 jFA
@@ -266459,10 +266627,10 @@ bhJ
 bhJ
 xkH
 vnx
-omv
-omv
-omv
-sBu
+tQL
+tQL
+tQL
+liN
 niV
 eTA
 jFA
@@ -266573,14 +266741,14 @@ xkH
 xkH
 eTA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -266910,11 +267078,11 @@ bhJ
 bhJ
 bhJ
 xkH
-dpz
-hMt
-hMt
-hMt
-dyB
+rBI
+oFF
+oFF
+oFF
+rlj
 xkH
 niV
 niV
@@ -267025,14 +267193,14 @@ jFA
 xkH
 eTA
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 jFA
 xkH
@@ -267361,15 +267529,15 @@ bhJ
 bhJ
 bhJ
 bhJ
-tMy
-rcC
-lry
-bmi
-eXH
+qgl
+hry
+vac
+iXm
+uZy
 sZa
 xkH
 jFA
-rLY
+hFD
 jFA
 jFA
 xkH
@@ -267477,14 +267645,14 @@ jFA
 xkH
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 xkH
 eTA
@@ -267814,11 +267982,11 @@ bhJ
 bhJ
 sxx
 gTh
-rQG
-eXH
-bmi
-eXH
-sFs
+wPT
+uZy
+iXm
+uZy
+mlR
 jFA
 jFA
 jFA
@@ -267929,14 +268097,14 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 jFA
 xkH
@@ -268266,10 +268434,10 @@ bhJ
 bhJ
 bhJ
 sxx
-uvu
-eXH
-bmi
-eXH
+sse
+uZy
+iXm
+uZy
 jFA
 jFA
 xkH
@@ -268381,14 +268549,14 @@ jFA
 jFA
 jFA
 jFA
-eTA
-xkH
-eXH
-bmi
-lal
-eXH
-xkH
-jFA
+oCL
+dsA
+uZy
+iXm
+hyg
+uZy
+dsA
+xAh
 jFA
 gTh
 viL
@@ -268618,7 +268786,7 @@ sns
 sns
 vOG
 sns
-rHc
+qUz
 udL
 kzi
 sns
@@ -268718,25 +268886,25 @@ bhJ
 bhJ
 bhJ
 bhJ
-byK
-qcy
-bmi
-eXH
-sZa
-xkH
-xkH
-qcy
-eXH
-xkH
-jFA
-jFA
-xkH
-xkH
-xkH
-jFA
-xkH
-wph
-jFA
+tse
+umA
+iXm
+uZy
+lWf
+dsA
+dsA
+umA
+uZy
+dsA
+xAh
+xAh
+dsA
+dsA
+dsA
+xAh
+dsA
+dyO
+xAh
 wRg
 wRg
 xkH
@@ -268833,14 +269001,14 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 lTP
 niV
@@ -269170,31 +269338,31 @@ bhJ
 bhJ
 bhJ
 bhJ
-xCw
-eXH
-bmi
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-ocQ
-eXH
-eXH
-uDZ
-xkH
-wRg
-wph
-xkH
-sZa
-jFA
-jFA
-jFA
+rFR
+uZy
+iXm
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+tdb
+uZy
+uZy
+hFC
+dsA
+bAZ
+dyO
+dsA
+lWf
+xAh
+xAh
+xAh
 xkH
 jFA
 jFA
@@ -269285,14 +269453,14 @@ jFA
 jFA
 jFA
 jFA
-eTA
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+oCL
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 xkH
 xkH
@@ -269622,10 +269790,10 @@ bhJ
 bhJ
 bhJ
 sxx
-hJW
-eXH
-bmi
-bmi
+nRG
+uZy
+iXm
+iXm
 fjG
 fjG
 fjG
@@ -269637,16 +269805,16 @@ fjG
 fjG
 fjG
 fjG
-bmi
-eXH
-eXH
-eXH
-eXH
-qcy
-xkH
-sZa
-jFA
-xkH
+iXm
+uZy
+uZy
+uZy
+uZy
+umA
+dsA
+lWf
+xAh
+dsA
 jFA
 niV
 niV
@@ -269737,14 +269905,14 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 gTh
 kwg
@@ -269975,7 +270143,7 @@ nJH
 vOG
 sns
 ogT
-doK
+cFV
 ykU
 sns
 aWT
@@ -270074,12 +270242,10 @@ bhJ
 bhJ
 bhJ
 bhJ
-uvu
-eXH
+sse
+uZy
 fjG
-bmi
-fjG
-fjG
+iXm
 fjG
 fjG
 fjG
@@ -270094,11 +270260,13 @@ fjG
 fjG
 fjG
 fjG
-bmi
-eXH
-eXH
-eXH
-xkH
+fjG
+fjG
+iXm
+uZy
+uZy
+uZy
+dsA
 eTA
 xkH
 xkH
@@ -270189,14 +270357,14 @@ sZa
 jFA
 jFA
 uDZ
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-jFA
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+xAh
 jFA
 eTA
 xkH
@@ -270526,9 +270694,9 @@ bhJ
 bhJ
 bhJ
 bhJ
-hJW
-xkH
-eXH
+nRG
+dsA
+uZy
 fjG
 fjG
 fjG
@@ -270536,21 +270704,21 @@ fjG
 fjG
 fjG
 fjG
-oZo
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
+oCV
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
 fjG
 fjG
 fjG
 fjG
 fjG
 fjG
-bmi
-eXH
+iXm
+uZy
 xkH
 niV
 xkH
@@ -270641,14 +270809,14 @@ sZa
 jFA
 jFA
 jFA
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 eTA
 xkH
@@ -270978,31 +271146,31 @@ bhJ
 bhJ
 bhJ
 sxx
-uvu
-jFA
-qcy
-eXH
-wRg
-eXH
-jFA
-sZa
-eXH
-eXH
-qcy
-jFA
-jFA
-jFA
-jFA
-sZa
-jFA
-qcy
-eXH
-eXH
-eXH
-eXH
-eXH
+sse
+xAh
+umA
+uZy
+bAZ
+uZy
+xAh
+lWf
+uZy
+uZy
+umA
+xAh
+xAh
+xAh
+xAh
+lWf
+xAh
+umA
+uZy
+uZy
+uZy
+uZy
+uZy
 fjG
-eXH
+uZy
 xkH
 niV
 xkH
@@ -271093,14 +271261,14 @@ jFA
 jFA
 jFA
 eTA
-xkH
-xkH
-eXH
-bmi
-bmi
+dsA
+dsA
+uZy
+iXm
+iXm
 sux
-xkH
-xkH
+dsA
+dsA
 jFA
 xkH
 jFA
@@ -271430,7 +271598,7 @@ bhJ
 bhJ
 sxx
 gTh
-oAo
+vND
 jFA
 xkH
 xkH
@@ -271439,24 +271607,24 @@ eTA
 xkH
 xkH
 xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-eTA
-xkH
-jFA
-xkH
-eTA
-xkH
-eXH
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+dsA
+oCL
+dsA
+xAh
+dsA
+oCL
+dsA
+uZy
 fjG
-bmi
-qcy
-xkH
+iXm
+umA
+dsA
 jFA
 jFA
 eHk
@@ -271545,14 +271713,14 @@ jFA
 jFA
 sZa
 xkH
-xkH
-xkH
-eXH
-lal
-bmi
-ocQ
-xkH
-xkH
+dsA
+dsA
+uZy
+hyg
+iXm
+tdb
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -271881,9 +272049,9 @@ bhJ
 bhJ
 bhJ
 bhJ
-klO
-xpJ
-fCm
+fcm
+oJD
+qtk
 jFA
 sZa
 xkH
@@ -271904,13 +272072,13 @@ jFA
 xkH
 xkH
 jFA
-xkH
-eXH
+dsA
+uZy
 fjG
-eXH
-eXH
-jFA
-sZa
+uZy
+uZy
+xAh
+lWf
 jFA
 dXq
 dXq
@@ -271997,14 +272165,14 @@ jFA
 jFA
 sZa
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -272356,17 +272524,17 @@ jFA
 xkH
 eTA
 xkH
-jFA
-eXH
+xAh
+uZy
 fjG
 fjG
-bmi
-eXH
-jFA
-niV
-niV
-jFA
-jFA
+iXm
+uZy
+xAh
+oei
+oei
+xAh
+xAh
 dXq
 inM
 dXq
@@ -272449,14 +272617,14 @@ jFA
 jFA
 xkH
 xkH
-xkH
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-xkH
+dsA
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+dsA
 xkH
 jFA
 jFA
@@ -272808,21 +272976,21 @@ jFA
 xkH
 jFA
 sZa
-sZa
-uDZ
-eXH
+lWf
+hFC
+uZy
 fjG
 fjG
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-eXH
-qcy
-eXH
-niV
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+uZy
+umA
+uZy
+oei
 xkH
 xkH
 eTA
@@ -272901,14 +273069,14 @@ jFA
 jFA
 jFA
 jFA
-jFA
-xkH
-eXH
-bmi
-bmi
-eXH
-xkH
-eTA
+xAh
+dsA
+uZy
+iXm
+iXm
+uZy
+dsA
+oCL
 xkH
 xkH
 jFA
@@ -273177,7 +273345,7 @@ phl
 phl
 pWT
 aZo
-kwV
+xRM
 fpx
 fpx
 pWT
@@ -273262,8 +273430,8 @@ jFA
 jFA
 jFA
 sZa
-xkH
-qcy
+dsA
+umA
 fjG
 fjG
 fjG
@@ -273273,9 +273441,9 @@ fjG
 fjG
 fjG
 fjG
-bmi
-eXH
-niV
+iXm
+uZy
+oei
 jFA
 jFA
 jFA
@@ -273353,14 +273521,14 @@ xkH
 xkH
 jFA
 jFA
-jFA
-xkH
-bmi
-bmi
-bmi
-bmi
-xkH
-jin
+xAh
+dsA
+iXm
+iXm
+iXm
+iXm
+dsA
+rRX
 xkH
 xkH
 xkH
@@ -273594,7 +273762,7 @@ eKH
 eBq
 uCs
 mPk
-waj
+dQu
 llx
 llx
 mPk
@@ -273714,10 +273882,10 @@ jFA
 xkH
 niV
 xkH
-xkH
-niV
-eXH
-eXH
+dsA
+oei
+uZy
+uZy
 fjG
 fjG
 fjG
@@ -273726,8 +273894,8 @@ fjG
 fjG
 fjG
 fjG
-bmi
-qcy
+iXm
+umA
 xkH
 fOj
 jFA
@@ -273805,14 +273973,14 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-bmi
-bmi
-bmi
-bmi
-xkH
-eTA
+dsA
+dsA
+iXm
+iXm
+iXm
+iXm
+dsA
+oCL
 xkH
 xkH
 xkH
@@ -274167,21 +274335,21 @@ niV
 jFA
 jFA
 jFA
-xkH
-xkH
-jFA
-eXH
-eXH
-eXH
-qcy
-eXH
-eXH
-eXH
+dsA
+dsA
+xAh
+uZy
+uZy
+uZy
+umA
+uZy
+uZy
+uZy
 fjG
 fjG
-bmi
-eXH
-jFA
+iXm
+uZy
+xAh
 eTA
 niV
 xkH
@@ -274257,14 +274425,14 @@ xkH
 eTA
 xkH
 xkH
-xkH
-xkH
-bmi
+dsA
+dsA
+iXm
 pGd
-bmi
-bmi
-xkH
-xkH
+iXm
+iXm
+dsA
+dsA
 niV
 mHL
 xkH
@@ -274532,7 +274700,7 @@ lKo
 pqo
 lKo
 vXe
-pBi
+xYg
 sns
 sns
 sns
@@ -274626,14 +274794,14 @@ sZa
 jFA
 xkH
 mHL
-xkH
-jFA
-xkH
-eXH
-eXH
-bmi
-eXH
-xkH
+dsA
+xAh
+dsA
+uZy
+uZy
+iXm
+uZy
+dsA
 niV
 jFA
 xkH
@@ -275081,11 +275249,11 @@ sZa
 sZa
 jFA
 uDZ
-xkH
-eXH
-bmi
-bmi
-eXH
+dsA
+uZy
+iXm
+iXm
+uZy
 jFA
 jFA
 xkH
@@ -275533,11 +275701,11 @@ sZa
 sZa
 jFA
 jFA
-jFA
-eXH
-bmi
-bmi
-eXH
+xAh
+uZy
+iXm
+iXm
+uZy
 sZa
 sZa
 niV
@@ -275613,14 +275781,14 @@ niV
 xkH
 vWm
 xkH
-xkH
-xkH
-bmi
-bmi
-bmi
-bmi
-xkH
-xkH
+dsA
+dsA
+iXm
+iXm
+iXm
+iXm
+dsA
+dsA
 xkH
 niV
 eTA
@@ -275985,11 +276153,11 @@ jFA
 jFA
 xkH
 xkH
-bbQ
-eXH
-bmi
-bmi
-qcy
+oRM
+uZy
+iXm
+iXm
+umA
 sZa
 sZa
 niV
@@ -276065,14 +276233,14 @@ niV
 xkH
 xkH
 xkH
-xkH
-xkH
+dsA
+dsA
 fjG
-bmi
-bmi
-ngr
-jFA
-jFA
+iXm
+iXm
+ydz
+xAh
+xAh
 eTA
 xkH
 xkH
@@ -276438,10 +276606,10 @@ xkH
 xkH
 xkH
 eMx
-eXH
-bmi
-bmi
-kVg
+uZy
+iXm
+iXm
+nDo
 jFA
 xkH
 xkH
@@ -276517,13 +276685,13 @@ niV
 xkH
 jFA
 jFA
-jFA
-xkH
-xkH
-bmi
-bmi
-xkH
-jFA
+xAh
+dsA
+dsA
+iXm
+iXm
+dsA
+xAh
 jFA
 xkH
 xkH
@@ -276892,8 +277060,8 @@ eMx
 eMx
 eMx
 eMx
-bmi
-xkH
+iXm
+dsA
 xkH
 jFA
 xkH
@@ -276970,12 +277138,12 @@ xkH
 jFA
 jFA
 jFA
-jFA
-xkH
-bmi
-bmi
-xkH
-jFA
+xAh
+dsA
+iXm
+iXm
+dsA
+xAh
 jFA
 jFA
 jFA
@@ -277422,12 +277590,12 @@ jFA
 xkH
 xkH
 jFA
-jFA
-xkH
-bmi
-bmi
-xkH
-xkH
+xAh
+dsA
+iXm
+iXm
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -277874,12 +278042,12 @@ jFA
 jFA
 jFA
 jFA
-jFA
-xkH
-bmi
-bmi
-xkH
-xkH
+xAh
+dsA
+iXm
+iXm
+dsA
+dsA
 jFA
 jFA
 eTA
@@ -278326,12 +278494,12 @@ jFA
 jFA
 jFA
 jFA
-jFA
-xkH
-bmi
-bmi
-xkH
-xkH
+xAh
+dsA
+iXm
+iXm
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -278778,12 +278946,12 @@ xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-bmi
-bmi
-xkH
-xkH
+dsA
+dsA
+iXm
+iXm
+dsA
+dsA
 jFA
 jFA
 jFA
@@ -279230,12 +279398,12 @@ eMx
 eMx
 eMx
 eMx
-xkH
-xkH
-bmi
-bmi
-xkH
-xkH
+dsA
+dsA
+iXm
+iXm
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -279684,10 +279852,10 @@ eMx
 eMx
 eMx
 eMx
-bmi
-bmi
-xkH
-xkH
+iXm
+iXm
+dsA
+dsA
 jFA
 jFA
 xkH
@@ -287138,7 +287306,7 @@ pww
 pww
 nTh
 njP
-wGa
+umf
 rMf
 jQE
 uMp
@@ -287590,7 +287758,7 @@ aHM
 aHM
 rni
 nTh
-oei
+lRi
 rMf
 jQE
 rAR
@@ -288494,7 +288662,7 @@ noW
 jjT
 noW
 pww
-rGn
+oXZ
 rMf
 jQE
 weQ
@@ -289398,7 +289566,7 @@ cOh
 awz
 noW
 nTh
-rGn
+oXZ
 rMf
 jQE
 weQ
@@ -290754,7 +290922,7 @@ vQv
 heB
 noW
 pww
-oei
+lRi
 rMf
 jQE
 weQ
@@ -293471,7 +293639,7 @@ fXm
 vAw
 vAw
 vAw
-pLV
+caU
 kAx
 rMf
 rMf
@@ -293919,14 +294087,14 @@ agp
 noW
 njP
 ppQ
-xMz
-rZW
-rZW
-rZW
-uAa
-rZW
-uAa
-tMt
+bIK
+feV
+feV
+feV
+fKJ
+feV
+fKJ
+qdI
 jJH
 jQE
 weQ
@@ -294376,9 +294544,9 @@ aym
 hbr
 dYg
 dYg
-aTo
-cZA
-gEA
+tPn
+kjr
+tDN
 vAw
 jQE
 weQ
@@ -294829,7 +294997,7 @@ oSt
 oSt
 oSt
 qQo
-orZ
+hhu
 vAw
 vAw
 vxV
@@ -295281,7 +295449,7 @@ pSa
 jGN
 drN
 oSt
-fpq
+lNl
 kAx
 jJH
 jQE
@@ -296577,7 +296745,7 @@ qyR
 qyR
 pWT
 fpx
-tXD
+aGz
 exD
 exD
 exD
@@ -323060,10 +323228,10 @@ aBB
 aBB
 aBB
 eMx
-hlK
-eGq
+aWl
+bjV
 eTA
-ukO
+wPC
 lue
 eMx
 eMx
@@ -323511,14 +323679,14 @@ aBB
 aBB
 aBB
 eMx
-hlK
-xdh
-aUe
+aWl
+fAa
+fZe
 uDZ
-jLH
-aMK
-aUe
-xGB
+hHg
+rFr
+fZe
+gWP
 eMx
 aBB
 aBB
@@ -323964,14 +324132,14 @@ aBB
 aBB
 eMx
 lue
-ttU
-eHC
+efX
+waC
 eXH
-hfu
+sFJ
 eXH
 eXH
 xkH
-hlK
+aWl
 eMx
 eMx
 aBB
@@ -324415,15 +324583,15 @@ aBB
 aBB
 aBB
 eMx
-aUe
+fZe
 eXH
-cjd
-aUe
-dMR
-aUe
-wUZ
-eHC
-wfE
+vDp
+fZe
+jzb
+fZe
+wai
+waC
+vBZ
 eTA
 eMx
 eMx
@@ -324434,8 +324602,8 @@ aBB
 aBB
 aBB
 aBB
-hlK
-hlK
+aWl
+aWl
 lue
 xkH
 eMx
@@ -324869,14 +325037,14 @@ aBB
 eMx
 eMT
 eXH
-mhp
+rzx
 niV
 niV
 xkH
-oMo
+nus
 eXH
 eMT
-dwp
+sFs
 lue
 xkH
 eMx
@@ -324888,8 +325056,8 @@ eMx
 eMx
 lue
 sZa
-hlK
-dwp
+aWl
+sFs
 eMx
 eMx
 aBB
@@ -325320,17 +325488,17 @@ aBB
 aBB
 eMx
 eTA
-hfu
-wWD
+sFJ
+kPQ
 niV
-nYW
+npJ
 niV
 niV
 niV
 xkH
 eTA
-mtt
-feV
+prW
+qKN
 lue
 eMx
 eMx
@@ -325771,9 +325939,9 @@ aBB
 aBB
 aBB
 eMx
-feV
+qKN
 eXH
-wWD
+kPQ
 niV
 niV
 xkH
@@ -325781,17 +325949,17 @@ niV
 xkH
 niV
 eMT
-nGj
+gAk
 eTA
-feV
+qKN
 lue
 sdo
-feV
+qKN
 kRr
 xkH
 xkH
-feV
-aWl
+qKN
+uvu
 sZa
 xkH
 xkH
@@ -326223,27 +326391,27 @@ aBB
 aBB
 aBB
 eMx
-feV
+qKN
 eXH
-cOP
+gQj
 xkH
 niV
 niV
-aUe
+fZe
 eXH
 niV
 niV
 xkH
-cni
-neM
-iXm
-iXm
+fle
+tpM
+eew
+eew
 luC
-iXm
+eew
 lue
 lue
 jFA
-aWl
+uvu
 eXH
 lue
 xkH
@@ -326675,27 +326843,27 @@ aBB
 aBB
 eMx
 eMx
-wfE
-oxl
-jKU
-sfJ
-stb
-aUe
-cjd
-oxl
-uLg
+vBZ
+hjf
+mHK
+mWB
+vZO
+fZe
+vDp
+hjf
+hhA
 xkH
 niV
 niV
-aWl
+uvu
 eMT
 eMT
-iyc
+lSb
 nKD
-iXm
-aWl
+eew
+uvu
 hds
-iXm
+eew
 eXH
 eTA
 lue
@@ -327128,27 +327296,27 @@ aBB
 eMx
 sdo
 eTA
-jGc
-oxl
+nez
+hjf
 eXH
 eXH
 ocQ
 eXH
-gfu
-vxu
-aWl
-sFs
+nYZ
+olV
+uvu
+mlR
 xkH
 niV
-aPu
-feV
-nGj
+heP
+qKN
+gAk
 eMT
-feV
-aWl
-aWl
-oYh
-dDi
+qKN
+uvu
+uvu
+bdp
+daR
 lue
 xkH
 eMx
@@ -327578,29 +327746,29 @@ aBB
 aBB
 aBB
 eMx
-xdh
+fAa
 xkH
 uDZ
-wfE
-vqR
+vBZ
+cHF
 kqa
-aMK
-aUe
-ern
-azJ
-aWl
-dQi
-rsD
-qLA
-rjT
-jUT
+rFr
+fZe
+xXw
+iYi
+uvu
+hqA
+yiY
+oHf
+mel
+hid
 inM
-aTV
-gTC
+qSf
+dwp
 pSM
 pSM
-feV
-nAs
+qKN
+brh
 xkH
 eMx
 eMx
@@ -328033,25 +328201,25 @@ eMx
 lue
 xkH
 eMT
-rsD
-gHx
-feV
+yiY
+rfX
+qKN
 jFA
-sFs
-dpQ
+mlR
+aAv
 kqa
-dQi
-pvE
+hqA
+shO
 veg
 tzL
-aYu
+cNN
 hTd
-cEy
-ium
-bvM
+dIr
+vdw
+fRQ
 eHk
-kUO
-feV
+wem
+qKN
 hds
 eMx
 eMx
@@ -328484,19 +328652,19 @@ aBB
 eMx
 eMx
 lue
-hyF
-tBC
+nlp
+ivj
 sdo
 xkH
 jFA
 sZa
-aWl
-gHx
-oYh
+uvu
+rfX
+bdp
 inM
 uQv
 qzg
-aWd
+qee
 qzg
 dXq
 dXq
@@ -328504,7 +328672,7 @@ pfw
 dXq
 mGK
 umH
-aWl
+uvu
 kgg
 aBB
 aBB
@@ -328935,28 +329103,28 @@ aBB
 aBB
 aBB
 eMx
-pHp
-eGq
-sFs
+vtD
+bjV
+mlR
 lue
 sZa
 jFA
 xkH
-feV
+qKN
 jFA
-phD
-qLA
-cEy
+xoo
+oHf
+dIr
 qzg
-kio
-wUE
-nUT
-dsA
+iUI
+oMK
+tRd
+yfv
 dXq
 psV
 mGK
 umH
-aWl
+uvu
 kgg
 aBB
 aBB
@@ -329387,28 +329555,28 @@ aBB
 aBB
 aBB
 aBB
-pHp
-sIG
+vtD
+gnJ
 sZa
-tgG
+hEY
 xkH
 jFA
-ern
+xXw
 jFA
 xkH
 niV
-rWj
-btN
-btN
-btN
+nuB
+kHb
+kHb
+kHb
 kFg
 tNg
-bUW
+pGJ
 pfw
 psV
 mGK
 umH
-aWl
+uvu
 kgg
 aBB
 aBB
@@ -329839,28 +330007,28 @@ aBB
 aBB
 aBB
 aBB
-pHp
-xdh
-nRo
-vSS
+vtD
+fAa
+uCt
+wFV
 niV
 xkH
 niV
 niV
-ern
+xXw
 xkH
-rWj
-btN
-btN
-btN
+nuB
+kHb
+kHb
+kHb
 kFg
 tNg
-bUW
+pGJ
 dXq
 psV
 mGK
 umH
-aWl
+uvu
 kgg
 aBB
 aBB
@@ -330291,28 +330459,28 @@ aBB
 aBB
 aBB
 aBB
-pHp
+vtD
 sdo
 sZa
-xBr
+oDJ
 xkH
 jFA
 jFA
 jFA
 jFA
-rSb
-qLA
+szs
+oHf
 qzg
 qzg
-kDm
-sPd
-mBR
-foS
+kcW
+gYy
+jaB
+kMI
 dXq
 psV
 mGK
 umH
-aWl
+uvu
 kgg
 aBB
 aBB
@@ -330744,27 +330912,27 @@ aBB
 aBB
 aBB
 eMx
-hlK
-eGq
+aWl
+bjV
 eTA
 jFA
 jFA
 eTA
 jFA
 kRr
-oYh
+bdp
 hds
 uQv
 qzg
 qzg
-aWd
+qee
 dXq
 dXq
 pfw
 dXq
 mGK
 oCk
-aWl
+uvu
 kgg
 aBB
 aBB
@@ -331196,26 +331364,26 @@ aBB
 aBB
 eMx
 eMx
-hlK
+aWl
 sZa
-sFs
+mlR
 jFA
 jFA
 xkH
 jFA
 jFA
-ern
+xXw
 hds
 veg
-lmS
+mwc
 dXq
-iko
+wVJ
 eHk
-snu
+hiB
 pfw
 pfw
-ccY
-lNE
+pla
+bQI
 kgg
 aBB
 aBB
@@ -331647,29 +331815,29 @@ aBB
 aBB
 eMx
 eMx
-hlK
+aWl
 lue
-dGk
+gLC
 jFA
 psx
 jFA
-dGk
-iPf
-aWl
+gLC
+cRJ
+uvu
 jFA
-ern
-bXk
-qhG
-wkq
-rjT
-gWt
-iLt
-iLt
-rjB
-eTF
-mxC
+xXw
+tvx
+eLc
+uoF
+mel
+mKg
+sYt
+sYt
+cQu
+nAQ
+lGI
 veg
-rwq
+ygS
 aBB
 aBB
 aBB
@@ -332098,29 +332266,29 @@ aBB
 aBB
 aBB
 eMx
-pHp
-hlK
-oIC
-uPm
-hVz
-xCH
+vtD
+aWl
+pbs
+tZS
+aLg
+suB
 psx
 jFA
-ern
-ern
+xXw
+xXw
 xkH
-feV
-oYh
-oYh
+qKN
+bdp
+bdp
 eMT
-hmM
-cni
-aWl
-lNE
-uXh
+vrf
+fle
+uvu
+bQI
+otW
 tNg
 tNg
-lNE
+bQI
 aBB
 aBB
 aBB
@@ -332550,29 +332718,29 @@ aBB
 aBB
 aBB
 eMx
-pHp
+vtD
 eTA
-sSN
-iCt
-xWb
+uWJ
+mxB
+wHN
 kRr
 sZa
-vVH
+wmq
 xkH
 obK
 sZa
 hds
-tfT
+wob
 tmt
 obK
-fHG
-aWl
+aOy
+uvu
 eMT
 hds
-nAs
-duw
+brh
+mDZ
 oyQ
-rwq
+ygS
 aBB
 aBB
 aBB
@@ -333003,12 +333171,12 @@ aBB
 aBB
 eMx
 eMx
-qro
+qVF
 ixl
 fuj
 fuj
-uOG
-ppp
+sjG
+fwZ
 sZa
 xkH
 jFA
@@ -333017,12 +333185,12 @@ jFA
 sZa
 luC
 hds
-uWJ
+qzF
 hds
 hds
 uDZ
 lue
-ivZ
+jIC
 aBB
 aBB
 aBB
@@ -333456,22 +333624,22 @@ aBB
 aBB
 eMx
 eMx
-otv
+gAS
 fuj
 fuj
-gRo
+wbG
 ixl
 xkH
 niV
-woL
-mtV
+hhU
+anW
 jFA
 niV
 fBJ
 jFA
-uWJ
+qzF
 obK
-hHg
+aCt
 xkH
 xkH
 eMx
@@ -333908,9 +334076,9 @@ aBB
 aBB
 aBB
 eMx
-cbE
-stY
-bJI
+uYl
+ioO
+xKg
 fuj
 fuj
 uWS
@@ -333919,12 +334087,12 @@ xkH
 hds
 eCd
 nKD
-feV
+qKN
 hds
-pBz
-tzq
+vxZ
+qLc
 xkH
-feV
+qKN
 kRr
 eMx
 aBB
@@ -334360,23 +334528,23 @@ aBB
 aBB
 eMx
 eMx
-xTn
-xYX
+rtR
+dcP
 eTA
 fuj
 fuj
 ixl
-rDS
+xdl
 kRr
 eTA
 xkH
-oDa
+vIC
 luC
 lue
 xkH
-uWJ
+qzF
 sZa
-feV
+qKN
 lue
 eMx
 aBB
@@ -334811,11 +334979,11 @@ aBB
 aBB
 eMx
 eMx
-jhf
+ipZ
 xkH
 fuj
-jST
-ksx
+pUD
+faJ
 fuj
 fuj
 uWS
@@ -334824,11 +334992,11 @@ apU
 dXq
 pfw
 apU
-iXm
+eew
 xkH
-uWJ
-rLY
-eGq
+qzF
+hFD
+bjV
 lue
 eMx
 aBB
@@ -335262,24 +335430,24 @@ aBB
 aBB
 aBB
 eMx
-pHp
+vtD
 xkH
-hJn
+rmX
 fuj
 xkH
 eTA
 fuj
-stY
+ioO
 ixl
 hds
-xZJ
+qeA
 pfw
 pfw
 dXq
 niV
 niV
-fnG
-cSb
+oYh
+kAL
 eTA
 eMx
 eMx
@@ -335714,16 +335882,16 @@ aBB
 aBB
 eMx
 xkH
-pHp
+vtD
 lue
-kmp
+vQe
 fuj
 fuj
-oHL
-xYX
+oin
+dcP
 sZa
-sFs
-cQR
+mlR
+amh
 dXq
 pfw
 pfw
@@ -335731,8 +335899,8 @@ pfw
 niV
 xkH
 sni
-uWJ
-hlK
+qzF
+aWl
 eMx
 aBB
 aBB
@@ -336166,25 +336334,25 @@ aBB
 aBB
 eMx
 xkH
-xdh
-qMb
-kBO
-gRo
+fAa
+htp
+lrK
+wbG
 fuj
-iCt
+mxB
 uWS
 lJO
-qYS
-rZa
-wDS
+vuH
+veo
+ydi
 pfw
 pfw
-fmC
+snA
 hds
-inL
+fUu
 niV
-uWJ
-hlK
+qzF
+aWl
 eMx
 aBB
 aBB
@@ -336618,25 +336786,25 @@ aBB
 aBB
 eMx
 xkH
-hlK
-pHp
+aWl
+vtD
 sZa
-iCt
+mxB
 uWS
 lue
 apU
-nus
-nus
+toh
+toh
 eYU
 veg
 xLB
 xLB
 veg
-iXm
-sad
+eew
+fUB
 niV
-oDa
-dwp
+vIC
+sFs
 eMx
 eMx
 eMx
@@ -337071,8 +337239,8 @@ aBB
 eMx
 xkH
 sZa
-pHp
-oEs
+vtD
+cup
 jFA
 jFA
 eTA
@@ -337083,13 +337251,13 @@ dXq
 pfw
 pfw
 dXq
-nus
+toh
 eTA
 xkH
-vIC
+xaK
 sZa
 xkH
-cTD
+pxo
 lue
 eMx
 eMx
@@ -337522,27 +337690,27 @@ aBB
 aBB
 eMx
 xkH
-qCf
-hlK
-hlK
+ntW
+aWl
+aWl
 sZa
 jFA
-dwp
-nus
+sFs
+toh
 veg
 kFg
 pfw
 pfw
 pfw
-dKU
-nus
+pnW
+toh
 lue
 xkH
-uWJ
+qzF
 niV
 jFA
 jFA
-hlK
+aWl
 lue
 eMx
 eMx
@@ -337973,12 +338141,12 @@ aBB
 aBB
 aBB
 eMx
-hlK
+aWl
 xkH
-qCf
-qCf
-hlK
-hlK
+ntW
+ntW
+aWl
+aWl
 jFA
 lMW
 veg
@@ -337988,15 +338156,15 @@ mlS
 pfw
 iBx
 gOR
-feV
+qKN
 lue
-uWJ
+qzF
 niV
 xkH
 sZa
-dGk
-hlK
-hlK
+gLC
+aWl
+aWl
 eMx
 aBB
 aBB
@@ -338425,24 +338593,24 @@ aBB
 aBB
 aBB
 eMx
-hlK
+aWl
 eTA
 xkH
 sdo
 lue
-hlK
+aWl
 lue
 apU
-nus
-nus
+toh
+toh
 ndL
 rbN
-bcf
+lgr
 ndL
 apU
-feV
+qKN
 fBJ
-dfN
+spl
 niV
 xkH
 jFA
@@ -338878,27 +339046,27 @@ aBB
 aBB
 eMx
 xkH
-rDS
+xdl
 xkH
 lue
 eMx
 eMx
 eMx
 eMx
-cTD
-hlK
+pxo
+aWl
 lue
 xkH
 xkH
-feV
-feV
-iXm
-iXm
-hWm
+qKN
+qKN
+eew
+eew
+tIr
 niV
 jFA
 eXH
-oYh
+bdp
 eTA
 xkH
 eMx
@@ -339338,19 +339506,19 @@ eMx
 eMx
 eMx
 sdo
-hHg
+aCt
 xkH
 xkH
 xkH
 xkH
 jFA
-iOg
-aAs
-vIC
+uhD
+xyi
+xaK
 xkH
 fBJ
 eXH
-aWl
+uvu
 lue
 eMx
 eMx
@@ -339791,17 +339959,17 @@ aBB
 eMx
 eMx
 yhK
-uWJ
-vIC
-vIC
-mxB
+qzF
+xaK
+xaK
+qFL
 niV
-hmM
-uWJ
-uWJ
-dwp
+vrf
+qzF
+qzF
+sFs
 eXH
-aWl
+uvu
 lue
 lue
 eMx
@@ -340244,18 +340412,18 @@ eMx
 eMx
 yhK
 niV
-uWJ
-uWJ
-uWJ
+qzF
+qzF
+qzF
 niV
-tjL
-sad
+wMQ
+fUB
 jFA
-tfT
-dQi
+wob
+hqA
 eTA
-hlK
-hlK
+aWl
+aWl
 eMx
 aBB
 aBB
@@ -340694,15 +340862,15 @@ aBB
 aBB
 eMx
 sdo
-hHg
-sFs
+aCt
+mlR
 jFA
 jFA
 jFA
-hlK
+aWl
 hds
 jFA
-xdh
+fAa
 eTA
 xkH
 xkH
@@ -341146,7 +341314,7 @@ aBB
 aBB
 eMx
 eMx
-rIw
+uMV
 jFA
 jFA
 hds
@@ -341155,7 +341323,7 @@ hds
 jFA
 sZa
 xkH
-kWi
+rSc
 eTA
 xkH
 eMx
@@ -341598,17 +341766,17 @@ aBB
 aBB
 eMx
 lue
-dGk
+gLC
 sZa
 jFA
 jFA
 jFA
 sZa
-sFs
+mlR
 jFA
 kRr
-hlK
-hlK
+aWl
+aWl
 eMx
 eMx
 aBB
@@ -342055,11 +342223,11 @@ jFA
 jFA
 jFA
 eXH
-dGk
-feV
-hlK
-hlK
-hlK
+gLC
+qKN
+aWl
+aWl
+aWl
 eMx
 eMx
 aBB
@@ -342502,14 +342670,14 @@ aBB
 aBB
 eMx
 lue
-xdh
+fAa
 jFA
-vEB
+iFZ
 xkH
 eTA
-feV
+qKN
 xkH
-hlK
+aWl
 eMx
 aBB
 aBB
@@ -342952,14 +343120,14 @@ aBB
 aBB
 aBB
 aBB
-hlK
-hlK
+aWl
+aWl
 eTA
 lue
-hlK
-feV
-feV
-hlK
+aWl
+qKN
+qKN
+aWl
 xkH
 eMx
 eMx
@@ -343404,14 +343572,14 @@ aBB
 aBB
 aBB
 aBB
-hlK
+aWl
 eMx
 xkH
-hlK
-hlK
+aWl
+aWl
 eMx
-hlK
-hlK
+aWl
+aWl
 eMx
 eMx
 aBB
@@ -343862,7 +344030,7 @@ eMx
 eMx
 eMx
 eMx
-hlK
+aWl
 eMx
 eMx
 aBB
@@ -372132,8 +372300,8 @@ fVj
 dJN
 lpV
 gwD
-xVA
-iaM
+nSN
+vqf
 tvR
 hEb
 hiM
@@ -372584,7 +372752,7 @@ fVj
 dJN
 vDZ
 uKP
-cGN
+fLM
 rbu
 jlo
 uyR
@@ -375744,7 +375912,7 @@ tvR
 rbu
 rMT
 oKQ
-hSt
+fNd
 oKQ
 oKQ
 oKQ
@@ -377191,8 +377359,8 @@ vvB
 vvB
 vvB
 vvB
-umA
-dqy
+rIw
+wfE
 vvB
 vvB
 vvB
@@ -377641,12 +377809,12 @@ vvB
 vvB
 vvB
 vvB
-umA
-dqy
-dqy
-dqy
-dqy
-umA
+rIw
+wfE
+wfE
+wfE
+wfE
+rIw
 vvB
 vvB
 aBB
@@ -378093,14 +378261,14 @@ vvB
 vvB
 vvB
 vvB
-dqy
-dqy
-dqy
-dqy
-dqy
-dqy
-uuE
-eOe
+wfE
+wfE
+wfE
+wfE
+wfE
+wfE
+lEb
+pxl
 aBB
 aBB
 aBB
@@ -378456,7 +378624,7 @@ tvR
 rbu
 rbu
 rbu
-gLC
+nxP
 rbu
 rbu
 rbu
@@ -378546,13 +378714,13 @@ vvB
 vvB
 vvB
 vvB
-dqy
-dqy
-dqy
-dqy
-dqy
-uBd
-uuE
+wfE
+wfE
+wfE
+wfE
+wfE
+pDm
+lEb
 aBB
 aBB
 aBB
@@ -378998,11 +379166,11 @@ vvB
 vvB
 vvB
 vvB
-umA
-dqy
-dqy
-dqy
-dqy
+rIw
+wfE
+wfE
+wfE
+wfE
 vvB
 vvB
 aBB
@@ -379451,9 +379619,9 @@ vvB
 vvB
 vvB
 vvB
-dqy
-dqy
-umA
+wfE
+wfE
+rIw
 vvB
 vvB
 vvB
@@ -382623,7 +382791,7 @@ vvB
 vvB
 vvB
 aBB
-qzF
+qGH
 aBB
 aBB
 aBB
@@ -383073,9 +383241,9 @@ vvB
 vvB
 vvB
 vvB
-rep
-uov
-uJe
+hfA
+bBp
+cZA
 nRO
 aBB
 aBB
@@ -383525,9 +383693,9 @@ vvB
 vvB
 vvB
 vvB
-fZN
-rep
-uJe
+hmM
+hfA
+cZA
 nRO
 aBB
 aBB
@@ -383976,10 +384144,10 @@ vvB
 vvB
 vvB
 vvB
-fZN
-fZN
-fZN
-uJe
+hmM
+hmM
+hmM
+cZA
 nRO
 aBB
 aBB
@@ -384428,10 +384596,10 @@ vvB
 vvB
 vvB
 vvB
-fZN
-fZN
-fZN
-uJe
+hmM
+hmM
+hmM
+cZA
 nRO
 aBB
 aBB
@@ -384880,10 +385048,10 @@ vvB
 vvB
 vvB
 vvB
-fZN
-fZN
-qGH
-uJe
+hmM
+hmM
+uGQ
+cZA
 nRO
 aBB
 aBB
@@ -385332,10 +385500,10 @@ vvB
 vvB
 vvB
 vvB
-fZN
-fZN
-fZN
-uJe
+hmM
+hmM
+hmM
+cZA
 nRO
 aBB
 aBB
@@ -385784,10 +385952,10 @@ vvB
 vvB
 vvB
 vvB
-fZN
-fZN
-fZN
-uJe
+hmM
+hmM
+hmM
+cZA
 nRO
 aBB
 aBB
@@ -386237,9 +386405,9 @@ vvB
 vvB
 vvB
 vvB
-fZN
-rep
-uJe
+hmM
+hfA
+cZA
 nRO
 aBB
 aBB
@@ -386689,9 +386857,9 @@ vvB
 vvB
 vvB
 vvB
-rep
-vNC
-uJe
+hfA
+qkg
+cZA
 nRO
 aBB
 aBB
@@ -387143,7 +387311,7 @@ vvB
 vvB
 vvB
 aBB
-pqc
+qhi
 aBB
 aBB
 aBB
@@ -438321,7 +438489,7 @@ aBB
 aBB
 aBB
 aBB
-lXx
+heG
 aBB
 aBB
 aBB
@@ -438772,12 +438940,12 @@ aBB
 aBB
 aBB
 aBB
-lXx
-rwq
-rwq
-lXx
-lXx
-lXx
+heG
+ygS
+ygS
+heG
+heG
+heG
 aBB
 aBB
 aBB
@@ -439225,14 +439393,14 @@ aBB
 aBB
 aBB
 aBB
-lXx
+heG
 aBB
 aBB
 aBB
-lXx
-rwq
+heG
+ygS
 aBB
-lXx
+heG
 aBB
 aBB
 aBB
@@ -439677,13 +439845,13 @@ aBB
 aBB
 aBB
 aBB
-lXx
+heG
 tNg
 tNg
 tNg
 tNg
-hAp
-lXx
+cPq
+heG
 aBB
 aBB
 aBB
@@ -440128,20 +440296,20 @@ aBB
 aBB
 aBB
 aBB
-lXx
+heG
 aBB
 tNg
 tNg
 tNg
 tNg
 tNg
-lXx
+heG
 iiA
-oCL
-mSR
+xTn
+wGZ
 aBB
 iiA
-mSR
+wGZ
 iiA
 aBB
 aBB
@@ -440588,12 +440756,12 @@ tNg
 tNg
 tNg
 aBB
-oCL
+xTn
 aBB
-sYb
+eHC
 iiA
-mSR
-sYb
+wGZ
+eHC
 iiA
 iiA
 aBB
@@ -441032,27 +441200,27 @@ aBB
 aBB
 aBB
 aBB
-lXx
+heG
 aBB
 tNg
 tNg
 tNg
 tNg
 tNg
-oBU
-hDG
-kZU
-kDV
+dQi
+wAa
+eOe
+mGN
 aBB
-sYb
-fVL
-oCL
+eHC
+oOE
+xTn
 iiA
-mSR
+wGZ
 iiA
-mSR
+wGZ
 iiA
-mSR
+wGZ
 aBB
 aBB
 aBB
@@ -441484,7 +441652,7 @@ aBB
 aBB
 aBB
 aBB
-lXx
+heG
 aBB
 tNg
 tNg
@@ -441492,19 +441660,19 @@ tNg
 tNg
 tNg
 aBB
-rGN
+imy
 oJW
 oJW
 oJW
-kZU
-kZU
-tso
-fKJ
-fKJ
+eOe
+eOe
+lpn
+mBR
+mBR
 iiA
-fVL
+oOE
 iiA
-sYb
+eHC
 iiA
 aBB
 aBB
@@ -441936,28 +442104,28 @@ aBB
 aBB
 aBB
 aBB
-rwq
-rwq
+ygS
+ygS
 tNg
 tNg
 tNg
 tNg
 tNg
-lXx
-mNc
+heG
+fdJ
 oJW
-mNc
+fdJ
 eTR
 tWF
 oJW
-ilj
+wIv
 iiA
 iiA
-fKJ
-fKJ
-fKJ
-fKJ
-uyS
+mBR
+mBR
+mBR
+mBR
+ueJ
 aBB
 aBB
 aBB
@@ -442392,22 +442560,22 @@ aBB
 aBB
 aBB
 aBB
-rwq
+ygS
 aBB
 aBB
-lXx
-asA
-rib
-srr
+heG
+krt
+eny
+xtv
 eTR
-jrR
+rvF
 tWF
-ilj
-pPf
-pKX
+wIv
+mkI
+hik
 iiA
 iiA
-oCL
+xTn
 iiA
 iiA
 aBB
@@ -442840,25 +443008,25 @@ aBB
 aBB
 aBB
 aBB
-lXx
-lXx
+heG
+heG
 aBB
-rwq
+ygS
 aBB
 aBB
-lXx
+heG
 iiA
-yiG
+vzE
 eTR
 eTR
-gXi
-rGQ
-pyX
-uQR
-gXi
+hfu
+lRy
+jvb
+hLA
+hfu
 eTR
 eTR
-pYc
+sso
 eTR
 oCk
 iiA
@@ -443292,15 +443460,15 @@ aBB
 aBB
 aBB
 aBB
-lXx
+heG
 aBB
 aBB
 aBB
-lXx
-lXx
-vzE
-pgb
-pPf
+heG
+heG
+aXK
+kuQ
+mkI
 eTR
 qOD
 cme
@@ -443308,13 +443476,13 @@ tNg
 tNg
 rbX
 veg
-mKO
-hEY
+pFz
+uBd
 qOD
-ehr
-wvi
+vVH
+btN
 oCk
-uyS
+ueJ
 aBB
 aBB
 aBB
@@ -443743,30 +443911,30 @@ aBB
 aBB
 aBB
 aBB
-lXx
+heG
 aBB
 aBB
 aBB
 aBB
 aBB
 aBB
-pUD
+bXk
 aBB
-yiG
-pRv
-qWI
+vzE
+biI
+fAi
 rub
 eTR
-lca
+oBU
 qOD
 qOD
 qOD
 gnN
 rbX
 qOD
-ehr
-wvi
-fPD
+vVH
+btN
+xYX
 iiA
 aBB
 aBB
@@ -444195,31 +444363,31 @@ aBB
 aBB
 aBB
 aBB
-lXx
+heG
 lZK
 aBB
 aBB
 aBB
-pUD
+bXk
 aBB
 aBB
 aBB
 aBB
-xbM
+cbt
 qOD
-kHS
-lca
+buC
+oBU
 gnN
 hOX
-iiV
+dGk
 uii
-eMp
+dXb
 qOD
-hEY
-pkz
-wvi
+uBd
+rWf
+btN
 jjR
-uyS
+ueJ
 aBB
 aBB
 aBB
@@ -444650,19 +444818,19 @@ aBB
 aBB
 lZK
 aBB
-pUD
+bXk
 aBB
 aBB
 aBB
 aBB
 aBB
 aBB
-rOR
+sCr
 qOD
 qOD
 rbX
 qOD
-gpd
+jiH
 tNg
 tNg
 dTG
@@ -444670,7 +444838,7 @@ qOD
 apU
 veg
 eTR
-fPD
+xYX
 iiA
 iiA
 aBB
@@ -445108,13 +445276,13 @@ aBB
 aBB
 aBB
 aBB
-oBU
-rOR
+dQi
+sCr
 qOD
 qOD
 rbX
 qOD
-gpd
+jiH
 tNg
 tNg
 dTG
@@ -445122,9 +445290,9 @@ qOD
 apU
 veg
 eTR
-fPD
-pPf
-uyS
+xYX
+mkI
+ueJ
 aBB
 aBB
 aBB
@@ -445554,28 +445722,28 @@ aBB
 aBB
 lZK
 aBB
-pUD
+bXk
 aBB
 aBB
 aBB
 aBB
 aBB
 iiA
-xbM
+cbt
 qOD
-kHS
-lca
+buC
+oBU
 eDq
-qWI
-emf
+fAi
+tOR
 rub
 hiu
 qOD
-hEY
-pkz
-wvi
+uBd
+rWf
+btN
 jjR
-uyS
+ueJ
 iiA
 aBB
 aBB
@@ -446007,26 +446175,26 @@ aBB
 aBB
 aBB
 aBB
-pUD
+bXk
 aBB
 aBB
-pUD
+bXk
 oJW
-yiG
-pRv
+vzE
+biI
 hOX
 uii
 eTR
-lca
+oBU
 qOD
 qOD
 qOD
 eDq
 rbX
 qOD
-ehr
-wvi
-fPD
+vVH
+btN
+xYX
 iiA
 aBB
 aBB
@@ -446463,20 +446631,20 @@ aBB
 aBB
 aBB
 oJW
-heG
-pgb
+fOE
+kuQ
 eTR
 qOD
 cme
 tNg
 eTR
-xsx
+bqQ
 veg
-mKO
-hEY
+pFz
+uBd
 qOD
-ehr
-wvi
+vVH
+btN
 oCk
 iiA
 iiA
@@ -446915,18 +447083,18 @@ aBB
 aBB
 aBB
 aBB
-pUD
-yiG
+bXk
+vzE
 eTR
 eTR
-gXi
-mKO
+hfu
+pFz
 szH
 qOD
-qHJ
-gXi
-gXi
-pYc
+dNJ
+hfu
+hfu
+sso
 eTR
 eTR
 iiA
@@ -447370,19 +447538,19 @@ aBB
 aBB
 iiA
 eTR
-acQ
+cHP
 szH
 gnN
 qOD
 qOD
 szH
 eTR
-fKJ
+mBR
 aBB
 aBB
-pUD
-pgb
-uyS
+bXk
+kuQ
+ueJ
 aBB
 aBB
 aBB
@@ -447817,22 +447985,22 @@ aBB
 aBB
 aBB
 aBB
-pUD
+bXk
 aBB
 iiA
 iiA
-gXi
-fyO
+hfu
+bxQ
 qOD
 qOD
 qOD
 szH
 eTR
 tNg
-fKJ
+mBR
 aBB
-fKJ
-fKJ
+mBR
+mBR
 iiA
 iiA
 aBB
@@ -448270,19 +448438,19 @@ aBB
 aBB
 aBB
 aBB
-pUD
+bXk
 iiA
 iiA
 xRV
 szH
 qOD
 qOD
-asu
-toh
+wrn
+uXX
 eTR
 eTR
-pPf
-uyS
+mkI
+ueJ
 iiA
 iiA
 iiA
@@ -448719,20 +448887,20 @@ aBB
 aBB
 aBB
 aBB
-ozv
+mSV
 aBB
 aBB
 aBB
 aBB
-tUg
-lop
+hyy
+kBT
 qOD
 qOD
 szH
-brh
+sfX
 iiA
 iiA
-sYb
+eHC
 iiA
 iiA
 iiA
@@ -449171,20 +449339,20 @@ aBB
 aBB
 aBB
 aBB
-rLo
+lbO
 aBB
 aBB
 aBB
 iiA
-oCL
+xTn
 eTR
 qOD
 qOD
-unb
+auf
 eTR
-qei
+xOD
 iiA
-sse
+gXi
 iiA
 iiA
 iiA
@@ -449623,20 +449791,20 @@ aBB
 aBB
 aBB
 aBB
-pUD
-ozv
+bXk
+mSV
 aBB
 iiA
 iiA
-fVL
-lmg
+oOE
+ris
 qOD
 qOD
 eTR
-sYb
+eHC
 iiA
 iiA
-pUD
+bXk
 iiA
 aBB
 aBB
@@ -450076,18 +450244,18 @@ aBB
 aBB
 aBB
 aBB
-rLo
+lbO
 aBB
-oCL
-yiG
-pUD
+xTn
+vzE
+bXk
 apU
 rbX
 eYU
 apU
 hxC
 iiA
-oCL
+xTn
 iiA
 aBB
 aBB
@@ -450528,18 +450696,18 @@ aBB
 aBB
 aBB
 aBB
-pUD
+bXk
 iiA
-sYb
+eHC
 iiA
-sYb
+eHC
 lMW
 tlX
-iZR
+oyP
 gOR
 iiA
 iiA
-fVL
+oOE
 aBB
 aBB
 aBB
@@ -450982,16 +451150,16 @@ iiA
 iiA
 iiA
 iiA
-pUD
+bXk
 iiA
-sse
+gXi
 lMW
 tlX
 tlX
 gOR
-mSR
+wGZ
 iiA
-pUD
+bXk
 aBB
 aBB
 aBB
@@ -451429,10 +451597,10 @@ aBB
 aBB
 aBB
 lZK
-oCL
-oCL
+xTn
+xTn
 iiA
-oCL
+xTn
 iiA
 iiA
 iiA
@@ -451441,9 +451609,9 @@ lMW
 tlX
 tlX
 veg
-sYb
-mSR
-sse
+eHC
+wGZ
+gXi
 aBB
 aBB
 aBB
@@ -451880,11 +452048,11 @@ aBB
 aBB
 aBB
 aBB
-tFJ
-pUD
-fVL
-kVi
-sYb
+mNJ
+bXk
+oOE
+sGV
+eHC
 apU
 eYU
 eYU
@@ -451893,8 +452061,8 @@ veg
 tlX
 tlX
 tlX
-kZU
-cvP
+eOe
+unh
 iiA
 iiA
 iiA
@@ -452331,24 +452499,24 @@ aBB
 aBB
 aBB
 aBB
-pUD
+bXk
 lZK
-sse
-sYb
-kZU
-pUD
-jdg
-hMM
-hMM
-hMM
-jdg
+gXi
+eHC
+eOe
+bXk
+gtQ
+pHp
+pHp
+pHp
+gtQ
 tlX
 tlX
-vNA
-pUD
-ilj
-uyS
-pUD
+wMu
+bXk
+wIv
+ueJ
+bXk
 iiA
 aBB
 aBB
@@ -452784,23 +452952,23 @@ aBB
 aBB
 aBB
 aBB
-oBU
-vGk
-pUD
+dQi
+qfS
+bXk
 oJW
-gCO
+bPK
 tlX
 nde
 tNg
 tNg
-jKc
+fqb
 tlX
 tlX
 tlX
-vtD
-kwi
+bFm
+dmV
 iiA
-lXx
+heG
 iiA
 iiA
 iiA
@@ -453238,25 +453406,25 @@ aBB
 aBB
 aBB
 iiA
-mgZ
+nSf
 oJW
 oJW
-iaY
+oGh
 nde
 tNg
 tNg
-haW
-ged
-acn
+eDY
+jlR
+orG
 veg
 hxC
-sYb
+eHC
 iiA
-lXx
-lXx
-pUD
+heG
+heG
+bXk
 iiA
-lXx
+heG
 aBB
 aBB
 aBB
@@ -453687,12 +453855,12 @@ aBB
 aBB
 aBB
 aBB
-pUD
+bXk
 aBB
 iiA
-rJh
-dUx
-ghB
+ccV
+vrQ
+siz
 apU
 ndL
 ndL
@@ -453705,10 +453873,10 @@ iiA
 hxC
 iiA
 aBB
-lXx
-lXx
-lXx
-lXx
+heG
+heG
+heG
+heG
 aBB
 aBB
 aBB
@@ -454140,17 +454308,17 @@ aBB
 aBB
 aBB
 aBB
-vzE
-pgb
-pUD
-sse
-pUD
+aXK
+kuQ
+bXk
+gXi
+bXk
 iiA
 iiA
 iiA
 hxC
-sYb
-fVL
+eHC
+oOE
 hxC
 iiA
 iiA
@@ -454159,7 +454327,7 @@ iiA
 aBB
 aBB
 aBB
-lXx
+heG
 aBB
 aBB
 aBB
@@ -454594,25 +454762,25 @@ aBB
 aBB
 aBB
 iiA
-sYb
+eHC
 iiA
-sse
-iiA
-aBB
-iiA
-iiA
-fVL
-sYb
-iiA
+gXi
 iiA
 aBB
+iiA
+iiA
+oOE
+eHC
+iiA
+iiA
 aBB
 aBB
 aBB
 aBB
 aBB
 aBB
-lXx
+aBB
+heG
 aBB
 aBB
 aBB
@@ -455046,7 +455214,7 @@ aBB
 aBB
 aBB
 aBB
-sse
+gXi
 aBB
 iiA
 aBB
@@ -455063,8 +455231,8 @@ aBB
 aBB
 aBB
 aBB
-lXx
-lXx
+heG
+heG
 aBB
 aBB
 aBB
@@ -455513,7 +455681,7 @@ aBB
 aBB
 aBB
 aBB
-fKJ
+mBR
 aBB
 aBB
 aBB
@@ -455961,7 +456129,7 @@ aBB
 aBB
 aBB
 aBB
-fKJ
+mBR
 aBB
 aBB
 aBB
@@ -456410,9 +456578,9 @@ aBB
 aBB
 aBB
 aBB
-fKJ
+mBR
 aBB
-fKJ
+mBR
 aBB
 aBB
 aBB
@@ -456869,7 +457037,7 @@ aBB
 aBB
 aBB
 aBB
-lXx
+heG
 aBB
 aBB
 aBB
@@ -457318,10 +457486,10 @@ aBB
 aBB
 aBB
 aBB
-lXx
-lXx
-lXx
-lXx
+heG
+heG
+heG
+heG
 aBB
 aBB
 aBB
@@ -457759,18 +457927,18 @@ aBB
 aBB
 aBB
 aBB
-lXx
+heG
 aBB
 aBB
-lXx
-lXx
-lXx
+heG
+heG
+heG
 aBB
 aBB
 aBB
-lXx
-lXx
-lXx
+heG
+heG
+heG
 aBB
 aBB
 aBB
@@ -458212,15 +458380,15 @@ aBB
 aBB
 aBB
 aBB
-lXx
-lXx
+heG
+heG
 aBB
 aBB
-lXx
+heG
 aBB
 aBB
 aBB
-lXx
+heG
 aBB
 aBB
 aBB
@@ -458665,14 +458833,14 @@ aBB
 aBB
 aBB
 aBB
-lXx
+heG
 aBB
 aBB
-lXx
-lXx
-lXx
-lXx
-lXx
+heG
+heG
+heG
+heG
+heG
 aBB
 aBB
 aBB
@@ -487391,7 +487559,7 @@ kSK
 tvR
 oKQ
 vuu
-iaM
+vqf
 rbu
 rbu
 udU
@@ -487464,7 +487632,7 @@ aBB
 aBB
 aBB
 aBB
-ycv
+lVi
 aBB
 aBB
 aBB
@@ -487920,7 +488088,7 @@ bxz
 bxz
 bxz
 aBB
-ycv
+lVi
 aBB
 aBB
 aBB
@@ -488302,7 +488470,7 @@ jSr
 tvR
 pvg
 pvg
-rlj
+edA
 pvg
 cnL
 jIV
@@ -488374,7 +488542,7 @@ jWD
 jWD
 jWD
 aBB
-ycv
+lVi
 aBB
 aBB
 aBB
@@ -488819,19 +488987,19 @@ aBB
 bxz
 bxz
 bxz
-byw
+wku
 dif
 uJM
-unz
+rBS
 lkD
-rox
+dmn
 jWD
 jWD
 aBB
 aBB
-ycv
+lVi
 aBB
-ycv
+lVi
 jWD
 kGU
 kGU
@@ -489206,7 +489374,7 @@ rbu
 tvR
 imq
 imq
-lZj
+pHh
 rvn
 eKx
 tvR
@@ -489274,10 +489442,10 @@ bxz
 uyq
 hFR
 rQP
-tdO
+dZt
 cxC
 cxC
-lVI
+vUd
 jWD
 jWD
 jWD
@@ -489650,7 +489818,7 @@ kSK
 kSK
 tvR
 kat
-bPB
+lMU
 tvR
 rbu
 rbu
@@ -489731,16 +489899,16 @@ cxC
 cxC
 cxC
 cxC
-vIo
+qcy
 cxC
-wSG
+cRf
 cxC
 gjk
 gXN
 nKE
 vJA
 vJA
-hbH
+vNX
 dif
 bxz
 aBB
@@ -490627,23 +490795,23 @@ aBB
 aBB
 aBB
 kGU
-bNB
+tvc
 gyl
 tYQ
-xnn
-dHy
+lEo
+soG
 wtI
 fQS
-mlR
+syO
 cxC
 cxC
 cxC
 cxC
-uZy
-fZe
-mel
-mel
-cot
+dTL
+tPo
+dJj
+dJj
+oUJ
 smT
 uWq
 qTi
@@ -491001,10 +491169,10 @@ kSK
 fbg
 gvx
 pvg
-pKo
+rLa
 pvg
 gvx
-msQ
+rFN
 pvg
 pvg
 ePp
@@ -491014,7 +491182,7 @@ rbu
 tvR
 pvg
 pvg
-oCV
+hHG
 pvg
 cnL
 jIV
@@ -491088,17 +491256,17 @@ xlK
 wYH
 cjY
 rCh
-xkz
+jjM
 cxC
 cxC
 cxC
-ehR
+byw
 gPm
-cxH
-qUO
+sws
+vob
 cDc
-xGW
-tKY
+agN
+ptd
 xoe
 bxz
 aBB
@@ -491458,7 +491626,7 @@ pvg
 kat
 tvR
 kat
-bPB
+lMU
 tvR
 rbu
 rbu
@@ -491549,7 +491717,7 @@ qVi
 lGD
 ygf
 wMc
-vob
+lwX
 cDc
 nKE
 jWD
@@ -491994,16 +492162,16 @@ qTi
 vJA
 vJA
 mSD
-oaH
+wJA
 cxC
 rfR
 ygf
 ygf
-lWf
+tsK
 ygf
 nNa
-pvK
-nZu
+pBu
+ygc
 rdr
 jWD
 aBB
@@ -492357,10 +492525,10 @@ kSK
 tvR
 rbu
 rbu
-iaM
+vqf
 rbu
 rbu
-iaM
+vqf
 rbu
 kGT
 rbu
@@ -492445,14 +492613,14 @@ jWD
 vJA
 vJA
 vJA
-oKj
+cnp
 cxC
 llc
 rfR
 ygf
-cRQ
-xeJ
-rkg
+jwy
+tEb
+dpQ
 ygf
 wMc
 cDc
@@ -492895,19 +493063,19 @@ aBB
 aBB
 aBB
 kGU
-frC
+vSM
 vJA
-wbv
-sTA
+gFb
+eQE
 odv
 rfR
 mdB
-wCu
+wRt
 mTs
-hTS
+bZq
 ygf
 ygf
-pvK
+pBu
 dLx
 jWD
 aBB
@@ -493262,12 +493430,12 @@ tvR
 rbu
 rbu
 rbu
-gLC
+nxP
 rbu
 rbu
 rbu
 rbu
-gLC
+nxP
 rbu
 rbu
 gSn
@@ -493349,19 +493517,19 @@ aBB
 jWD
 vEO
 bwx
-nUJ
+wjp
 cxC
 nhl
-uRn
+lyD
 ygf
-iOt
-qaY
-bri
-lWf
+bFS
+iaM
+qNG
+tsK
 nNa
-pBu
-oJn
-maO
+lHJ
+sfL
+hZI
 aBB
 aBB
 aBB
@@ -493802,18 +493970,18 @@ aBB
 jWD
 vEO
 eJR
-wSG
+cRf
 cxC
 rfR
 nNa
-lWf
+tsK
 ygf
 ygf
 ygf
 ygf
-pvK
-oJn
-gby
+pBu
+sfL
+eGq
 aBB
 aBB
 aBB
@@ -494254,16 +494422,16 @@ aBB
 aBB
 jWD
 qtu
-qRm
+oiN
 cxC
 ivn
-fjp
+iOt
 ygf
 ygf
 mdB
 ygf
 tBQ
-eQf
+fWu
 uWq
 kGU
 aBB
@@ -494616,7 +494784,7 @@ bGf
 kSK
 fbg
 qEt
-eJz
+hml
 cnL
 tvR
 fVT
@@ -494625,7 +494793,7 @@ xdW
 cnL
 tvR
 ndh
-lPz
+nNP
 cnL
 rRi
 kSK
@@ -494715,7 +494883,7 @@ nNa
 ygf
 tBQ
 jTc
-xkz
+jjM
 bwx
 kGU
 aBB
@@ -495067,7 +495235,7 @@ bGf
 bGf
 kSK
 tvR
-pxl
+rwq
 pvg
 pvg
 tvR
@@ -495076,7 +495244,7 @@ xdW
 xdW
 pvg
 tvR
-pxl
+rwq
 pvg
 pvg
 tvR
@@ -495165,9 +495333,9 @@ cxC
 ivn
 jCB
 jCB
-eQf
-bDe
-pkU
+fWu
+ifC
+yeP
 eJR
 kGU
 aBB
@@ -495617,7 +495785,7 @@ nKE
 rkU
 cxC
 cxC
-xkz
+jjM
 osI
 fnp
 qJU
@@ -497424,7 +497592,7 @@ eZk
 scU
 nKE
 cxC
-xkz
+jjM
 vut
 lPL
 vJA
@@ -498333,8 +498501,8 @@ aRu
 cgn
 rQD
 dLa
-vUC
-wef
+tAM
+oFI
 wpd
 aBB
 aBB
@@ -498780,14 +498948,14 @@ jWD
 jAc
 cxC
 cxC
-uZy
+dTL
 uWq
 hVR
 nKE
-uZy
-wuP
-cHP
-bef
+dTL
+ooX
+kEG
+dak
 aBB
 aBB
 aBB
@@ -499234,13 +499402,13 @@ dLa
 cxC
 cxC
 cxC
-uZy
-qFK
+dTL
+dhG
 cxC
-mMD
-brR
-brR
-mCw
+rUk
+ehr
+ehr
+xmS
 aBB
 aBB
 aBB
@@ -499689,10 +499857,10 @@ cxC
 cxC
 cxC
 cxC
-brT
-rsN
-cak
-oUJ
+hlK
+fzT
+dLe
+jWQ
 aBB
 aBB
 aBB
@@ -500141,10 +500309,10 @@ cxC
 cxC
 cxC
 cxC
-brT
-tDB
-pmv
-plQ
+hlK
+dtz
+bZO
+dAW
 aBB
 aBB
 aBB
@@ -500593,10 +500761,10 @@ lNW
 mHw
 cxC
 cxC
-brT
-ikY
-wkM
-ciL
+hlK
+dds
+shY
+eRi
 aBB
 aBB
 aBB
@@ -501043,12 +501211,12 @@ nKE
 nKE
 nKE
 aRu
-ehh
+uxf
 cxC
-mkb
-brR
-brR
-cDJ
+dtc
+ehr
+ehr
+joN
 aBB
 aBB
 aBB
@@ -501496,10 +501664,10 @@ nKE
 nKE
 aRu
 lgU
-nNP
-wuP
-cHP
-fGf
+jmX
+ooX
+kEG
+lNP
 aBB
 aBB
 aBB
@@ -501949,8 +502117,8 @@ qTi
 wYH
 ntY
 dLa
-ceO
-sXF
+sYb
+pLo
 wpd
 aBB
 aBB
@@ -506468,7 +506636,7 @@ aBB
 aBB
 aBB
 bxz
-sgq
+svy
 qTi
 lgU
 jWD
@@ -507375,7 +507543,7 @@ aBB
 aBB
 jWD
 nKE
-jxy
+vXW
 jWD
 aBB
 aBB
@@ -507826,9 +507994,9 @@ aBB
 aBB
 aBB
 kGU
-wUK
+tPY
 vJA
-wUK
+tPY
 kGU
 aBB
 aBB

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -116,6 +116,11 @@
 "acj" = (
 /turf/open/floor/rogue/grassyel,
 /area/rogue/under/cave)
+"acn" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/rope,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "acD" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -125,6 +130,10 @@
 "acF" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave)
+"acQ" = (
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "acY" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -1101,6 +1110,10 @@
 	max_integrity = 50000
 	},
 /area/rogue/under/cave/mazedungeon)
+"arS" = (
+/turf/closed/wall/mineral/rogue/craftstone,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "arT" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile,
@@ -1145,11 +1158,26 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
+"asu" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot/stone,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "asw" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
+"asA" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/storage/backpack/rogue/satchel,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "asJ" = (
 /obj/effect/decal/cleanable/debris/glassy,
 /turf/open/floor/rogue/naturalstone,
@@ -1602,6 +1630,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter/woods)
+"azJ" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
+	},
+/obj/structure/flora/roguegrass/thorn_bush,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "azP" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood{
@@ -1641,16 +1676,23 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town/roofs)
-"aAv" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 4
+"aAs" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 10;
+	pixel_y = 0
 	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
+"aAv" = (
 /obj/structure/fluff/railing/border{
-	dir = 6
+	dir = 1
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/area/rogue/indoors/town/tavern)
 "aAy" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/blocks,
@@ -2391,6 +2433,10 @@
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"aMK" = (
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "aMX" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -2542,6 +2588,14 @@
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"aPu" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = 7
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "aPz" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -2641,6 +2695,10 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
+"aQJ" = (
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/indoors/town)
 "aQK" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -2773,6 +2831,12 @@
 	smooth_icon = null
 	},
 /area/rogue/indoors/town)
+"aTo" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "aTs" = (
 /obj/machinery/light/rogue/wallfire/candle/off/r,
 /turf/open/floor/rogue/metal,
@@ -2796,6 +2860,10 @@
 /obj/structure/far_travel,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains)
+"aTV" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "aTX" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -2809,6 +2877,10 @@
 /obj/effect/spawner/lootdrop/potion_ingredient/herb,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cave/skeletoncrypt)
+"aUe" = (
+/obj/item/natural/rock,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "aUk" = (
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/cobble/mossy,
@@ -2897,13 +2969,20 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
-"aWl" = (
-/obj/structure/flora/newleaf/corner{
-	dir = 6
+"aWd" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 1
 	},
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/grassred,
 /area/rogue/indoors/shelter/woods)
+"aWh" = (
+/obj/item/natural/rock,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
+"aWl" = (
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "aWn" = (
 /obj/structure/vine{
 	opacity = 1
@@ -3063,6 +3142,12 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/under/town/basement)
+"aYu" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "aYE" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/fluff/railing/border,
@@ -3277,6 +3362,10 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement/keep)
+"bbQ" = (
+/obj/structure/flora/hotspring_rocks/grassy,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "bbR" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/grass,
@@ -3289,6 +3378,14 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
+"bcf" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/obj/structure/bars/shop/bronze,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "bcl" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/dirt,
@@ -3310,6 +3407,10 @@
 /obj/structure/fermentation_keg,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"bcv" = (
+/obj/structure/vine,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "bcx" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/AzureSand,
@@ -3440,6 +3541,15 @@
 "bdZ" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/mazedungeon)
+"bef" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "bem" = (
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/shelter/mountains/decap)
@@ -4129,12 +4239,24 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblindungeon)
 "brh" = (
-/obj/structure/bed/rogue/inn/hay,
-/obj/effect/landmark/start/druid{
-	dir = 1
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	pixel_y = -4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
+"bri" = (
+/obj/structure/hotspring,
+/obj/effect/lily_petal,
+/obj/structure/hotspring/border/twelve{
+	pixel_y = 13;
+	pixel_x = -13
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "brv" = (
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/rogue/grassyel,
@@ -4156,6 +4278,9 @@
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
+"brR" = (
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "brS" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -4164,6 +4289,10 @@
 	smooth_icon = null
 	},
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"brT" = (
+/obj/structure/stairs,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "brW" = (
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
@@ -4288,9 +4417,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "btN" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/closed/wall/mineral/rogue/wooddark,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter/woods)
 "btP" = (
 /turf/closed/wall/mineral/rogue/tent{
@@ -4448,6 +4575,10 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
+"bvM" = (
+/obj/structure/flora/roguegrass/herb/random,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "bwp" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -4621,12 +4752,12 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/basement)
 "byw" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/flora/sakura{
+	pixel_x = -54;
+	pixel_y = 0
 	},
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/rtfield/eora)
 "byz" = (
 /obj/machinery/tanningrack,
 /turf/open/floor/rogue/hexstone,
@@ -4639,6 +4770,13 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
+"byK" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "byP" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/cobble,
@@ -4785,12 +4923,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "bAZ" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/leafless{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/obj/item/alch/salvia,
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "bBi" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -4922,6 +5057,13 @@
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
+"bDe" = (
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "bDg" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/rogue/torchholder/l,
@@ -4944,6 +5086,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"bDu" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "bDv" = (
 /obj/structure/rack/rogue,
 /obj/item/ingot/gold,
@@ -5202,9 +5350,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "bIK" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/rtfield/eora)
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "bJa" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -5325,6 +5475,12 @@
 /obj/structure/fluff/wallclock,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement)
+"bJI" = (
+/obj/structure/flora/newbranch{
+	dir = 8
+	},
+/turf/open/water/pond,
+/area/rogue/outdoors/woods)
 "bJM" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/herringbone,
@@ -5546,6 +5702,13 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/cell)
+"bNB" = (
+/obj/structure/flora/sakura{
+	pixel_x = -58;
+	pixel_y = -9
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "bNE" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/cell)
@@ -5624,6 +5787,11 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
+"bPB" = (
+/obj/structure/closet/crate/drawer,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "bPC" = (
 /obj/effect/decal/mossy{
 	dir = 4
@@ -5637,7 +5805,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "bPI" = (
 /obj/structure/fluff/railing/border{
@@ -5796,6 +5964,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter)
+"bSd" = (
+/obj/structure/table/wood{
+	icon_state = "longtable_mid"
+	},
+/obj/structure/rogue/trophy/deer,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "bSn" = (
 /obj/item/grown/log/tree/small,
 /turf/open/water/swamp,
@@ -5999,6 +6174,13 @@
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"bUW" = (
+/obj/structure/flora/roguegrass/bush,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "bUX" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/beach/forest)
@@ -6097,11 +6279,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter)
 "bXk" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/obj/item/rope,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/goblindungeon)
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/woods)
 "bXl" = (
 /obj/structure/fluff/walldeco/bigpainting{
 	pixel_x = 2
@@ -6179,7 +6359,11 @@
 /area/rogue/outdoors/exposed/town/keep)
 "bYj" = (
 /obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/ruinedwood/herringbone,
+/obj/structure/curtain/magenta{
+	color = 54202a;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
 "bYk" = (
 /obj/structure/chair/bench/ultimacouch/r,
@@ -6344,6 +6528,12 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
+"cak" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "cas" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -6407,6 +6597,13 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/dwarfin)
+"cbE" = (
+/obj/structure/bars/shop/bronze,
+/turf/open/water/river{
+	dir = 1;
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/woods)
 "cbR" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/dwarfin)
@@ -6437,6 +6634,11 @@
 /obj/effect/spawner/lootdrop/potion_ingredient,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/cave)
+"ccY" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "cdf" = (
 /obj/structure/roguerock,
 /turf/open/water/swamp,
@@ -6502,6 +6704,20 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"ceO" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/table/wood/folding,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "ceR" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -6727,6 +6943,16 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"ciL" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/mountains)
 "ciS" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt/road,
@@ -6759,6 +6985,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors)
+"cjd" = (
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = -5
+	},
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "cjj" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/cooking,
@@ -6979,6 +7211,10 @@
 "cne" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/town)
+"cni" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "cnj" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/blocks,
@@ -6997,6 +7233,13 @@
 /obj/item/clothing/suit/roguetown/armor/gambeson/lord,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"cnp" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink,
+/obj/machinery/light/rogue/wallfire/candle/floorcandle{
+	pixel_y = -14
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "cns" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/railing/border,
@@ -7046,6 +7289,15 @@
 	max_integrity = 5000
 	},
 /area/rogue/under/cave/mazedungeon)
+"cot" = (
+/obj/structure/chair/hotspring_bench/right{
+	dir = 4
+	},
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "coB" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor6-old"
@@ -7482,6 +7734,16 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
+"cvP" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "cvU" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -7628,6 +7890,10 @@
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/mountains)
 "cxC" = (
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
+"cxH" = (
+/obj/structure/hotspring/border/seven,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "cxP" = (
@@ -7914,7 +8180,7 @@
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "cDc" = (
 /obj/structure/hotspring/border,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "cDn" = (
 /obj/machinery/light/rogue/campfire/densefire,
@@ -7943,6 +8209,17 @@
 "cDB" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/under/cave/dukecourt)
+"cDJ" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/mountains)
 "cDU" = (
 /obj/effect/landmark/start/bogguardsman{
 	dir = 8;
@@ -7976,6 +8253,10 @@
 /obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/metal,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"cEy" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/woods)
 "cEz" = (
 /obj/structure/closet/dirthole,
 /turf/open/floor/rogue/dirt/road,
@@ -8112,14 +8393,22 @@
 /area/rogue/indoors/town)
 "cGL" = (
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/alt/pink,
+/obj/effect/lily_petal/two,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "cGN" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
+/obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"cGO" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle,
+/obj/item/alch/rosa,
+/obj/item/alch/rosa{
+	pixel_y = -7;
+	pixel_x = -13
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "cGT" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia,
 /turf/open/water/swamp/deep,
@@ -8156,9 +8445,11 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
 "cHP" = (
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/tavern)
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "cIe" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor6-old"
@@ -8293,6 +8584,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/underdark)
+"cKI" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 8;
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "cKK" = (
 /obj/item/cigbutt/roach{
 	pixel_x = 7;
@@ -8511,6 +8810,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/magician)
+"cML" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "cMM" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1
@@ -8684,6 +8987,11 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
+"cOP" = (
+/obj/item/natural/rock,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "cOS" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/newtree,
@@ -8820,6 +9128,11 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"cQR" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "cQS" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp/deep,
@@ -8876,6 +9189,21 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/underdark)
+"cRQ" = (
+/obj/structure/hotspring,
+/obj/effect/lily_petal/three,
+/obj/structure/hotspring/border/nine{
+	pixel_x = 13;
+	pixel_y = -15
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
+"cSb" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "cSx" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/whip,
@@ -8899,6 +9227,10 @@
 /obj/item/reagent_containers/glass/bottle/claybottle/wine,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"cSM" = (
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "cSN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia,
 /turf/open/floor/rogue/dirt,
@@ -8958,6 +9290,10 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
+"cTD" = (
+/obj/structure/vine,
+/turf/closed/wall/shroud,
+/area/rogue/outdoors/woods)
 "cTF" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -9126,7 +9462,6 @@
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/under/cave/licharena)
 "cWq" = (
-/obj/structure/flora/sakura,
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/falling_sakura,
@@ -9330,11 +9665,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "cZA" = (
-/obj/structure/flora/newleaf/corner{
-	dir = 6
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/fluff/railing/border,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "cZB" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt,
@@ -9467,6 +9802,14 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/mazedungeon)
+"dcl" = (
+/obj/structure/fluff/walldeco/stone{
+	icon_state = "walldec6";
+	pixel_y = -12;
+	pixel_x = 1
+	},
+/turf/closed/wall/mineral/rogue/decostone/fluffstone,
+/area/rogue/indoors/town/tavern)
 "dcn" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/cave)
@@ -9602,9 +9945,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "dfN" = (
-/obj/structure/flora/roguegrass/bush,
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "dfR" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -9672,6 +10017,12 @@
 /obj/structure/stone_tile/surrounding_tile/burnt,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"dgI" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "dgV" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -10079,6 +10430,11 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
+"doK" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/machinery/light/rogue/lanternpost,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "doY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/royalblack,
@@ -10118,6 +10474,12 @@
 "dpy" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/shelter/woods)
+"dpz" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "dpF" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/dirt/road,
@@ -10132,9 +10494,9 @@
 	},
 /area/rogue/under/cave/dukecourt)
 "dpQ" = (
-/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/goblindungeon)
+/area/rogue/outdoors/woods)
 "dqi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -10164,11 +10526,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
 "dqy" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/shelter/woods)
+/turf/open/water/river,
+/area/rogue/outdoors/mountains)
 "dqz" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -10341,7 +10700,9 @@
 /turf/open/water/ocean,
 /area/rogue/under/cave)
 "dsA" = (
-/obj/structure/flora/roguetree/wise,
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/shelter/woods)
 "dsC" = (
@@ -10439,6 +10800,10 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
+"duw" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "duA" = (
 /obj/effect/decal/wood/herringbone{
 	dir = 10;
@@ -10501,12 +10866,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "dwp" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/obj/structure/flora/newleaf{
-	icon_state = "tree1"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/vine,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "dwF" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia,
 /turf/open/water/swamp,
@@ -10606,6 +10968,12 @@
 "dyx" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave)
+"dyB" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "dyE" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -10645,7 +11013,7 @@
 /area/rogue/outdoors/town)
 "dzd" = (
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "dzh" = (
 /obj/machinery/light/rogue/lanternpost,
@@ -10870,6 +11238,11 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/woods)
+"dDi" = (
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "slittedwooddark"
+	},
+/area/rogue/outdoors/woods)
 "dDj" = (
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/twig,
@@ -10994,6 +11367,14 @@
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"dFv" = (
+/obj/effect/particle_effect/smoke{
+	lifetime = 14400
+	},
+/turf/open/water/river{
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/woods)
 "dFy" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/potion_ingredient/herb,
@@ -11020,11 +11401,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "dGk" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "dGl" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/cobble,
@@ -11095,6 +11474,13 @@
 /obj/item/rogueweapon/sword/decorated,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
+"dHy" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "dHA" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -11151,8 +11537,9 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/underdark)
 "dIr" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/bodypart/head/goblin,
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
+	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "dIu" = (
@@ -11324,6 +11711,10 @@
 /obj/structure/fluff/walldeco/psybanner,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/church/chapel)
+"dKU" = (
+/obj/machinery/gear_painter,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "dLa" = (
 /obj/machinery/light/rogue/torchholder/hotspring/standing,
 /turf/open/floor/rogue/grass,
@@ -11422,6 +11813,10 @@
 	},
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/mountains/decap)
+"dMR" = (
+/obj/item/natural/stone,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "dMS" = (
 /obj/structure/table/church,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -11632,10 +12027,9 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "dQi" = (
 /obj/structure/flora/newleaf,
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/leafless,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "dQo" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -11765,6 +12159,10 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"dSw" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "dSz" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/AzureSand,
@@ -11913,6 +12311,14 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/sewer)
+"dUx" = (
+/obj/structure/bed/rogue/inn/hay,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "dUy" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -12029,7 +12435,8 @@
 /obj/structure/fluff/statue/femalestatue2{
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/tile/brownbrick,
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
 "dWk" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -12207,6 +12614,11 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
+"dZH" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
+/obj/item/alch/rosa,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "dZM" = (
 /obj/machinery/light/rogue/oven/east,
 /turf/open/floor/rogue/hexstone,
@@ -12652,6 +13064,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
+"ehh" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 5
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "ehi" = (
 /obj/structure/chair/stool/rogue,
 /obj/structure/roguemachine/scomm/l,
@@ -12691,11 +13109,8 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "ehr" = (
-/obj/structure/chair/stool/rogue,
-/obj/structure/roguemachine/scomm{
-	scom_tag = "Druids' Tower"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/curtain/green,
+/turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/woods)
 "ehv" = (
 /obj/structure/roguewindow,
@@ -12721,6 +13136,11 @@
 "ehN" = (
 /turf/open/floor/rogue/snowpatchy,
 /area/rogue/outdoors/mountains)
+"ehR" = (
+/obj/structure/chair/hotspring_bench/left,
+/obj/effect/decal/mossy,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "ehT" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/beach)
@@ -12886,7 +13306,7 @@
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "ejS" = (
 /obj/structure/fluff/railing/wood{
@@ -13050,6 +13470,16 @@
 /obj/effect/decal/cleanable/blood/puddle,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors)
+"emf" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/newtree,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "emg" = (
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/cobble,
@@ -13404,6 +13834,9 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"ern" = (
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "err" = (
 /obj/item/natural/bone,
 /turf/open/floor/rogue/naturalstone,
@@ -13561,6 +13994,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
+"euz" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "euB" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -13643,7 +14082,8 @@
 /obj/structure/fluff/statue/femalestatue1{
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/tile/brownbrick,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
 "evu" = (
 /turf/open/lava,
@@ -14324,12 +14764,11 @@
 /turf/open/water/bloody,
 /area/rogue/indoors/shelter/mountains/decap)
 "eGq" = (
-/obj/structure/chair/stool/rogue,
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "eGx" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/outdoors/mountains)
@@ -14351,6 +14790,16 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
+"eGU" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/candle/yellow{
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "eHa" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
@@ -14371,9 +14820,11 @@
 /turf/closed/mineral/rogue/coal,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "eHC" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "eHJ" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt,
@@ -14473,6 +14924,10 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
+"eJz" = (
+/obj/effect/decal/carpet/kover_purple,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "eJC" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -14611,6 +15066,12 @@
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/shelter/mountains/decap)
+"eMp" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "eMr" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/naturalstone,
@@ -14686,14 +15147,11 @@
 	},
 /area/rogue/indoors/shelter/woods)
 "eOe" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/item/natural/rock,
+/turf/open/water/river{
+	icon_state = "rockwd"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/area/rogue/outdoors/mountains)
 "eOn" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt/road,
@@ -14799,6 +15257,14 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter)
+"eQf" = (
+/obj/structure/hotspring/border/three,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
+"eQi" = (
+/obj/structure/flora/rogueshroom/happy/mushroom4,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "eQn" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
@@ -14991,6 +15457,10 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
+"eTF" = (
+/obj/structure/fermentation_keg/water,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "eTJ" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -15664,14 +16134,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "fdJ" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
 	},
-/obj/structure/roguemachine/musicbox{
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
+/area/rogue/under/cave/goblindungeon)
 "fdL" = (
 /obj/structure/fluff/littlebanners,
 /turf/open/floor/rogue/grass,
@@ -15760,14 +16226,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/woods)
 "feV" = (
-/obj/structure/flora/newleaf/corner{
-	dir = 10
-	},
-/obj/structure/flora/newbranch/leafless{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "ffa" = (
 /obj/structure/fluff/customsign{
 	name = "TURN BACK NOW!!!"
@@ -16014,6 +16475,11 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach/forest)
+"fjp" = (
+/obj/structure/hotspring/border/eleven,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "fju" = (
 /turf/open/water/swamp,
 /area/rogue/under/cave)
@@ -16248,6 +16714,10 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"fmC" = (
+/obj/structure/vine,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "fmF" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16321,6 +16791,12 @@
 "fnC" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
+"fnG" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 5
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "fnJ" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/outdoors/bog)
@@ -16403,6 +16879,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"foS" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "foY" = (
 /obj/structure/bed/rogue/inn/double{
 	dir = 1
@@ -16427,6 +16909,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/cave)
+"fpq" = (
+/obj/structure/flora/roguetree/burnt{
+	pixel_y = 11
+	},
+/obj/structure/fluff/railing/border,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "fpx" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -16601,6 +17092,19 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"frC" = (
+/obj/structure/flora/sakura{
+	pixel_x = -57;
+	pixel_y = -3
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
+"frL" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "frP" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/horny_armor_spawner,
@@ -16726,7 +17230,7 @@
 /area/rogue/under/cave/goblinfort)
 "fus" = (
 /obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "fuw" = (
 /obj/structure/fluff/railing/border,
@@ -17019,6 +17523,15 @@
 /obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"fyO" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/machinery/light/rogue/cauldron,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "fyQ" = (
 /obj/item/bedsheet/rogue/double_pelt,
 /obj/structure/bed/rogue/inn/wooldouble,
@@ -17210,7 +17723,7 @@
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/manor)
 "fBJ" = (
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
 "fCh" = (
@@ -17222,6 +17735,14 @@
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
+"fCm" = (
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "fCr" = (
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/blocks,
@@ -17431,6 +17952,15 @@
 /obj/item/clothing/suit/roguetown/shirt/robe/mage,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"fGf" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "fGp" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/structure/fluff/walldeco/med5{
@@ -17521,6 +18051,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"fHG" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 9
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "fHT" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -17693,12 +18232,9 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "fKJ" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/connector{
-	dir = 1
-	},
+/obj/structure/flora/roguegrass/bush/wall,
 /turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/area/rogue/outdoors/mountains)
 "fKK" = (
 /obj/structure/bed/rogue/inn/hay{
 	dir = 1
@@ -17759,6 +18295,7 @@
 /obj/structure/chair/wood/rogue{
 	dir = 4
 	},
+/obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "fLP" = (
@@ -17820,6 +18357,16 @@
 	},
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
+"fMu" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
+/obj/machinery/light/rogue/wallfire/candle/floorcandle{
+	pixel_y = -14
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "fMw" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/outdoors/mountains)
@@ -17960,6 +18507,9 @@
 /area/rogue/under/cave/goblindungeon)
 "fPa" = (
 /obj/machinery/tanningrack,
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
 "fPd" = (
@@ -17983,6 +18533,11 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/cell)
+"fPD" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "fPO" = (
 /obj/structure/glowshroom,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -18056,6 +18611,9 @@
 /area/rogue/outdoors/beach/forest)
 "fQS" = (
 /obj/structure/flora/hotspring_rocks/small/five,
+/obj/effect/decal/mossy{
+	dir = 8
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "fQU" = (
@@ -18131,10 +18689,14 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/basement)
 "fRW" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
+/obj/effect/decal/cobbleedge{
+	dir = 4;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "fRX" = (
 /obj/structure/stairs/stone,
@@ -18359,6 +18921,13 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"fVL" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/connector{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "fVR" = (
 /obj/structure/closet/crate/drawer,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -18409,11 +18978,12 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
 "fWu" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "fWw" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -18590,11 +19160,14 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "fZe" = (
-/obj/structure/stairs{
-	dir = 8
+/obj/structure/chair/hotspring_bench/corner{
+	dir = 4
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "fZg" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/naturalstone,
@@ -18683,6 +19256,13 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/woods)
+"gbd" = (
+/obj/structure/bars,
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave/goblindungeon)
 "gbg" = (
 /obj/structure/fermentation_keg/random/water,
 /obj/machinery/light/rogue/torchholder/l,
@@ -18695,7 +19275,7 @@
 /obj/structure/roguemachine/atm{
 	location_tag = "Tavern Lobby"
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "gbq" = (
 /obj/structure/chair/stool/rogue,
@@ -18706,6 +19286,17 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/cavewet/bogcaves)
+"gby" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "gbU" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -18856,6 +19447,11 @@
 	},
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"ged" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/woodclub,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "gee" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/gloves/roguetown/fingerless_leather,
@@ -18921,6 +19517,12 @@
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"gfu" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "gfv" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -19036,6 +19638,15 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"ghB" = (
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/bed/rogue/inn/hay,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "ghJ" = (
 /mob/living/carbon/human/species/goblin/npc/hell,
 /turf/open/floor/rogue/grasscold,
@@ -19089,9 +19700,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "gjk" = (
-/obj/structure/flora/newbranch/leafless{
-	dir = 4
-	},
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/obj/effect/lily_petal,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield/eora)
 "gjo" = (
@@ -19347,10 +19957,7 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/under/underdark)
 "gpd" = (
-/obj/structure/chair/stool/rogue,
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
+/obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "gpe" = (
@@ -19610,6 +20217,16 @@
 	},
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
+"gry" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
+"grz" = (
+/obj/effect/lily_petal/three,
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "grA" = (
 /obj/item/clothing/suit/roguetown/shirt/dress/royal,
 /obj/item/clothing/wrists/roguetown/royalsleeves,
@@ -19909,7 +20526,7 @@
 /area/rogue/indoors/town/shop)
 "gwi" = (
 /obj/structure/fluff/walldeco/wantedposter,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "gwq" = (
 /obj/structure/roguerock,
@@ -20188,7 +20805,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "gAa" = (
 /obj/structure/rack/rogue,
@@ -20322,6 +20939,11 @@
 "gCJ" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/shelter)
+"gCO" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/natural/bundle/fibers/full,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "gCP" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/rogue/blocks,
@@ -20441,6 +21063,14 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"gEA" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/roguemachine/noticeboard{
+	pixel_y = -12;
+	pixel_x = 2
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "gEC" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/cobblerock,
@@ -20611,6 +21241,10 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter/mountains/decap)
+"gHx" = (
+/obj/structure/flora/roguegrass/herb/random,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "gHA" = (
 /obj/structure/bed/rogue/inn/hay{
 	dir = 1
@@ -20852,15 +21486,9 @@
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "gLC" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/obj/effect/landmark/start/druid{
-	dir = 1
-	},
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/area/rogue/indoors/town/tavern)
 "gLG" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt,
@@ -20980,7 +21608,7 @@
 	dir = 1;
 	name = "Innkeeper"
 	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
 "gOC" = (
 /obj/item/reagent_containers/glass/cup/silver{
@@ -21028,7 +21656,7 @@
 /area/rogue/indoors/town/tavern)
 "gPm" = (
 /obj/structure/hotspring/border/four,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "gPo" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
@@ -21120,6 +21748,12 @@
 	},
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/cave)
+"gRo" = (
+/obj/structure/hotspring{
+	icon_state = "lilypetals1"
+	},
+/turf/open/water/pond,
+/area/rogue/outdoors/woods)
 "gRy" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/railing/wood{
@@ -21188,7 +21822,7 @@
 /area/rogue/outdoors/town)
 "gSn" = (
 /obj/structure/fluff/clock,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "gSw" = (
 /obj/item/natural/stone{
@@ -21279,6 +21913,11 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach/forest)
+"gTC" = (
+/obj/structure/flora/newtree,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "gTH" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/beach/forest)
@@ -21455,11 +22094,17 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"gWt" = (
+/turf/open/floor/rogue/grass,
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
+	},
+/area/rogue/indoors/shelter/woods)
 "gWE" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "gWG" = (
 /obj/item/roguebin/water,
@@ -21517,9 +22162,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
 "gXi" = (
-/mob/living/carbon/human/species/goblin/npc/ambush,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cave/goblindungeon)
+/obj/structure/flora/newtree,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "gXk" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -21549,6 +22194,7 @@
 /area/rogue/under/town/sewer)
 "gXN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab/cabbit,
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "gXS" = (
@@ -21569,6 +22215,9 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
+"gYo" = (
+/turf/open/floor/rogue/grassyel,
+/area/rogue/indoors/town)
 "gYq" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/naturalstone,
@@ -21726,6 +22375,19 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter/mountains/decap)
+"haW" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/obj/structure/rack/rogue,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/item/rogueweapon/stoneaxe,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "haY" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt/road,
@@ -21810,6 +22472,11 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/physician)
+"hbH" = (
+/obj/effect/falling_sakura,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "hbQ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/rogue/hexstone,
@@ -21952,8 +22619,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "hds" = (
-/obj/effect/decal/remains/wolf,
-/obj/item/ammo_casing/caseless/rogue/arrow/stone,
+/obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
 "hdw" = (
@@ -22035,9 +22701,12 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/exposed/town/keep)
 "heG" = (
-/mob/living/carbon/human/species/goblin/npc/ambush,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/under/cave/goblindungeon)
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch{
+	dir = 1
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "hfa" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
@@ -22085,12 +22754,9 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/beach)
 "hfu" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/connector{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/obj/effect/wisp/prestidigitation,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "hfx" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/beach)
@@ -22367,6 +23033,10 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/underdark)
+"hjL" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "hkf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -22460,13 +23130,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "hlK" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/turf/closed/wall/shroud,
+/area/rogue/outdoors/woods)
 "hlN" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/outdoors/exposed/town/keep)
@@ -22533,9 +23198,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "hmM" = (
-/obj/structure/flora/hotspring_rocks/small/three,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/rtfield/eora)
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "hmQ" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/dirt/road,
@@ -22619,6 +23286,12 @@
 /obj/item/clothing/gloves/roguetown/chain,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
+"hon" = (
+/obj/structure/flora/roguetree/pine{
+	icon_state = "pine3"
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield)
 "hoo" = (
 /obj/structure/flora/rogueshroom{
 	pixel_y = -5
@@ -22718,14 +23391,13 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
 "hqA" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/fluff/pillow/magenta{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = 1
 	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "hqE" = (
 /obj/structure/flora/roguegrass/water/reeds{
 	pixel_y = 4
@@ -22789,6 +23461,12 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
+"hrm" = (
+/obj/structure/spider/stickyweb{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "hrn" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -23380,6 +24058,10 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/physician)
+"hyF" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "hyG" = (
 /obj/structure/fluff/psycross{
 	pixel_y = 15
@@ -23489,6 +24171,10 @@
 /obj/item/rogueweapon/huntingknife/idagger/steel,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"hAp" = (
+/obj/structure/vine,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "hAG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -23697,6 +24383,18 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/shelter/woods)
+"hDG" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "hDH" = (
 /obj/structure/rack/rogue,
 /obj/item/book/rogue/sword,
@@ -23722,6 +24420,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"hEi" = (
+/obj/effect/lily_petal/three{
+	icon_state = "lilypetals1"
+	},
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "hEo" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
@@ -23775,10 +24479,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
 "hEY" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/twig,
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
+	},
 /area/rogue/indoors/shelter/woods)
 "hFr" = (
 /turf/open/floor/rogue/cobble,
@@ -23909,18 +24613,9 @@
 	},
 /area/rogue/indoors/town/physician)
 "hHg" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "hHl" = (
 /turf/open/water/river{
 	dir = 8;
@@ -23932,9 +24627,11 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/woods)
 "hHG" = (
-/obj/effect/landmark/start/druid,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/effect/lily_petal/three{
+	icon_state = "lilypetals2"
+	},
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "hHJ" = (
 /obj/structure/bars/steel,
 /turf/open/floor/rogue/blocks,
@@ -24020,6 +24717,17 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"hJn" = (
+/obj/structure/flora/hotspring_rocks/small{
+	pixel_y = -17;
+	pixel_x = 8
+	},
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/clothing/under/roguetown/loincloth,
+/obj/item/soap/bath,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/woods)
 "hJo" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -24053,6 +24761,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/underdark)
+"hJW" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "hKh" = (
 /obj/structure/bars/pipe{
 	dir = 9
@@ -24135,10 +24850,14 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/goblinfort)
 "hLv" = (
-/obj/structure/well/fountain{
-	pixel_x = -16
+/obj/effect/decal/cobbleedge{
+	dir = 8;
+	pixel_y = 1
 	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/roguemachine/noticeboard{
+	pixel_y = 9
+	},
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "hLz" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -24179,13 +24898,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement)
 "hMt" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/connector{
+/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/woods)
 "hMv" = (
 /obj/structure/stairs{
 	dir = 1
@@ -24225,6 +24942,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cave/mazedungeon)
+"hMM" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "hMR" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -24514,6 +25238,9 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet/bogcaves)
+"hSt" = (
+/turf/closed/wall/mineral/rogue/decostone/fluffstone,
+/area/rogue/indoors/town/tavern)
 "hSE" = (
 /obj/item/natural/bowstring,
 /turf/open/floor/rogue/concrete,
@@ -24580,6 +25307,13 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
+"hTS" = (
+/obj/structure/hotspring,
+/obj/structure/hotspring/border/five{
+	pixel_y = 13
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "hUe" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -24634,6 +25368,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/shelter/woods)
+"hVz" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "hVG" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork{
@@ -24704,6 +25442,14 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town)
+"hWm" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 10;
+	pixel_y = 0;
+	pixel_x = 7
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "hWq" = (
 /obj/structure/mineral_door/wood/violet{
 	locked = 1
@@ -24918,7 +25664,10 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "iaa" = (
-/turf/open/floor/rogue/ruinedwood/herringbone,
+/obj/structure/curtain/magenta{
+	color = 54202a
+	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
 "iad" = (
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -24957,15 +25706,19 @@
 	},
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "iaM" = (
-/obj/effect/decal/cleanable/blood/gibs/core,
-/obj/effect/decal/cleanable/blood,
-/mob/living/simple_animal/hostile/retaliate/rogue/wolf,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/woods)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "iaP" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"iaY" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "ibc" = (
 /obj/structure/fluff/walldeco/painting/queen,
 /turf/closed/wall/mineral/rogue/decostone/long{
@@ -25494,6 +26247,10 @@
 /obj/structure/flora/newleaf,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"iiC" = (
+/obj/structure/flora/hotspring_rocks/small/three,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "iiJ" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/natural/stone,
@@ -25517,6 +26274,13 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
+"iiV" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/newtree,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "ijd" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -25634,6 +26398,12 @@
 /obj/structure/fluff/statue/scare,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
+"iko" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "ikr" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -25668,13 +26438,22 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "ikY" = (
-/obj/structure/flora/roguegrass/bush,
-/turf/open/floor/rogue/grassyel,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "ila" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave)
+"ilj" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "ilm" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -25744,6 +26523,7 @@
 /area/rogue/indoors/shelter)
 "imq" = (
 /obj/structure/closet/crate/roguecloset,
+/obj/item/candle/yellow,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "imz" = (
@@ -25835,6 +26615,12 @@
 "inF" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/mazedungeon)
+"inL" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "inM" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -26288,6 +27074,12 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
+"ium" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/woods)
 "iuA" = (
 /obj/structure/roguemachine/vendor/bathhouse,
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -26354,6 +27146,10 @@
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"ivZ" = (
+/obj/structure/vine,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/woods)
 "iwm" = (
 /obj/structure/vine{
 	opacity = 1
@@ -26466,6 +27262,11 @@
 /obj/item/ingot/blacksteel,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
+"iyc" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "iyf" = (
 /obj/structure/table/vtable/v2,
 /obj/item/roguegem/violet{
@@ -26551,11 +27352,9 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/shelter)
 "iAh" = (
-/obj/structure/closet/crate/chest/wicker,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/food,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/food,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/town)
 "iAB" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/grasscold,
@@ -26625,7 +27424,7 @@
 "iBx" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/goblindungeon)
+/area/rogue/indoors/shelter/woods)
 "iBC" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -26694,6 +27493,10 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/mountains/decap)
+"iCt" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water/pond,
+/area/rogue/outdoors/woods)
 "iCw" = (
 /obj/structure/bars/passage/shutter/open,
 /turf/open/floor/rogue/metal{
@@ -27211,9 +28014,7 @@
 	},
 /area/rogue/indoors/town)
 "iKO" = (
-/obj/structure/roguemachine/scomm/l{
-	scom_tag = "Tailor"
-	},
+/obj/structure/roguemachine/scomm/l,
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -27256,6 +28057,10 @@
 "iLo" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"iLt" = (
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "iLv" = (
 /obj/structure/chair/wood/rogue/chair3,
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
@@ -27458,6 +28263,14 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors)
+"iOg" = (
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/obj/effect/decal/cobble/mossy{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "iOk" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -27480,9 +28293,14 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
 "iOt" = (
-/obj/item/rogueweapon/huntingknife/stoneknife,
+/obj/structure/hotspring,
+/obj/effect/lily_petal/two,
+/obj/structure/hotspring/border/ten{
+	pixel_y = -19;
+	pixel_x = -14
+	},
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/rtfield/eora)
 "iOC" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/item/reagent_containers/glass/bottle,
@@ -27537,6 +28355,11 @@
 "iOX" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/shelter/woods)
+"iPf" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "iPh" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned,
@@ -27767,7 +28590,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "iTC" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -27992,12 +28815,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "iXm" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "iXq" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -28181,6 +29001,10 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"iZR" = (
+/obj/machinery/tanningrack,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "iZX" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 4
@@ -28412,6 +29236,12 @@
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"jdg" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "jdh" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -28685,6 +29515,17 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/shelter/woods)
+"jhf" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "jhm" = (
 /obj/structure/vine,
 /obj/effect/decal/cleanable/greenglow{
@@ -29016,12 +29857,15 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
 "jmL" = (
-/obj/item/rogue/instrument/lute,
-/obj/item/rogue/instrument/harp,
-/obj/item/rogue/instrument/guitar,
-/obj/item/rogue/instrument/flute,
-/obj/structure/closet/crate/chest/crate,
-/turf/open/floor/rogue/ruinedwood/herringbone,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/chair/stool/rogue,
+/obj/effect/decal/cobbleedge{
+	dir = 8;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "jmR" = (
 /obj/effect/decal/remains/human,
@@ -29281,6 +30125,15 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
+"jrR" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "jrV" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -29587,6 +30440,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/mountains/decap)
+"jxy" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "jxz" = (
 /obj/item/grown/log/tree/small,
 /obj/structure/table/wood{
@@ -29863,7 +30720,7 @@
 /area/rogue/outdoors/bog)
 "jCB" = (
 /obj/structure/hotspring/border/eight,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "jCC" = (
 /obj/item/rogue/painting/queen,
@@ -30040,6 +30897,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/under/cave/dukecourt)
+"jGc" = (
+/obj/structure/flora/roguegrass/thorn_bush,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "jGd" = (
 /obj/structure/fluff/pillow/magenta,
 /turf/open/floor/rogue/tile/harem,
@@ -30276,6 +31137,14 @@
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"jKc" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "jKf" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 8
@@ -30327,6 +31196,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter)
+"jKU" = (
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = 5
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "jKV" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/robber,
@@ -30340,6 +31215,11 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"jLH" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "jLU" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors)
@@ -30742,9 +31622,14 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"jST" = (
+/obj/machinery/light/rogue/torchholder/hotspring,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "jTc" = (
 /obj/structure/hotspring/border/three,
-/turf/open/floor/rogue/grass,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "jTf" = (
 /obj/structure/closet/crate/chest/crate,
@@ -30848,6 +31733,12 @@
 /obj/structure/roguemachine/vendor,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/shop)
+"jUT" = (
+/turf/open/floor/rogue/dirt/road,
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
+	},
+/area/rogue/indoors/shelter/woods)
 "jVh" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/golden{
@@ -31692,6 +32583,18 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"kio" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 9
+	},
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "kis" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/spawner/lootdrop/potion_vitals,
@@ -31733,6 +32636,20 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
+"kjw" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 8;
+	icon_state = "borderfall"
+	},
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "kjC" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/carpet/red,
@@ -31914,6 +32831,12 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"klO" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "klR" = (
 /obj/structure/stairs{
 	dir = 1
@@ -31936,6 +32859,13 @@
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
+"kmp" = (
+/obj/structure/flora/hotspring_rocks{
+	pixel_y = -8;
+	pixel_x = -9
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/woods)
 "kmz" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -32079,8 +33009,8 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
 "kqa" = (
-/obj/item/ammo_casing/caseless/rogue/arrow/stone,
-/turf/open/floor/rogue/grass,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/woods)
 "kqg" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -32179,6 +33109,15 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"ksx" = (
+/obj/structure/hotspring{
+	icon_state = "lilypetals2"
+	},
+/obj/structure/flora/newbranch{
+	dir = 8
+	},
+/turf/open/water/pond,
+/area/rogue/outdoors/woods)
 "ksA" = (
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /turf/open/floor/rogue/cobble,
@@ -32433,6 +33372,16 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
+"kwi" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "kwt" = (
 /obj/structure/bars/passage{
 	max_integrity = 3000;
@@ -32504,6 +33453,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"kwV" = (
+/obj/structure/closet/dirthole/grave,
+/obj/item/alch/rosa,
+/obj/effect/landmark/start/orphan,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "kxk" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/cobblerock,
@@ -32632,6 +33588,7 @@
 	dir = 5
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "kzp" = (
@@ -32813,6 +33770,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cave/mazedungeon)
+"kBO" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/newbranch{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "kBQ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -32924,6 +33888,15 @@
 /obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
+"kDm" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 5
+	},
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "kDx" = (
 /obj/item/roguestatue/aalloy,
 /turf/open/floor/rogue/naturalstone,
@@ -32934,6 +33907,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/cave)
+"kDA" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "kDC" = (
 /obj/structure/stairs{
 	dir = 4
@@ -32952,6 +33932,14 @@
 "kDS" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"kDV" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "kEf" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/table/wood{
@@ -33047,7 +34035,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/under/cave/goblindungeon)
+/area/rogue/indoors/shelter/woods)
 "kFq" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
@@ -33134,7 +34122,7 @@
 /area/rogue/indoors/town/church/chapel)
 "kGT" = (
 /obj/structure/fluff/walldeco/wantedposter/l,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "kGU" = (
 /obj/structure/flora/newtree,
@@ -33188,6 +34176,12 @@
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/carpet/red,
 /area/rogue/outdoors/mountains/decap)
+"kHS" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "kHY" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -33868,6 +34862,10 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement/keep)
+"kUO" = (
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "kVf" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -33876,6 +34874,14 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"kVg" = (
+/obj/structure/flora/hotspring_rocks,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
+"kVi" = (
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "kVm" = (
 /obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/woodturned,
@@ -33937,6 +34943,10 @@
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
+"kWi" = (
+/obj/structure/fluff/statue/knight/interior/r,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "kWj" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -34082,11 +35092,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
 "kYZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/wood,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "kZf" = (
 /obj/structure/fluff/railing/border{
@@ -34118,12 +35126,12 @@
 /turf/closed,
 /area/rogue/outdoors/mountains/decap)
 "kZU" = (
-/obj/structure/flora/newleaf{
-	icon_state = "tree1"
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
 	},
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "kZV" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -34137,6 +35145,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"kZX" = (
+/obj/effect/particle_effect/smoke,
+/turf/open/water/river{
+	dir = 1;
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/woods)
 "kZY" = (
 /obj/structure/stairs{
 	dir = 4
@@ -34191,8 +35206,7 @@
 /area/rogue/outdoors/exposed/town/keep)
 "laE" = (
 /obj/structure/roguemachine/scomm{
-	pixel_y = -32;
-	scom_tag = "Inn"
+	pixel_y = -32
 	},
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -34282,6 +35296,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"lca" = (
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "lch" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -34733,6 +35753,9 @@
 /obj/structure/flora/newbranch/leafless{
 	dir = 4
 	},
+/obj/effect/decal/mossy{
+	dir = 4
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "lkJ" = (
@@ -34863,6 +35886,11 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"lmg" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/machinery/light/rogue/torchholder,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "lmh" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -34911,6 +35939,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"lmS" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "lmV" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9;
@@ -35011,6 +36045,18 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
+"lop" = (
+/obj/structure/stairs,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "loq" = (
 /obj/structure/roguewindow,
 /obj/structure/fluff/railing/border{
@@ -35139,8 +36185,9 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "lpW" = (
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
+/obj/structure/vine,
+/turf/open/transparent/openspace,
+/area/rogue/under/cave/goblindungeon)
 "lpZ" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -35154,8 +36201,7 @@
 "lqg" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/roguemachine/scomm{
-	pixel_y = -32;
-	scom_tag = "Manor Courtyard"
+	pixel_y = -32
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
@@ -35229,6 +36275,14 @@
 "lro" = (
 /turf/open/water/ocean,
 /area/rogue/under/cave)
+"lry" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "lrE" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/item/rogueweapon/mace/wsword,
@@ -35416,8 +36470,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/orcdungeon)
 "ltx" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/chair/bench/church/smallbench,
+/obj/structure/well/fountain{
+	pixel_y = 5
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "ltD" = (
@@ -35486,8 +36541,7 @@
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors)
 "luC" = (
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/effect/decal/cleanable/blood,
+/obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "luD" = (
@@ -35929,7 +36983,7 @@
 /area/rogue/outdoors/town)
 "lBQ" = (
 /obj/structure/roguemachine/lottery_roguetown,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "lBV" = (
 /obj/structure/flora/roguegrass,
@@ -36431,6 +37485,12 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/woods)
+"lKJ" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "lKO" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -36653,6 +37713,11 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/chapel)
+"lNE" = (
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "slittedwooddark"
+	},
+/area/rogue/indoors/shelter/woods)
 "lNW" = (
 /obj/structure/flora/hotspring_rocks/small/four,
 /turf/open/floor/rogue/grass,
@@ -36747,6 +37812,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/roofs)
+"lPz" = (
+/obj/effect/decal/carpet,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "lPL" = (
 /obj/structure/flora/roguegrass/herb/salvia,
 /turf/open/floor/rogue/grass,
@@ -36998,6 +38067,13 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/town)
+"lVI" = (
+/obj/structure/flora/roguegrass/herb/salvia,
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "lVW" = (
 /obj/structure/stairs{
 	dir = 1
@@ -37010,9 +38086,10 @@
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/bog)
 "lWf" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/hotspring,
+/obj/item/alch/salvia,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "lWk" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/ruinedwood{
@@ -37098,11 +38175,8 @@
 	},
 /area/rogue/indoors/shelter/woods)
 "lXx" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/turf/closed/wall/shroud,
+/area/rogue/outdoors/mountains)
 "lXy" = (
 /obj/structure/closet/dirthole,
 /turf/open/floor/rogue/dirt/road,
@@ -37177,6 +38251,11 @@
 /obj/item/roguegem/random,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave)
+"lZj" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/globe,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "lZu" = (
 /obj/effect/spawner/roguemap/stump,
 /obj/structure/flora/roguegrass,
@@ -37193,6 +38272,10 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/orcdungeon)
+"lZD" = (
+/obj/structure/flora/rogueshroom/happy/mushroom4,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "lZJ" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -37275,6 +38358,16 @@
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"maO" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "maZ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -37420,7 +38513,7 @@
 	dir = 6
 	},
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "mdl" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -37543,11 +38636,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "mel" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/chair/hotspring_bench{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "meq" = (
 /obj/effect/decal/mossy{
 	dir = 8
@@ -37675,6 +38771,13 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"mgZ" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch{
+	dir = 4
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "mha" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -37697,6 +38800,11 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"mhp" = (
+/obj/item/natural/rock,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "mhs" = (
 /obj/structure/fermentation_keg/crafted,
 /obj/machinery/light/rogue/torchholder/l,
@@ -37844,6 +38952,18 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
+"mkb" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "mkj" = (
 /obj/structure/fluff/wallclock{
 	dir = 3
@@ -37959,12 +39079,14 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/dwarfin)
 "mlR" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/connector{
-	dir = 4
+/obj/effect/decal/mossy{
+	dir = 8
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "mlS" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -38127,6 +39249,12 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"moO" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "moR" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
@@ -38348,6 +39476,10 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
+"msQ" = (
+/obj/structure/fluff/walldeco/rpainting/forest,
+/turf/closed/wall/mineral/rogue/decostone/fluffstone,
+/area/rogue/indoors/town/tavern)
 "mtb" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/wood,
@@ -38361,6 +39493,10 @@
 /obj/structure/bars/pipe,
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"mtt" = (
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "mtv" = (
 /obj/structure/fluff/walldeco/painting,
 /turf/closed/wall/mineral/rogue/decostone,
@@ -38399,6 +39535,15 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin)
+"mtV" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "slittedwooddark"
+	},
+/area/rogue/outdoors/woods)
 "mtW" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -38472,6 +39617,15 @@
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave/dukecourt)
+"mvn" = (
+/obj/structure/fluff/railing/border{
+	pixel_y = -7
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "mvr" = (
 /turf/open/water/ocean/deep,
 /area/rogue/outdoors/beach/forest)
@@ -38608,11 +39762,16 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/shelter/mountains/decap)
 "mxB" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/connector{
+/obj/effect/decal/cobble/mossy{
+	dir = 10
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
+"mxC" = (
+/obj/structure/spider/stickyweb{
 	dir = 4
 	},
-/turf/open/floor/rogue/twig/platform,
+/turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "mxK" = (
 /turf/closed/wall/mineral/rogue/stone/red_moss,
@@ -38878,10 +40037,11 @@
 	},
 /area/rogue/indoors/town)
 "mBR" = (
-/obj/structure/flora/newleaf/corner{
-	dir = 9
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/transparent/openspace,
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grassred,
 /area/rogue/indoors/shelter/woods)
 "mBW" = (
 /obj/structure/flora/roguetree/stump/log{
@@ -38929,11 +40089,21 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/orcdungeon)
+"mCw" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/mountains)
 "mCR" = (
 /obj/structure/fluff/walldeco/rpainting/crown{
 	pixel_y = 32
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "mCW" = (
 /obj/machinery/light/rogue/hearth,
@@ -39053,6 +40223,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"mEG" = (
+/obj/effect/landmark/start/knavewench,
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "mEK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -39252,8 +40429,10 @@
 /area/rogue/indoors/town/dwarfin)
 "mHw" = (
 /obj/structure/flora/sakura,
-/obj/structure/flora/hotspring_rocks/small/four,
 /obj/effect/falling_sakura,
+/obj/effect/decal/cobble/mossy{
+	dir = 5
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "mHy" = (
@@ -39430,9 +40609,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church/chapel)
 "mKO" = (
-/obj/structure/roguetent,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/under/cave/goblindungeon)
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "mKP" = (
 /obj/structure/table/wood,
 /obj/item/cooking/platter/gold{
@@ -39567,6 +40746,19 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/basement)
+"mMD" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "mMF" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -39593,6 +40785,13 @@
 "mMU" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
+"mNc" = (
+/obj/structure/flora/newleaf,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/flashlight/flare/torch/lantern,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "mNd" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -39649,6 +40848,13 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/dwarfin)
+"mNN" = (
+/obj/structure/curtain/magenta{
+	color = 54202a;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "mNW" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -39914,8 +41120,11 @@
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "mSD" = (
-/obj/structure/flora/roguegrass,
 /obj/effect/falling_sakura,
+/obj/structure/flora/sakura{
+	pixel_x = -57;
+	pixel_y = -3
+	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/eora)
 "mSF" = (
@@ -39937,6 +41146,13 @@
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
+"mSR" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/leafless{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "mTd" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt,
@@ -39950,9 +41166,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/orcdungeon)
 "mTs" = (
-/obj/structure/hotspring,
-/obj/structure/flora/rock/pile/largejungle,
-/obj/effect/lily_petal,
+/obj/structure/eoran_pomegranate_tree{
+	pixel_y = 13;
+	pixel_x = -9
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "mTu" = (
@@ -40274,6 +41491,12 @@
 /obj/structure/fermentation_keg/random/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
+"mYM" = (
+/obj/structure/flora/roguetree/pine{
+	icon_state = "pine2"
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield)
 "mYQ" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -40550,7 +41773,7 @@
 /area/rogue/indoors/shelter/woods)
 "ndh" = (
 /obj/structure/chair/bench/coucha/r,
-/turf/open/floor/carpet/red,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "ndj" = (
 /mob/living/carbon/human/species/goblin/npc/cave,
@@ -40663,6 +41886,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/mazedungeon)
+"neM" = (
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "neO" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
@@ -40874,6 +42101,12 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
+"nhM" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "nhU" = (
 /obj/structure/bars/passage/shutter{
 	redstone_id = "golgothaone"
@@ -40960,7 +42193,7 @@
 	dir = 9
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "niV" = (
 /turf/open/floor/rogue/dirt/road,
@@ -41216,8 +42449,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
 "nmH" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/wood,
+/obj/structure/chair/stool/rogue,
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "nmK" = (
 /obj/structure/table/wood{
@@ -41429,6 +42663,13 @@
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"npi" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-e"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "npK" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -41662,12 +42903,8 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/cave/dukecourt)
 "nus" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/obj/item/rogueweapon/huntingknife/stoneknife,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/closed,
 /area/rogue/indoors/shelter/woods)
 "nuv" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
@@ -41971,6 +43208,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"nAs" = (
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
+	},
+/area/rogue/outdoors/woods)
 "nAH" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -42004,12 +43246,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "nAQ" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/rogueshroom/happy/mushroom2,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "nAZ" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grassred,
@@ -42369,6 +43608,10 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/cell)
+"nGj" = (
+/obj/structure/flora/roguegrass/herb/random,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "nGq" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -42620,8 +43863,7 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "nKD" = (
-/obj/effect/decal/cleanable/blood,
-/mob/living/carbon/human/species/goblin/npc/ambush,
+/obj/structure/flora/newleaf,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "nKE" = (
@@ -42732,6 +43974,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"nMk" = (
+/obj/structure/vine,
+/obj/structure/vine,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "nMB" = (
 /obj/effect/decal/cobbleedge{
 	pixel_y = 1
@@ -42752,6 +43999,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin)
+"nMH" = (
+/obj/structure/flora/hotspring_rocks/small/five,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "nMI" = (
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/wood/herringbone{
@@ -42798,10 +44049,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/mountains/decap)
 "nNP" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/connector,
-/turf/open/floor/rogue/twig/platform,
-/area/rogue/indoors/shelter/woods)
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "nNT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle/alchemical/conpot{
@@ -43034,6 +44286,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
+"nRo" = (
+/obj/structure/fluff/psycross/crafted,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "nRr" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -43328,6 +44584,20 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"nUJ" = (
+/obj/structure/table/church{
+	icon_state = "churchtable_end"
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals{
+	pixel_y = 9;
+	pixel_x = -12
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "nUP" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1;
@@ -43340,6 +44610,13 @@
 "nUS" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/roofs)
+"nUT" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "nUZ" = (
 /obj/item/ash,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -43415,9 +44692,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/woods)
 "nWo" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/roguetree/pine{
+	icon_state = "pine3"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "nWw" = (
 /obj/structure/fluff/walldeco/stone/bronze{
 	pixel_y = 32
@@ -43534,6 +44813,16 @@
 "nYS" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/cave/orcdungeon)
+"nYW" = (
+/obj/structure/flora/roguetree/wise{
+	pixel_x = 4
+	},
+/obj/machinery/light/rogue/firebowl/standing/blue{
+	pixel_y = 5;
+	pixel_x = 15
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "nZb" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -43577,6 +44866,12 @@
 "nZr" = (
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"nZu" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 10
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "nZA" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/town/roofs/keep)
@@ -43664,6 +44959,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"oaH" = (
+/obj/effect/lily_petal/two,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "oaL" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -43777,6 +45076,12 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
+"ocC" = (
+/obj/structure/roguewindow/harem3{
+	name = "Frosted Glass Window"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "ocH" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/blocks,
@@ -43860,10 +45165,9 @@
 	},
 /area/rogue/outdoors/beach/forest)
 "oei" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/leafless,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "oek" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/red,
@@ -44205,6 +45509,13 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield)
+"ojF" = (
+/obj/structure/spider/stickyweb{
+	dir = 1;
+	icon_state = "stickyweb2"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "ojI" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -44326,6 +45637,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/cave)
+"omv" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/woods)
 "omx" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/grass,
@@ -44372,6 +45689,10 @@
 "onI" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
+"onU" = (
+/obj/structure/flora/rogueshroom/happy/mushroom5,
+/turf/open/water/cleanshallow,
 /area/rogue/outdoors/woods)
 "onX" = (
 /obj/machinery/light/rogue/torchholder{
@@ -44602,6 +45923,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"orZ" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "osb" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor5-old"
@@ -44683,6 +46010,20 @@
 "oto" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/cand,
 /area/rogue/indoors/town)
+"otv" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/greenstone/runed,
+/area/rogue/outdoors/woods)
 "otR" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -44833,8 +46174,12 @@
 /area/rogue/under/town/sewer)
 "oxi" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"oxl" = (
+/obj/structure/glowshroom,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "oxo" = (
 /obj/structure/flora/roguegrass,
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
@@ -44989,6 +46334,12 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/mountains)
+"ozv" = (
+/obj/structure/flora/newbranch{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "ozx" = (
 /obj/effect/decal/carpet/kover_purple{
 	pixel_x = 16;
@@ -45046,6 +46397,17 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"oAo" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/obj/structure/fluff/statue/pillar{
+	pixel_y = 2;
+	pixel_x = 10
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "oAq" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 8
@@ -45060,6 +46422,10 @@
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
+"oAC" = (
+/obj/structure/flora/mushroomcluster,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "oAD" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -45147,12 +46513,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "oBU" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/flora/newbranch{
+	dir = 1
 	},
-/obj/item/candle/yellow/lit,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "oBY" = (
 /mob/living/carbon/human/species/dwarfskeleton/ambush/knight/summoned,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -45201,8 +46566,11 @@
 /area/rogue/under/town/sewer)
 "oCL" = (
 /obj/structure/flora/newleaf,
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/newbranch{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "oCN" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -45216,10 +46584,13 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "oCV" = (
-/obj/structure/hotspring,
-/obj/structure/flora/rock/jungle,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/eora)
+/obj/effect/decal/carpet/kover_black,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/tavern)
+"oDa" = (
+/obj/structure/vine,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "oDf" = (
 /obj/structure/rack/rogue,
 /obj/item/flashlight/flare/torch/lantern/copper,
@@ -45285,7 +46656,7 @@
 "oDG" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/fluff/clock,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "oDW" = (
 /turf/closed/wall/mineral/rogue/stone,
@@ -45309,6 +46680,12 @@
 	smooth_icon = null
 	},
 /area/rogue/indoors/town)
+"oEs" = (
+/obj/structure/flora/newbranch{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "oEt" = (
 /mob/living/carbon/human/species/elf/dark/drowraider,
 /turf/open/floor/rogue/blocks/platform,
@@ -45413,6 +46790,12 @@
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
+"oGr" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "oGu" = (
 /obj/structure/rack/rogue/shelf/big{
 	icon_state = "shelf_biggest";
@@ -45515,6 +46898,12 @@
 "oHH" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors)
+"oHL" = (
+/obj/structure/flora/newbranch{
+	dir = 4
+	},
+/turf/open/water/pond,
+/area/rogue/outdoors/woods)
 "oHM" = (
 /obj/structure/fluff/pillow/magenta{
 	pixel_x = 7
@@ -45574,6 +46963,14 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
+"oIC" = (
+/obj/structure/flora/hotspring_rocks{
+	pixel_y = -6;
+	icon_state = "bigrock_grass";
+	pixel_x = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "oID" = (
 /obj/structure/stairs{
 	dir = 4
@@ -45648,6 +47045,10 @@
 /obj/structure/vine,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/underdark)
+"oJn" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "oJs" = (
 /obj/random/spider,
 /turf/open/floor/rogue/cobblerock,
@@ -45690,6 +47091,19 @@
 "oKc" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/church/chapel)
+"oKj" = (
+/obj/effect/falling_sakura,
+/obj/structure/table/church,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals{
+	pixel_y = 6;
+	pixel_x = 11
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "oKp" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -45800,6 +47214,10 @@
 	},
 /turf/open/water/bloody,
 /area/rogue/indoors/shelter/mountains/decap)
+"oMo" = (
+/obj/item/natural/rock,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "oMA" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/blocks,
@@ -45921,7 +47339,7 @@
 /obj/structure/fluff/railing/border{
 	pixel_y = -7
 	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
 "oOv" = (
 /obj/structure/flora/roguetree/burnt,
@@ -46083,16 +47501,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach/forest)
 "oRq" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
+/obj/structure/curtain/magenta{
+	color = 54202a
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/area/rogue/indoors/town/tavern)
 "oRu" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/item/roguebin/water,
@@ -46109,6 +47522,10 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"oRN" = (
+/obj/effect/particle_effect/smoke,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "oRZ" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -46263,14 +47680,15 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/beach/forest)
 "oUJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
 	},
-/obj/effect/landmark/start/druid{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	pixel_y = 2
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/area/rogue/outdoors/mountains)
 "oUR" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -46387,6 +47805,20 @@
 /obj/item/kitchen/spoon/tin,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"oWZ" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/obj/effect/decal/carpet/kover_darkred{
+	pixel_y = -10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n";
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "oXa" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -46493,13 +47925,10 @@
 	},
 /area/rogue/indoors/town/manor)
 "oYh" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/alch/rosa,
-/obj/item/candle/eora/lit,
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
+/obj/structure/flora/newleaf,
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "oYo" = (
 /obj/item/roguegem/ruby,
 /obj/item/roguegem/ruby,
@@ -46570,6 +47999,12 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs/keep)
+"oZo" = (
+/turf/open/water/river{
+	dir = 8;
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/woods)
 "oZs" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -46986,6 +48421,13 @@
 /obj/effect/spawner/lootdrop/general_loot_mid/x3,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"pgb" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/connector{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "pgi" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -47096,6 +48538,11 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"phD" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/glowshroom,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "phE" = (
 /obj/structure/stairs{
 	dir = 1
@@ -47127,7 +48574,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "pic" = (
 /obj/item/book/rogue/arcyne,
@@ -47257,16 +48704,44 @@
 /obj/structure/fluff/statue/femalestatue{
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/tile/brownbrick,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
+"pkz" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/obj/structure/curtain/green,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "pkE" = (
 /mob/living/carbon/human/species/skeleton/npc/bogguard/master,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"pkK" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
+/obj/machinery/light/rogue/wallfire/candle/floorcandle{
+	pixel_y = -14
+	},
+/obj/item/alch/rosa{
+	pixel_y = -2;
+	pixel_x = -8
+	},
+/obj/item/alch/rosa{
+	pixel_y = -9;
+	pixel_x = 5
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "pkN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/ranged,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
+"pkU" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/hotspring_rocks/small/two,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "pkX" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/wood,
@@ -47323,6 +48798,16 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
+"plQ" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/mountains)
 "plY" = (
 /obj/structure/flora/sakura,
 /obj/structure/flora/roguegrass/herb/hypericum,
@@ -47345,6 +48830,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
+"pmv" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/rtfield/eora)
 "pmF" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -47357,6 +48846,13 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
+"pmJ" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "pnb" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
@@ -47400,7 +48896,7 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "poe" = (
 /obj/structure/fluff/walldeco/wantedposter/r,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "poh" = (
 /obj/structure/roguewindow/stained/zizo,
@@ -47464,12 +48960,9 @@
 	},
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "ppp" = (
-/obj/structure/flora/newleaf/corner{
-	dir = 6
-	},
-/obj/structure/flora/newleaf,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/vine,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/woods)
 "ppw" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/dirt,
@@ -47494,9 +48987,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/orcdungeon)
 "pqc" = (
-/obj/structure/flora/roguegrass/water,
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/floor/rogue/rooftop{
+	icon_state = "roofg"
+	},
+/area/rogue/outdoors/mountains)
 "pqi" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/carpet/royalblack,
@@ -47600,6 +49098,10 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
+"prF" = (
+/obj/structure/flora/roguegrass/thorn_bush,
+/turf/closed/wall/shroud,
+/area/rogue/outdoors/woods)
 "psb" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/ruinedwood{
@@ -47707,6 +49209,14 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/dwarfin)
+"ptR" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle,
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_x = -3;
+	pixel_y = -12
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "puw" = (
 /obj/structure/flora/roguetree/pine/dead,
 /turf/open/floor/rogue/dirt/road,
@@ -47793,9 +49303,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
 "pvE" = (
-/obj/structure/flora/newleaf,
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/grass,
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "slittedwooddark"
+	},
 /area/rogue/indoors/shelter/woods)
+"pvK" = (
+/obj/structure/hotspring/border/two,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "pvR" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 1
@@ -47890,7 +49406,7 @@
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "pxn" = (
 /obj/structure/fluff/railing/border{
@@ -48022,6 +49538,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"pyX" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "pzb" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/rogueweapon/hoe,
@@ -48210,6 +49733,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"pBi" = (
+/obj/structure/roguemachine/noticeboard{
+	pixel_y = -14;
+	pixel_x = 17
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "pBk" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -48239,12 +49769,17 @@
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "pBu" = (
 /obj/structure/hotspring/border/two,
-/turf/open/floor/rogue/grass,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals_dried,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "pBv" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon1/gethsmane)
+"pBz" = (
+/obj/effect/decal/cobble/mossy,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "pBB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -48515,7 +50050,7 @@
 /area/rogue/outdoors/beach)
 "pFU" = (
 /obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "pGa" = (
 /obj/effect/decal/cobbleedge{
@@ -48586,10 +50121,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
 "pHp" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/connector,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/turf/closed/wall/mineral/rogue/stone/moss,
+/area/rogue/outdoors/woods)
 "pHr" = (
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/outdoors/mountains)
@@ -48797,6 +50330,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"pKo" = (
+/obj/structure/fluff/walldeco/rpainting/crown,
+/turf/closed/wall/mineral/rogue/decowood,
+/area/rogue/indoors/town/tavern)
 "pKy" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte,
@@ -48831,6 +50368,11 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement/keep)
+"pKX" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/leafless,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "pKZ" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
@@ -48881,6 +50423,10 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
+"pLV" = (
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "pLW" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
@@ -49059,6 +50605,11 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
+"pPf" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/connector,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "pPg" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/wood{
@@ -49188,6 +50739,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"pRv" = (
+/turf/closed/wall/mineral/rogue/wooddark,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/woods)
 "pRw" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -49370,9 +50925,9 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "pUD" = (
-/obj/machinery/light/rogue/campfire/densefire,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/under/cave/goblindungeon)
+/obj/structure/flora/newtree,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "pUP" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4;
@@ -49622,6 +51177,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"pYc" = (
+/turf/open/transparent/openspace,
+/turf/closed/wall/mineral/rogue/wooddark/window,
+/area/rogue/indoors/shelter/woods)
 "pYe" = (
 /obj/structure/rack/rogue/shelf/big{
 	icon_state = "shelf_biggest";
@@ -49813,6 +51372,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
+"qaY" = (
+/obj/structure/hotspring,
+/obj/structure/hotspring/border/seven{
+	pixel_x = -18
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "qbp" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mole,
 /turf/open/floor/rogue/naturalstone,
@@ -49894,9 +51460,9 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
 "qcy" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/tavern)
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "qcH" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -50004,12 +51570,11 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/town/basement/keep)
 "qdI" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/structure/roguewindow/harem3{
+	name = "Frosted Glass Window"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/indoors/town/tavern)
 "qdJ" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/storage/backpack/rogue/satchel,
@@ -50048,6 +51613,12 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
+"qei" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/leafless,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "qej" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
@@ -50093,7 +51664,7 @@
 /area/rogue/indoors/town)
 "qfx" = (
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "qfA" = (
 /turf/open/floor/rogue/cobble/mossy,
@@ -50215,6 +51786,12 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"qhG" = (
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "slittedwooddark"
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "qhN" = (
 /obj/structure/bars/tough,
 /turf/closed/wall/mineral/rogue/pipe,
@@ -50812,6 +52389,18 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/church/chapel)
+"qro" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/turf/closed/wall/mineral/rogue/stone/moss,
+/area/rogue/outdoors/woods)
 "qrp" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -51303,11 +52892,15 @@
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap)
 "qzF" = (
-/obj/structure/flora/newleaf/corner{
-	dir = 5
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/rooftop{
+	icon_state = "roofg"
+	},
+/area/rogue/outdoors/mountains)
 "qzN" = (
 /obj/structure/bars/passage{
 	density = 0;
@@ -51442,6 +53035,12 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors)
+"qCf" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "qCg" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -51693,6 +53292,12 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
+"qFK" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 9
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "qFM" = (
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
@@ -51745,16 +53350,18 @@
 /obj/item/roguegem/random,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cave/orcdungeon)
+"qGz" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/yellow{
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/tavern)
 "qGH" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/structure/fluff/alch,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/turf/closed/wall/mineral/rogue/decostone/fluffstone,
+/area/rogue/outdoors/mountains)
 "qHa" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /obj/structure/rack/rogue,
@@ -51777,6 +53384,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"qHr" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "qHt" = (
 /obj/item/storage/bag/tray{
 	pixel_y = 32
@@ -51812,6 +53426,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"qHJ" = (
+/obj/structure/closet/crate/chest/wicker,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "qHN" = (
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -52095,13 +53713,8 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/shelter)
 "qKN" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/leafless{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/under/cave/goblindungeon)
 "qKX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -52122,6 +53735,12 @@
 "qLt" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"qLA" = (
+/turf/open/floor/rogue/dirt,
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
+	},
+/area/rogue/indoors/shelter/woods)
 "qLO" = (
 /obj/machinery/light/rogue/wallfire,
 /turf/closed/wall/mineral/rogue/pipe,
@@ -52133,6 +53752,9 @@
 /obj/item/clothing/suit/roguetown/armor/gambeson,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"qMb" = (
+/turf/closed/wall/mineral/rogue/stone/window/moss,
+/area/rogue/outdoors/woods)
 "qMv" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor6-old"
@@ -52390,6 +54012,11 @@
 /obj/item/broom,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement/keep)
+"qRm" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "qRn" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -52625,6 +54252,11 @@
 "qUM" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/shelter/mountains/decap)
+"qUO" = (
+/obj/structure/hotspring/border/seven,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals_dried,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "qUQ" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -52657,6 +54289,7 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "qVi" = (
 /obj/structure/hotspring/border/twelve,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "qVk" = (
@@ -52710,6 +54343,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/tavern)
+"qWI" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "qWJ" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -52755,13 +54394,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach)
 "qXx" = (
-/obj/structure/stairs{
-	dir = 4
-	},
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_y = 32
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "qXz" = (
 /obj/structure/table/wood{
@@ -52863,6 +54499,18 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"qYS" = (
+/obj/structure/vine,
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
+"qYZ" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_y = -11
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "qZa" = (
 /obj/effect/decal/wood/herringbone2{
 	dir = 8
@@ -53075,6 +54723,15 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"rcC" = (
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "rcR" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/blocks/paving,
@@ -53383,6 +55040,12 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/church/basement)
+"rib" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "ric" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -53452,6 +55115,33 @@
 /obj/structure/telescope,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"rjB" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/seeds/apple,
+/obj/item/seeds/apple,
+/obj/item/seeds/pear,
+/obj/item/seeds/pear,
+/obj/item/seeds/wheat/oat,
+/obj/item/seeds/wheat/oat,
+/obj/item/seeds/tea,
+/obj/item/seeds/tea,
+/obj/item/seeds/tangerine,
+/obj/item/seeds/tangerine,
+/obj/item/seeds/cabbage,
+/obj/item/seeds/cabbage,
+/obj/item/seeds/potato,
+/obj/item/seeds/potato,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/garlick,
+/obj/item/seeds/garlick,
+/obj/item/seeds/strawberry,
+/obj/item/seeds/plum,
+/obj/item/seeds/raspberry,
+/obj/item/seeds/blackberry,
+/obj/item/seeds/berryrogue,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "rjF" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/tunic,
@@ -53488,6 +55178,23 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"rjT" = (
+/obj/structure/roguetent,
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
+"rkg" = (
+/obj/structure/hotspring,
+/obj/effect/lily_petal/two,
+/obj/structure/hotspring/border/twelve{
+	icon_state = "hotspring_border_11";
+	pixel_y = 11;
+	pixel_x = 12
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "rkG" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -53531,9 +55238,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "rlj" = (
-/obj/structure/roguemachine/noticeboard,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/effect/decal/carpet/square,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "rlk" = (
 /obj/machinery/light/rogue/wallfire/candle/off/r,
 /obj/effect/decal/cobbleedge{
@@ -53757,7 +55464,7 @@
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
 "rot" = (
 /obj/structure/rack/rogue,
@@ -53775,6 +55482,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"rox" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "roJ" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -53992,10 +55706,21 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/sewer)
+"rsD" = (
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "rsI" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/fishmandungeon)
+"rsN" = (
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "rsR" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/woodturned,
@@ -54124,7 +55849,7 @@
 /area/rogue/indoors/town/tavern)
 "ruI" = (
 /obj/structure/chair/bench/couchablack,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "ruS" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -54209,11 +55934,9 @@
 /turf/open/water/swamp,
 /area/rogue/under/cave/fishmandungeon)
 "rwq" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/tavern)
+/obj/structure/vine,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "rwF" = (
 /obj/structure/chair/wood/rogue/throne,
 /turf/open/floor/rogue/wood,
@@ -54269,6 +55992,21 @@
 /obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
+"rxS" = (
+/obj/item/rogue/instrument/lute,
+/obj/item/rogue/instrument/harp,
+/obj/item/rogue/instrument/guitar,
+/obj/item/rogue/instrument/flute,
+/obj/structure/closet/crate/chest/crate,
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/curtain/magenta{
+	color = 54202a
+	},
+/obj/item/rogue/instrument/harp/handcarved,
+/obj/item/rogue/instrument/viola,
+/obj/item/rogue/instrument/hurdygurdy,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "rxV" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/red,
@@ -54670,15 +56408,19 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
 "rDI" = (
-/obj/structure/fluff/railing/fence{
-	dir = 8
-	},
+/obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "rDO" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
+"rDS" = (
+/obj/structure/flora/newbranch{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "rEl" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/carpet/red,
@@ -54788,6 +56530,10 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
+"rGn" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "rGo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/bars/passage{
@@ -54834,12 +56580,32 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/town/basement/keep)
+"rGN" = (
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "rGP" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
+"rGQ" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "rGS" = (
 /turf/open/floor/rogue/wood/herringbone{
 	smooth_icon = null
@@ -54865,6 +56631,13 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/pond,
 /area/rogue/outdoors/mountains)
+"rHc" = (
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "rHf" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -54977,11 +56750,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "rIw" = (
-/obj/structure/flora/newleaf/corner{
-	dir = 10
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/roguegrass/thorn_bush,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "rIx" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -55006,6 +56777,13 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/orcdungeon)
+"rJh" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch{
+	dir = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "rJz" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/shelter)
@@ -55018,6 +56796,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"rJH" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "rJQ" = (
 /obj/item/grown/log/tree/stick,
 /mob/living/carbon/human/species/skeleton/npc/ambush,
@@ -55107,6 +56889,12 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/under/town/basement/keep)
+"rLo" = (
+/obj/structure/flora/newbranch/connector{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "rLp" = (
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/dirt,
@@ -55184,6 +56972,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/cave)
+"rLY" = (
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "rMe" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -55233,7 +57025,7 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "rMT" = (
 /obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "rNp" = (
 /obj/structure/chair/stool/rogue,
@@ -55278,6 +57070,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"rOc" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "rOd" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/blocks/green,
@@ -55312,6 +57111,15 @@
 /obj/structure/fluff/walldeco/maidensigil/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/mazedungeon)
+"rOR" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "rOV" = (
 /obj/structure/stairs{
 	dir = 1
@@ -55403,6 +57211,17 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
+"rQG" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/obj/structure/fluff/statue/pillar{
+	pixel_y = 1;
+	pixel_x = -12
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "rQI" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -55470,6 +57289,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/cave)
+"rSb" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/glowshroom,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "rSp" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -55744,6 +57568,10 @@
 	},
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/beach/forest)
+"rWj" = (
+/obj/structure/roguetent,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/shelter/woods)
 "rWq" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave/dungeon1/gethsmane)
@@ -55883,6 +57711,11 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/town)
+"rZa" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "rZb" = (
 /obj/structure/bars,
 /obj/effect/decal/cobbleedge{
@@ -55954,6 +57787,20 @@
 "rZO" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"rZW" = (
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
+"sad" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "sai" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt/road,
@@ -56131,6 +57978,15 @@
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
+"sdj" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/item/alch/rosa,
+/obj/item/candle/eora/lit,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "sdm" = (
 /obj/machinery/light/rogue/wallfire/candle/off/l,
 /obj/structure/rack/rogue/shelf/biggest,
@@ -56142,6 +57998,15 @@
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
+"sdr" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/yellow{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/tavern)
 "sdS" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/blocks,
@@ -56227,6 +58092,10 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
+"sfJ" = (
+/obj/item/natural/rock,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "sfM" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -56271,6 +58140,13 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon1/gethsmane)
+"sgq" = (
+/obj/structure/flora/sakura{
+	pixel_x = -57;
+	pixel_y = -3
+	},
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/rtfield/eora)
 "sgr" = (
 /obj/structure/chair/bench/coucha/r{
 	can_buckle = 0
@@ -56767,8 +58643,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/mountains/decap)
 "smT" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/table/wood/folding,
+/obj/effect/decal/mossy{
+	dir = 4
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "smV" = (
@@ -56831,8 +58709,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "snu" = (
-/obj/structure/roguetent,
-/turf/open/floor/rogue/grassred,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/woods)
 "snw" = (
 /obj/structure/bars/steel{
@@ -57155,6 +59036,12 @@
 "srn" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"srr" = (
+/obj/item/storage/backpack/rogue/satchel,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "srw" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -57195,12 +59082,11 @@
 /area/rogue/outdoors/beach/forest)
 "sse" = (
 /obj/structure/flora/newleaf,
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/leafless{
-	dir = 8
+/obj/structure/flora/newbranch{
+	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/area/rogue/outdoors/mountains)
 "ssj" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -57275,6 +59161,11 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"stb" = (
+/obj/item/natural/stone,
+/obj/effect/wisp/prestidigitation,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "stc" = (
 /obj/structure/roguemachine/withdraw{
 	pixel_x = 32;
@@ -57303,6 +59194,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"stY" = (
+/obj/structure/hotspring{
+	icon_state = "lilypetals3"
+	},
+/turf/open/water/pond,
+/area/rogue/outdoors/woods)
 "sua" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/churchmarble,
@@ -57749,6 +59646,12 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center/no_teleport,
 /area/rogue/under/cave/licharena)
+"sBu" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "sBx" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/herringbone,
@@ -57774,10 +59677,9 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
 "sCr" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newleaf,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "sCt" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 8
@@ -57879,9 +59781,9 @@
 /turf/open/water/swamp,
 /area/rogue/under/town/sewer)
 "sFs" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "sFt" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -58032,6 +59934,13 @@
 /obj/item/bedsheet/rogue/wool,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark)
+"sIG" = (
+/obj/structure/vine,
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "sIJ" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/bush,
@@ -58191,6 +60100,10 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"sLU" = (
+/obj/structure/roguerock,
+/turf/open/water/cleanshallow,
+/area/rogue/under/cave/goblindungeon)
 "sLY" = (
 /obj/structure/table/wood{
 	icon_state = "longtable_mid"
@@ -58376,9 +60289,17 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "sPd" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/transparent/openspace,
+/obj/effect/decal/cobble/mossy{
+	dir = 6;
+	pixel_y = 0
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/grassred,
 /area/rogue/indoors/shelter/woods)
 "sPj" = (
 /turf/open/floor/rogue/naturalstone,
@@ -58649,6 +60570,12 @@
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
+"sSN" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "sSO" = (
 /obj/structure/well,
 /obj/item/reagent_containers/glass/bucket{
@@ -58678,6 +60605,10 @@
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"sTA" = (
+/obj/effect/lily_petal,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "sTD" = (
 /obj/structure/closet/crate/chest/gold{
 	locked = 1;
@@ -58898,6 +60829,18 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/church/basement)
+"sXF" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "sXG" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
@@ -58934,9 +60877,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "sYb" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/connector{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "sYi" = (
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
@@ -59291,6 +61237,11 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/water/bloody,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"tdO" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt/pink,
+/obj/effect/lily_petal/three,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "tdZ" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -59379,7 +61330,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "teY" = (
 /obj/effect/decal/cobbleedge{
@@ -59432,6 +61383,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter/mountains/decap)
+"tfT" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "tfW" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/naturalstone,
@@ -59466,6 +61423,10 @@
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/physician)
+"tgG" = (
+/obj/structure/table/church,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "tgR" = (
 /obj/effect/decal/mossy{
 	dir = 1
@@ -59592,6 +61553,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"tjL" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "tjV" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -59776,7 +61743,11 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
 "tmt" = (
-/obj/effect/decal/cleanable/blood,
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "tmC" = (
@@ -59892,9 +61863,16 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "toh" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/dirt/road,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	pixel_y = -4
+	},
+/obj/item/rogueweapon/huntingknife/stoneknife,
+/turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/woods)
 "tok" = (
 /obj/effect/decal/mossy{
@@ -60128,6 +62106,17 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
+"tso" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/closet/crate/chest/wicker,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "tsp" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -60230,6 +62219,11 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"ttU" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/roguegrass/thorn_bush,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "ttW" = (
 /obj/item/clothing/neck/roguetown/psicross/silver,
 /obj/structure/closet/crate/coffin,
@@ -60289,7 +62283,7 @@
 /area/rogue/outdoors/woods)
 "tvb" = (
 /obj/structure/hotspring/border/thirteen,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "tvg" = (
 /obj/structure/fluff/railing/border{
@@ -60568,6 +62562,12 @@
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
+"tzq" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 10
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "tzs" = (
 /obj/structure/gate/bars/preopen,
 /turf/open/floor/rogue/grass,
@@ -60685,13 +62685,24 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"tBw" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/globe,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
+"tBC" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "tBE" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/mountains/decap)
 "tBQ" = (
 /obj/structure/hotspring/border/nine,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "tBW" = (
 /obj/structure/closet/crate/drawer,
@@ -60845,6 +62856,12 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"tDB" = (
+/obj/structure/fluff/railing/border{
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "tDH" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -60942,6 +62959,13 @@
 	},
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
+"tFJ" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/mountains)
 "tFL" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grassyel,
@@ -61100,10 +63124,11 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
 "tJh" = (
-/obj/structure/flora/roguegrass/bush,
-/obj/structure/flora/roguegrass/bush/wall/tall,
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "tJi" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -61216,6 +63241,13 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
+"tKY" = (
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "tKZ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -61326,6 +63358,19 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"tMt" = (
+/obj/structure/flora/roguegrass/bush{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
+"tMy" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "tMN" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -61743,6 +63788,17 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/cave)
+"tUg" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "tUu" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/bed/rogue/inn,
@@ -62001,6 +64057,13 @@
 /obj/structure/fluff/walldeco/rpainting/crown,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
+"tXD" = (
+/obj/structure/roguemachine/noticeboard{
+	pixel_y = 7;
+	pixel_x = 15
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "tXL" = (
 /obj/structure/roguewindow,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -62130,7 +64193,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "tYQ" = (
-/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/obj/machinery/light/rogue/torchholder/hotspring/standing{
+	pixel_y = -10
+	},
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/eora)
@@ -62392,10 +64457,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "udL" = (
-/obj/structure/flora/roguegrass,
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
 	},
+/obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "udM" = (
@@ -62800,7 +64865,14 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "ujZ" = (
-/obj/structure/flora/hotspring_rocks/grassy,
+/obj/structure/flora/hotspring_rocks/grassy{
+	pixel_y = 0;
+	pixel_x = -5
+	},
+/obj/structure/flora/sakura{
+	pixel_y = -1;
+	pixel_x = -29
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "ukg" = (
@@ -62844,6 +64916,11 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
+"ukO" = (
+/obj/structure/vine,
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "ukX" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -62991,9 +65068,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
 "umA" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/vine,
+/turf/open/water/river,
+/area/rogue/outdoors/mountains)
 "umD" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
@@ -63034,6 +65111,10 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
+"unb" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "unq" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -63052,6 +65133,13 @@
 /obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
+"unz" = (
+/obj/structure/flora/hotspring_rocks/small,
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "unE" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/goblinfort)
@@ -63105,6 +65193,12 @@
 /obj/item/clothing/under/roguetown/loincloth/brown,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/basement)
+"uov" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains)
 "uoI" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -63517,6 +65611,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"uuE" = (
+/turf/open/water/river{
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/mountains)
 "uuS" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach)
@@ -63566,9 +65665,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
 "uvu" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "uvy" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/concrete,
@@ -63802,6 +65904,11 @@
 "uyR" = (
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
+"uyS" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "uyU" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -63887,6 +65994,15 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/orcdungeon)
+"uAa" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "uAh" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -63957,9 +66073,11 @@
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
 "uBd" = (
-/obj/structure/flora/roguegrass/water,
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/vine,
+/turf/open/water/river{
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/mountains)
 "uBe" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
@@ -64493,6 +66611,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/cave/dukecourt)
+"uJe" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
+	},
+/area/rogue/outdoors/mountains)
 "uJk" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -64550,7 +66676,9 @@
 	},
 /area/rogue/indoors/town)
 "uJM" = (
-/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/obj/machinery/light/rogue/torchholder/hotspring/standing{
+	pixel_y = -9
+	},
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
@@ -64623,6 +66751,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors)
+"uLg" = (
+/obj/item/natural/rock,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "uLp" = (
 /obj/structure/flora/roguegrass/thorn_bush,
 /obj/structure/fluff/railing/wood{
@@ -64729,6 +66861,13 @@
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/sewer)
+"uOG" = (
+/obj/structure/flora/hotspring_rocks/small{
+	pixel_x = -8;
+	pixel_y = 14
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/woods)
 "uOM" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -64761,6 +66900,12 @@
 "uPk" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/goblinfort)
+"uPm" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/woods)
 "uPn" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/rogue/blocks,
@@ -64844,9 +66989,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "uQv" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods)
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/woods)
 "uQC" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -64892,6 +67037,12 @@
 	},
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"uQR" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "uQS" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -64903,6 +67054,11 @@
 	},
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"uRn" = (
+/obj/structure/hotspring/border/five,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals_dried,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "uRv" = (
 /obj/structure/fluff/railing/fence,
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
@@ -65040,6 +67196,13 @@
 	icon_state = "horzw"
 	},
 /area/rogue/outdoors/rtfield)
+"uSZ" = (
+/obj/structure/curtain/magenta{
+	color = 54202a;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "uTb" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/floor/rogue/dirt,
@@ -65222,11 +67385,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "uWJ" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/connector,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/woods)
 "uWO" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -65258,6 +67418,14 @@
 /obj/item/book/rogue/naledi4,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
+"uXh" = (
+/obj/structure/flora/newleaf,
+/obj/structure/spider/stickyweb{
+	dir = 1;
+	icon_state = "stickyweb2"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "uXk" = (
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/under/cave/goblindungeon)
@@ -65415,9 +67583,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "uZy" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/tavern)
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "uZz" = (
 /obj/structure/shisha/hookah{
 	pixel_x = 14;
@@ -65613,6 +67783,9 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
+/obj/item/candle/candlestick/gold{
+	pixel_y = 10
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "vch" = (
@@ -65710,9 +67883,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/mountains/decap)
 "veg" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
+	},
+/area/rogue/indoors/shelter/woods)
 "vek" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
@@ -65796,6 +67970,11 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/sewer)
+"vfW" = (
+/obj/item/natural/rock,
+/obj/item/natural/stone,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "vgd" = (
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -66281,7 +68460,8 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "vob" = (
 /obj/structure/hotspring/border/seven,
-/turf/open/floor/rogue/grass,
+/obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "vod" = (
 /obj/structure/closet/dirthole/closed/loot,
@@ -66435,16 +68615,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
 "vqR" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "vrg" = (
 /obj/structure/table/church{
 	icon_state = "churchtable_mid_alt"
@@ -66571,15 +68744,12 @@
 /turf/open/water/cleanshallow,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "vtD" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "vtP" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -66818,6 +68988,10 @@
 "vxh" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"vxu" = (
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "vxB" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/rogueweapon/sickle{
@@ -66927,23 +69101,15 @@
 /area/rogue/outdoors/woods)
 "vzB" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "vzE" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch/leafless{
+	dir = 1
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "vzI" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/dirt/road,
@@ -67043,10 +69209,9 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "vAV" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/structure/bookcase/random/religion,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/cave/goblindungeon)
+/area/rogue/indoors/shelter/woods)
 "vAX" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -67191,6 +69356,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"vDI" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
+/obj/structure/flora/rogueshroom/happy/mushroom4,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "vDJ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/basement)
@@ -67238,6 +69408,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"vEB" = (
+/obj/structure/fluff/statue/knight/interior/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "vEE" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/farmer,
@@ -67340,6 +69514,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"vGk" = (
+/obj/structure/flora/newbranch/connector{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "vGn" = (
 /obj/structure/fluff/psycross{
 	pixel_x = -15;
@@ -67445,6 +69625,11 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/mountains/decap)
+"vIo" = (
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/obj/effect/lily_petal,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "vIp" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -67477,21 +69662,24 @@
 	},
 /area/rogue/outdoors/mountains)
 "vIC" = (
-/obj/structure/closet/crate/chest/wicker,
-/obj/item/seeds/apple,
-/obj/item/seeds/apple,
-/obj/item/seeds/potato,
-/obj/item/seeds/potato,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pipeweed,
-/obj/item/seeds/pipeweed,
-/turf/open/floor/rogue/grassred,
-/area/rogue/indoors/shelter/woods)
+/obj/effect/decal/cobble/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "vII" = (
 /obj/structure/fluff/statue/astrata/gold,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"vIK" = (
+/obj/effect/particle_effect/smoke{
+	lifetime = 14400
+	},
+/obj/item/natural/rock,
+/turf/open/water/river{
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/woods)
 "vIP" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -67762,6 +69950,10 @@
 /obj/item/gavelhammer,
 /turf/open/floor/rogue/carpet,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"vNA" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "vNB" = (
 /obj/structure/fluff/psycross/crafted,
 /turf/open/floor/rogue/dirt/road,
@@ -68056,6 +70248,12 @@
 /obj/structure/flora/newbranch/leafless,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town/roofs)
+"vSS" = (
+/obj/structure/table/church{
+	icon_state = "churchtable_mid"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "vSY" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -68198,6 +70396,19 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/woods)
+"vUC" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/table/wood/folding,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "vUD" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/concrete,
@@ -68237,9 +70448,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "vVH" = (
-/obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/twig/platform,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/newbranch,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "vVK" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/rogue/greenstone,
@@ -68581,6 +70792,13 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
+"waj" = (
+/obj/structure/roguewindow,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "trader_stock_shutter"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/shop)
 "waG" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/dirt,
@@ -68619,6 +70837,14 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
+"wbv" = (
+/obj/structure/table/church/m,
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "wbC" = (
 /obj/effect/decal/cleanable/debris/stony,
 /obj/effect/decal/cleanable/debris/stony{
@@ -68779,6 +71005,17 @@
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"wef" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "weg" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -68830,6 +71067,13 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
+"wfc" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "wfo" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/rope/chain,
@@ -68845,11 +71089,9 @@
 	},
 /area/rogue/under/cave/dukecourt)
 "wfE" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/item/natural/rock,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "wfG" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/rogueweapon/hoe/stone,
@@ -69252,6 +71494,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains/decap)
+"wkq" = (
+/turf/closed/wall/mineral/rogue/wooddark{
+	icon_state = "wooddark-k"
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "wkv" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -69281,6 +71529,12 @@
 /mob/living/carbon/human/species/human/northern/highwayman,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/mountains/decap)
+"wkM" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield/eora)
 "wkO" = (
 /obj/structure/mineral_door/wood/deadbolt/shutter{
 	dir = 8
@@ -69496,6 +71750,16 @@
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"wnN" = (
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/alt{
+	pixel_y = -14
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "woi" = (
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/carpet/royalblack,
@@ -69536,6 +71800,18 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"woL" = (
+/obj/structure/stairs,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/woods)
 "woN" = (
 /obj/structure/table/vtable/v2,
 /obj/item/candle/eora/lit,
@@ -69853,14 +72129,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "wuP" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
 	},
-/obj/structure/closet/crate/chest,
-/obj/item/clothing/neck/roguetown/psicross/dendor,
-/obj/item/clothing/neck/roguetown/psicross/dendor,
+/obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/area/rogue/outdoors/rtfield/eora)
 "wuZ" = (
 /obj/structure/closet/crate/chest/gold{
 	locked = 1;
@@ -69880,6 +72156,13 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"wvi" = (
+/obj/structure/bed/rogue/bedroll,
+/obj/effect/landmark/start/druid{
+	dir = 1
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "wvj" = (
 /obj/structure/mannequin/male,
 /obj/item/clothing/suit/roguetown/shirt/tunic/silktunic,
@@ -70306,6 +72589,13 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
+"wCu" = (
+/obj/structure/hotspring,
+/obj/structure/hotspring/border/two{
+	pixel_y = -20
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "wCB" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -70387,11 +72677,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/cell)
 "wDS" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/connector{
-	dir = 1
-	},
-/turf/open/floor/rogue/twig/platform,
+/obj/machinery/tanningrack,
+/turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/woods)
 "wEc" = (
 /obj/structure/roguemachine/scomm{
@@ -70469,6 +72756,7 @@
 /area/rogue/indoors/town)
 "wFh" = (
 /obj/structure/table/wood{
+	dir = 1;
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/eora/lit,
@@ -70583,6 +72871,13 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"wGa" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "wGh" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/newleaf,
@@ -70929,7 +73224,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "wLS" = (
 /obj/structure/fluff/walldeco/painting/queen,
@@ -70946,7 +73241,7 @@
 /area/rogue/indoors/cave)
 "wMc" = (
 /obj/structure/hotspring/border/ten,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
 "wMj" = (
 /mob/living/simple_animal/hostile/rogue/haunt,
@@ -70981,7 +73276,7 @@
 /obj/structure/chair/wood/rogue{
 	dir = 1
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "wMR" = (
 /obj/structure/mineral_door/wood{
@@ -71303,6 +73598,13 @@
 	},
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
+"wSb" = (
+/obj/structure/bearpelt{
+	pixel_y = -16;
+	pixel_x = -13
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "wSh" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -71336,6 +73638,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"wSG" = (
+/obj/effect/lily_petal/three,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/eora)
 "wSO" = (
 /obj/machinery/light/rogue/wallfire/candle/floorcandle/pink,
 /turf/open/floor/rogue/churchbrick,
@@ -71431,6 +73737,16 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"wUE" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 10;
+	pixel_y = 0
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/indoors/shelter/woods)
 "wUI" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -71438,6 +73754,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"wUK" = (
+/obj/structure/flora/roguegrass/herb/rosa,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "wUO" = (
 /obj/structure/fluff/walldeco/innsign{
 	pixel_x = -32
@@ -71448,6 +73768,11 @@
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/sewer)
+"wUZ" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "wVu" = (
 /obj/structure/fluff/walldeco/chains{
 	icon_state = "chains8"
@@ -71541,6 +73866,10 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"wWD" = (
+/obj/item/natural/stone,
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/woods)
 "wWG" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -71887,6 +74216,15 @@
 /obj/structure/glowshroom,
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"xbM" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/shelter/woods)
 "xbS" = (
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/dirt,
@@ -71999,11 +74337,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xdh" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/flashlight/flare/torch/lantern,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "xdi" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town)
@@ -72105,6 +74443,14 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/cave/goblinfort)
+"xeJ" = (
+/obj/structure/hotspring,
+/obj/structure/hotspring/border/eight{
+	pixel_y = 0;
+	pixel_x = 14
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "xeW" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/blocks,
@@ -72398,6 +74744,12 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
+"xkz" = (
+/obj/effect/decal/cobble/mossy{
+	dir = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "xkB" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -72668,6 +75020,13 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"xnn" = (
+/obj/structure/flora/roguegrass,
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/rtfield/eora)
 "xnr" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /turf/open/floor/rogue/wood,
@@ -72720,17 +75079,9 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield/eora)
 "xoi" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/effect/landmark/start/druid{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/flora/roguegrass/thorn_bush,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
 "xol" = (
 /obj/machinery/light/rogue/hearth,
 /obj/machinery/light/rogue/oven{
@@ -72761,6 +75112,7 @@
 /area/rogue/under/cave/skeletoncrypt)
 "xoF" = (
 /obj/structure/fluff/statue/femalestatue2,
+/obj/structure/flora/roguegrass/herb/rosa,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "xoK" = (
@@ -72804,10 +75156,23 @@
 "xpH" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town/roofs/keep)
+"xpJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/machinery/light/rogue/torchholder/hotspring/standing,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "xpO" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
+"xpP" = (
+/obj/item/restraints/legcuffs/beartrap/armed,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "xpQ" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/flora/roguegrass,
@@ -72901,6 +75266,10 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
+"xrP" = (
+/obj/structure/flora/hotspring_rocks/small/five,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "xrQ" = (
 /obj/structure/roguemachine/withdraw,
 /obj/machinery/light/rogue/torchholder/l,
@@ -72943,6 +75312,14 @@
 /obj/item/clothing/ring/silver,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/exposed/bath/vault)
+"xsx" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/structure/roguetent,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/shelter/woods)
 "xsz" = (
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/greenstone,
@@ -73167,12 +75544,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
 "xyi" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newleaf/corner{
-	dir = 6
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/vine,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "xyq" = (
 /obj/structure/chair/bench{
 	dir = 8
@@ -73277,12 +75651,12 @@
 /turf/open/floor/carpet/stellar,
 /area/rogue/outdoors/beach)
 "xAh" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/chair/wood/rogue{
+	dir = 8
 	},
+/obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/area/rogue/indoors/town/tavern)
 "xAk" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/tile,
@@ -73308,6 +75682,10 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
+"xAI" = (
+/obj/structure/flora/rogueshroom/happy/mushroom5,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "xAN" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 4;
@@ -73370,6 +75748,12 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement/keep)
+"xBr" = (
+/obj/structure/table/church{
+	icon_state = "churchtable_end"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "xBE" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder/spear,
 /turf/open/floor/rogue/church,
@@ -73419,6 +75803,13 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet/bogcaves)
+"xCw" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "xCx" = (
 /turf/closed/wall/mineral/rogue/wooddark/slitted,
 /area/rogue/outdoors/mountains)
@@ -73438,6 +75829,15 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"xCH" = (
+/obj/structure/flora/roguetree/stump{
+	pixel_y = 0;
+	pixel_x = -10
+	},
+/obj/structure/table/wood/folding,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "xCK" = (
 /turf/open/water/swamp,
 /area/rogue/under/town/sewer)
@@ -73721,6 +76121,10 @@
 /obj/structure/flora/roguetree/pine,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
+"xGB" = (
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/woods)
 "xGD" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 2
@@ -73746,6 +76150,15 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
+"xGW" = (
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/obj/effect/decal/cobble/mossy{
+	dir = 10
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "xHb" = (
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/rogue/wood,
@@ -73770,6 +76183,24 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"xHC" = (
+/obj/item/clothing/neck/roguetown/psicross/eora{
+	pixel_y = 4
+	},
+/obj/item/candle/eora/lit{
+	pixel_y = -2;
+	pixel_x = 13
+	},
+/obj/item/candle/eora/lit{
+	pixel_y = -2;
+	pixel_x = -14
+	},
+/obj/machinery/light/rogue/wallfire/candle/floorcandle/pink{
+	pixel_x = -1;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "xHF" = (
 /obj/structure/closet/crate/chest/lootbox,
 /obj/item/scomstone,
@@ -74013,6 +76444,12 @@
 "xMv" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"xMz" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "xMP" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/fluff/littlebanners{
@@ -74046,6 +76483,16 @@
 /obj/structure/flora/roguegrass/herb/rosa,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"xNG" = (
+/obj/structure/roguemachine/musicbox{
+	pixel_y = 21
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "xNH" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -74361,8 +76808,17 @@
 /area/rogue/indoors/shelter/woods)
 "xRV" = (
 /obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10
+	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/shelter/woods)
 "xSa" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
@@ -74473,9 +76929,18 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/shop)
 "xTn" = (
-/obj/structure/roguetent,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/greenstone/runed,
+/area/rogue/outdoors/woods)
 "xTs" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -74530,6 +76995,11 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"xVA" = (
+/obj/structure/chair/stool/rogue,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "xVD" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -74586,6 +77056,17 @@
 	dir = 1
 	},
 /area/rogue/indoors/town)
+"xWb" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
+	},
+/obj/structure/hotspring{
+	icon_state = "bigrock_grass";
+	pixel_x = 13;
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/woods)
 "xWd" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 8
@@ -74645,8 +77126,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter)
 "xXw" = (
-/obj/structure/chair/bench/coucha,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
 "xXA" = (
 /obj/structure/fireaxecabinet/south,
@@ -74666,6 +77150,14 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
+"xYg" = (
+/obj/structure/vine,
+/obj/structure/glowshroom{
+	icon_state = "glowshroom3"
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave/goblindungeon)
 "xYj" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
@@ -74744,12 +77236,11 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/cave)
 "xYX" = (
-/obj/structure/flora/newleaf,
-/obj/structure/flora/newbranch/leafless{
-	dir = 4
+/obj/structure/flora/newbranch{
+	dir = 1
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/woods)
+/turf/open/water/pond,
+/area/rogue/outdoors/woods)
 "xZb" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/naturalstone,
@@ -74785,6 +77276,10 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
+"xZJ" = (
+/obj/structure/closet/crate/chest/crate,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "xZK" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
@@ -75007,6 +77502,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter)
+"ycv" = (
+/obj/structure/flora/newbranch/leafless{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "ycA" = (
 /obj/item/natural/bone,
 /turf/open/water/swamp/deep,
@@ -75372,6 +77873,11 @@
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
+"yhT" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
+/obj/structure/vine,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
 "yhV" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grass,
@@ -75391,6 +77897,10 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"yim" = (
+/obj/structure/flora/hotspring_rocks/small,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/woods)
 "yix" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -75412,6 +77922,13 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
+"yiG" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newbranch{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "yiT" = (
 /obj/item/grown/log/tree/small{
 	pixel_x = -11;
@@ -136830,14 +139347,14 @@ brW
 brW
 brW
 iSu
+kjb
 thH
-oYh
+sdj
 mri
-qDj
-qDj
+wfc
 iSu
-brW
-brW
+oGr
+moO
 brW
 rqY
 rqY
@@ -137279,17 +139796,17 @@ qcr
 thH
 brW
 brW
-brW
-wTp
+gry
+fMu
 iSu
 eXt
 haH
-haH
+cSM
 haH
 wTp
 iSu
 evs
-brW
+euz
 brW
 brW
 egF
@@ -137731,17 +140248,17 @@ qcr
 olQ
 brW
 brW
-qDj
+rJH
 pkw
+hEi
 haH
 haH
 haH
+cSM
 haH
 haH
-haH
-haH
-kjb
-pHU
+wnN
+qDj
 brW
 brW
 tyf
@@ -138183,16 +140700,16 @@ qcr
 mri
 brW
 brW
-pHU
+qYZ
+cSM
+bAZ
+cSM
 haH
 haH
 haH
+bAZ
 haH
-haH
-haH
-haH
-haH
-haH
+cSM
 qDj
 brW
 brW
@@ -138635,17 +141152,17 @@ rqY
 qcr
 brW
 brW
-qDj
+cKI
 haH
 haH
+hHG
 haH
+cGO
+cSM
+grz
+cSM
 haH
-kjb
-haH
-haH
-haH
-haH
-qDj
+hqA
 brW
 brW
 egF
@@ -139087,17 +141604,17 @@ rqY
 vqt
 twQ
 brW
-qDj
+wFh
 haH
 haH
 haH
-pHU
+dZH
 dWg
-kjb
+xHC
 haH
 haH
 haH
-qDj
+wFh
 brW
 rqY
 rqY
@@ -139539,17 +142056,17 @@ rqY
 qcr
 brW
 brW
-qDj
+mri
+haH
+cSM
+haH
+haH
+pkK
 haH
 haH
 haH
 haH
-wTp
-haH
-haH
-haH
-haH
-kjb
+mri
 brW
 egF
 qfW
@@ -139991,15 +142508,15 @@ qcr
 thH
 brW
 brW
-kjb
+ptR
+hHG
+hEi
+cSM
 haH
 haH
-haH
-haH
-haH
-haH
-haH
-haH
+bAZ
+hHG
+cSM
 haH
 qDj
 brW
@@ -140443,16 +142960,16 @@ qcr
 olQ
 brW
 brW
-qDj
+rJH
 evs
 haH
+bAZ
 haH
+cSM
 haH
+cSM
 haH
-haH
-haH
-haH
-wTp
+cnp
 qDj
 brW
 srz
@@ -140895,17 +143412,17 @@ qcr
 gZo
 brW
 brW
-brW
-pHU
+bIK
+rOc
 iSu
 hyA
-haH
+cSM
 haH
 haH
 wTp
 iSu
 pkw
-brW
+euz
 brW
 egF
 wLu
@@ -141354,10 +143871,10 @@ nrq
 mri
 wFh
 gZo
-qDj
+qHr
 iSu
-brW
-brW
+frL
+dgI
 brW
 egF
 haH
@@ -159113,7 +161630,7 @@ lpq
 dCq
 dCq
 sJx
-xwO
+tsw
 xwO
 gTH
 gTH
@@ -159566,7 +162083,7 @@ lpq
 dCq
 dCq
 xwO
-xwO
+tsw
 gTH
 gTH
 gTH
@@ -202570,14 +205087,14 @@ jFA
 jFA
 jFA
 jFA
-jFA
+sZa
 jFA
 xkH
-xkH
-wRg
-wRg
 xkH
 wRg
+wRg
+xkH
+wRg
 xkH
 xkH
 jFA
@@ -202591,7 +205108,7 @@ jFA
 jFA
 jFA
 jFA
-xkH
+jFA
 xkH
 xkH
 eTA
@@ -203043,9 +205560,9 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-xkH
+jFA
+jFA
+jFA
 xkH
 wRg
 wRg
@@ -203493,11 +206010,11 @@ jFA
 jFA
 xkH
 xkH
-xkH
-xkH
-xkH
-xkH
-xkH
+jFA
+jFA
+jFA
+jFA
+jFA
 xkH
 wRg
 wRg
@@ -203921,27 +206438,9 @@ niV
 xkH
 xkH
 jFA
+sZa
 jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-jFA
-jFA
-jFA
+sZa
 jFA
 xkH
 xkH
@@ -203951,6 +206450,24 @@ xkH
 xkH
 xkH
 xkH
+xkH
+xkH
+xkH
+xkH
+xkH
+xkH
+jFA
+jFA
+jFA
+jFA
+xkH
+xkH
+xkH
+jFA
+jFA
+jFA
+jFA
+jFA
 xkH
 wRg
 wRg
@@ -204398,12 +206915,12 @@ jFA
 jFA
 jFA
 xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
+jFA
+jFA
+jFA
+jFA
+jFA
+jFA
 wRg
 lgV
 wRg
@@ -204839,7 +207356,7 @@ xkH
 jFA
 jFA
 jFA
-jFA
+sZa
 jFA
 jFA
 jFA
@@ -204851,12 +207368,12 @@ xkH
 jFA
 xkH
 xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
+jFA
+jFA
+jFA
+jFA
+jFA
+jFA
 wRg
 wRg
 wRg
@@ -205281,34 +207798,34 @@ jFA
 xkH
 xkH
 niV
-niV
-niV
+xoi
+hlK
+hlK
 cAO
 cAO
-cAO
-cAO
+hlK
+dpQ
+dpQ
+xkH
+jFA
+jFA
+jFA
+jFA
+jFA
+jFA
+sZa
+jFA
+jFA
+jFA
+jFA
 xkH
 xkH
-xkH
+sZa
+jFA
+sZa
 jFA
 jFA
 jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-eTA
-xkH
-xkH
-xkH
-xkH
-xkH
 wRg
 wRg
 tqy
@@ -205733,17 +208250,19 @@ jFA
 xkH
 niV
 niV
-niV
+prF
 cAO
 cAO
 cAO
 cAO
 cAO
-cAO
-cAO
+hlK
+hlK
 xkH
 jFA
 jFA
+sZa
+sZa
 jFA
 jFA
 jFA
@@ -205751,14 +208270,12 @@ jFA
 jFA
 jFA
 jFA
-jFA
-jFA
-jFA
+sZa
 xkH
 xkH
-xkH
-xkH
-xkH
+jFA
+eTA
+jFA
 jFA
 jFA
 xkH
@@ -206193,7 +208710,7 @@ uLV
 uLV
 cAO
 cAO
-xkH
+hlK
 jFA
 jFA
 jFA
@@ -206202,18 +208719,18 @@ jFA
 jFA
 jFA
 jFA
+sZa
+jFA
+jFA
+rIw
+dpQ
+xkH
+eTA
 jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-xkH
-xkH
-xkH
 jFA
-jFA
-xkH
 wRg
 wRg
 tqy
@@ -206636,7 +209153,7 @@ xkH
 niV
 xkH
 niV
-niV
+dIr
 cAO
 cAO
 uLV
@@ -206645,27 +209162,27 @@ uLV
 uLV
 cAO
 cAO
+hlK
+hlK
+xkH
+eGq
+xkH
+jFA
+jFA
+jFA
+xkH
+jFA
+jFA
+hlK
+hlK
 cAO
 cAO
 xkH
 xkH
-xkH
 jFA
 jFA
 jFA
-xkH
 jFA
-jFA
-xkH
-xkH
-cAO
-cAO
-xkH
-xkH
-xkH
-jFA
-jFA
-xkH
 wRg
 wRg
 evK
@@ -207088,8 +209605,8 @@ jFA
 xkH
 xkH
 niV
-niV
-cAO
+bDu
+hlK
 cAO
 uLV
 uLV
@@ -207101,23 +209618,23 @@ cAO
 cAO
 cAO
 cAO
+xdh
 xkH
 xkH
 xkH
 xkH
-xkH
-xkH
-xkH
+hlK
+hlK
 cAO
 cAO
 cAO
 cAO
-xkH
+dpQ
 niV
 xkH
 jFA
 jFA
-xkH
+jFA
 wRg
 agc
 tqy
@@ -207534,42 +210051,42 @@ xkH
 jFA
 jFA
 jFA
-jFA
+sZa
 jFA
 jFA
 jFA
 jFA
 niV
-niV
+bDu
+hlK
+cAO
+uLV
+uLV
+uLV
+uLV
+uLV
+uLV
+aWh
+uLV
+uLV
 cAO
 cAO
-uLV
-uLV
-uLV
-uLV
-uLV
-uLV
-uLV
-uLV
-cAO
-cAO
-cAO
+xdh
+eGq
 xkH
+hlK
+cAO
+cAO
+cAO
+cAO
+cAO
+cAO
+cAO
+sni
 xkH
-xkH
-xkH
-cAO
-cAO
-cAO
-cAO
-cAO
-cAO
-cAO
-niV
-xkH
+sZa
+sZa
 jFA
-jFA
-xkH
 wRg
 wRg
 lmE
@@ -207986,20 +210503,22 @@ jFA
 jFA
 jFA
 jFA
+sZa
 jFA
 jFA
-jFA
-jFA
+sZa
 jFA
 niV
-niV
-cAO
+bDu
+hlK
 cAO
 hBS
 uLV
 uLV
 uLV
 uLV
+ixl
+ixl
 uLV
 uLV
 uLV
@@ -208007,9 +210526,7 @@ cAO
 cAO
 cAO
 cAO
-cAO
-cAO
-cAO
+hlK
 cAO
 cAO
 cAO
@@ -208018,9 +210535,9 @@ cAO
 cAO
 cAO
 niV
-xkH
+eTA
 jFA
-jFA
+sZa
 xkH
 wRg
 wRg
@@ -208444,18 +210961,18 @@ jFA
 jFA
 jFA
 niV
-niV
+xPA
 cAO
 cAO
 hBS
 hBS
 hBS
-hBS
-uLV
-uLV
-uLV
-uLV
-uLV
+ixl
+ixl
+ixl
+ixl
+ixl
+ixl
 uLV
 uLV
 uLV
@@ -208889,7 +211406,7 @@ xkH
 xkH
 jFA
 jFA
-jFA
+sZa
 jFA
 jFA
 jFA
@@ -208897,24 +211414,24 @@ jFA
 jFA
 niV
 niV
+hlK
 cAO
-cAO
 hBS
 hBS
-hBS
-hBS
-hBS
-hBS
-uLV
-uLV
-uLV
-uLV
+ixl
+ixl
+ixl
+ixl
+ixl
+ixl
+ixl
+ixl
 uLV
 uLV
 cAO
 qvT
-qvT
-qvT
+sMc
+sMc
 qvT
 cAO
 cAO
@@ -209348,32 +211865,32 @@ jFA
 xkH
 xkH
 niV
+hlK
 cAO
 cAO
+hBS
+xyi
+ixl
+ixl
+ixl
+hBS
+ixl
+ixl
+ixl
+ixl
+aWh
+uLV
 cAO
-hBS
-hBS
-hBS
-hBS
-hBS
-hBS
-hBS
-hBS
-uLV
-uLV
-uLV
-uLV
-cAO
+sMc
+lpW
+lpW
 qvT
-cPy
-cPy
-qvT
 cAO
 cAO
 cAO
 cAO
 cAO
-niV
+dIr
 xkH
 jFA
 jFA
@@ -209795,36 +212312,36 @@ jFA
 jFA
 jFA
 jFA
-jFA
+sZa
 jFA
 xkH
 xkH
-niV
+xoi
 cAO
 cAO
 cAO
 hBS
+eXH
+ixl
+ixl
 hBS
 hBS
-hBS
-hBS
-hBS
-hBS
-hBS
-hBS
-hBS
+ixl
+ixl
+ixl
+ixl
 hBS
 uLV
 cAO
 qvT
 cPy
 cPy
-qvT
+sMc
 cAO
 cAO
 cAO
 cAO
-niV
+bDu
 niV
 xkH
 jFA
@@ -210251,34 +212768,34 @@ jFA
 jFA
 xkH
 xkH
-niV
+xoi
 cAO
 cAO
 cAO
 hBS
+aWh
+ixl
+xyi
 hBS
 hBS
-hBS
-hBS
-hBS
-hBS
-hBS
-hBS
-hBS
+ixl
+ixl
+ixl
+ixl
 hBS
 hBS
 cAO
 qvT
 jKI
 jKI
-qvT
+sMc
 cAO
 cAO
+sni
+bDu
+xPA
 niV
-niV
-niV
-niV
-xkH
+jFA
 sZa
 jFA
 jFA
@@ -210704,33 +213221,33 @@ jFA
 xkH
 niV
 niV
-xkH
+hlK
 cAO
 cAO
 moj
+eXH
+ixl
+eXH
 moj
-moj
-moj
-moj
 hBS
 hBS
 hBS
-hBS
-hBS
+ixl
+ixl
 hBS
 cAO
 cAO
 qvT
-nSB
-nSB
+gbd
+xYg
 qvT
 cAO
 cAO
-niV
+bDu
 niV
 niV
 xkH
-xkH
+jFA
 jFA
 sZa
 jFA
@@ -211156,33 +213673,33 @@ jFA
 jFA
 niV
 niV
-xkH
-xkH
+hlK
+pHp
+moj
+moj
+xyi
+eXH
+eXH
 moj
 moj
 moj
-moj
-moj
-moj
-moj
-moj
-moj
-moj
+aWh
+ixl
 hBS
 hBS
 cAO
-qvT
-qvT
+qKN
+fdJ
+pdH
 nSB
-nHm
 qvT
-cAO
-cAO
-niV
+nAs
+bcv
+xPA
 niV
 xkH
 jFA
-xkH
+jFA
 jFA
 jFA
 jFA
@@ -211609,7 +214126,7 @@ jFA
 niV
 xkH
 xkH
-xkH
+pHp
 moj
 moj
 moj
@@ -211618,24 +214135,24 @@ moj
 moj
 moj
 moj
-moj
-moj
+ixl
+ixl
 moj
 moj
 cAO
-qvT
+sMc
 fSn
-gXi
 nSB
-qvT
-cAO
-cAO
+nSB
+sLU
+eXH
+eXH
 niV
 niV
 xkH
-xkH
 jFA
 jFA
+sZa
 jFA
 xkH
 xkH
@@ -212061,7 +214578,7 @@ xkH
 xkH
 xkH
 xbS
-xkH
+pHp
 moj
 moj
 moj
@@ -212070,24 +214587,24 @@ moj
 moj
 moj
 moj
-moj
-moj
+ixl
+ixl
 moj
 moj
 cAO
-qvT
+sMc
 fSn
 nSB
 nSB
-qvT
-cAO
-cAO
+sAu
+bcv
+eXH
 niV
 niV
 xkH
-xkH
 jFA
 jFA
+sZa
 jFA
 xkH
 xkH
@@ -212512,8 +215029,8 @@ eXH
 xkH
 xkH
 xkH
-xkH
-xkH
+hlK
+hlK
 moj
 moj
 moj
@@ -212522,18 +215039,18 @@ moj
 moj
 moj
 moj
-ixl
+xyi
 mxP
 moj
 moj
 cAO
-qvT
-qvT
-qvT
-qvT
-qvT
-cAO
-cAO
+qKN
+fdJ
+nSB
+sAu
+sAu
+nAs
+bcv
 niV
 xkH
 xkH
@@ -212965,32 +215482,32 @@ eXH
 eXH
 eXH
 eXH
-xkH
-ixl
+hlK
+nAQ
 ixl
 moj
 moj
+oAC
+xyi
+yhT
+nAQ
 ixl
 ixl
-klH
 ixl
 ixl
+xyi
+xyi
 ixl
 ixl
-ixl
+eXH
 cAO
 cAO
-cAO
-cAO
-cAO
-cAO
-cAO
-niV
-niV
+oDa
+dIr
 xkH
 jFA
+sZa
 jFA
-xkH
 jFA
 uDZ
 jFA
@@ -213430,14 +215947,14 @@ gwq
 eXH
 eXH
 eXH
-klH
-cAO
-cAO
-cAO
-cAO
-cAO
-niV
-niV
+vDI
+eXH
+eXH
+bcv
+eXH
+nAs
+sni
+cML
 niV
 xkH
 jFA
@@ -213875,7 +216392,7 @@ nqS
 eXH
 eXH
 eXH
-eXH
+eHC
 eXH
 eXH
 eXH
@@ -213884,19 +216401,19 @@ eXH
 eXH
 eXH
 ixl
-cAO
-cAO
-cAO
-cAO
+eXH
+eXH
+eXH
+bcv
 niV
-wZR
 niV
+dIr
 xkH
 xkH
+sZa
 jFA
 jFA
-jFA
-jFA
+sZa
 jFA
 xkH
 wRg
@@ -214326,29 +216843,29 @@ fjG
 fjG
 fjG
 eXH
+oxl
 eXH
 eXH
+eHC
+eXH
+pHp
+pHp
 eXH
 eXH
-eXH
-elL
-eXH
-eXH
-eXH
+pHp
+pHp
 ixl
 ixl
-ixl
-ixl
-ixl
-xkH
-xkH
-xkH
-xkH
+xyi
+hrm
+eTA
+dDi
+xdh
 xkH
 jFA
 jFA
 jFA
-jFA
+sZa
 jFA
 xkH
 wRg
@@ -214781,24 +217298,24 @@ elL
 eXH
 eXH
 eXH
-eXH
-eXH
+eHC
+lKJ
 qDW
 eXH
 eXH
 eXH
 gwq
+xyi
+xyi
 ixl
 ixl
-ixl
-ixl
-xkH
-xkH
-xbS
-xkH
+cAO
+cAO
+lue
 xkH
 xkH
 xkH
+eTA
 jFA
 jFA
 jFA
@@ -215223,7 +217740,7 @@ jFA
 jFA
 jFA
 xkH
-smb
+xpP
 xkH
 ixl
 ixl
@@ -215233,9 +217750,9 @@ eXH
 eXH
 eXH
 eXH
-eXH
-eXH
-eXH
+lKJ
+eQi
+lKJ
 eXH
 eXH
 eXH
@@ -215671,23 +218188,23 @@ xkH
 xkH
 niV
 jFA
+sZa
 jFA
 jFA
 jFA
-jFA
-jFA
-jFA
-xkH
+eXH
+eXH
+oRN
 moj
 ixl
+nAQ
 ixl
-ixl
 eXH
 eXH
 eXH
 eXH
-eXH
-eXH
+lKJ
+eHC
 eXH
 eXH
 eXH
@@ -216123,27 +218640,27 @@ xkH
 xkH
 xkH
 xkH
+sZa
 jFA
 jFA
 jFA
-jFA
-jFA
-smb
-xkH
+ngr
+ngr
+kZX
 moj
 moj
 moj
-ixl
-eXH
+oAC
+oxl
 eXH
 eXH
 elL
 eXH
-eXH
+oxl
 gwq
 elL
 eXH
-eXH
+onU
 eXH
 eXH
 eXH
@@ -216576,16 +219093,16 @@ xkH
 niV
 xkH
 jFA
+sZa
 jFA
 jFA
-jFA
-niV
-xkH
-xkH
+eXH
+eXH
+oRN
 moj
 moj
 moj
-ixl
+xyi
 klH
 eXH
 eXH
@@ -216594,14 +219111,14 @@ eXH
 eXH
 eXH
 eXH
-ixl
+oAC
 ixl
 ixl
 ixl
 ixl
 ixl
 xkH
-xkH
+eTA
 eXH
 eXH
 eXH
@@ -217039,23 +219556,23 @@ hBS
 moj
 moj
 moj
-ixl
-ixl
+xyi
+nMk
 ixl
 eXH
 eXH
 eXH
 ixl
 ixl
-ixl
+xyi
 cAO
-ixl
+xyi
 cAO
 cAO
-niV
+oDa
 xkH
 xkH
-xbS
+xkH
 xkH
 xkH
 xkH
@@ -217483,7 +220000,7 @@ xkH
 xkH
 jFA
 niV
-niV
+hlK
 cAO
 cAO
 hBS
@@ -217493,24 +220010,24 @@ moj
 moj
 moj
 moj
-klH
+vDI
 eXH
 eXH
 eXH
 ixl
-ixl
+xyi
 cAO
 cAO
 cAO
 cAO
+oDa
 niV
-wZR
 xkH
 jFA
 xkH
 xkH
 xkH
-jFA
+sZa
 jFA
 jFA
 xkH
@@ -217955,13 +220472,13 @@ cAO
 cAO
 cAO
 cAO
-niV
+sni
 xkH
-xkH
+eTA
 jFA
 jFA
 xkH
-xkH
+eTA
 jFA
 jFA
 jFA
@@ -218395,8 +220912,8 @@ hBS
 hBS
 hBS
 hBS
-moj
-moj
+vfW
+ixl
 mxP
 eXH
 eXH
@@ -218407,7 +220924,7 @@ cAO
 cAO
 cAO
 cAO
-niV
+hlK
 niV
 xkH
 xkH
@@ -218849,7 +221366,7 @@ hBS
 hBS
 hBS
 moj
-ixl
+xyi
 eXH
 bmi
 bmi
@@ -218859,10 +221376,10 @@ cAO
 cAO
 cAO
 cAO
+hlK
+xoi
 niV
-niV
-niV
-xkH
+eTA
 jFA
 xkH
 xkH
@@ -219283,11 +221800,11 @@ jFA
 jFA
 jFA
 jFA
+sZa
+sZa
 jFA
 jFA
-jFA
-jFA
-jFA
+sZa
 jFA
 niV
 niV
@@ -219301,25 +221818,25 @@ hBS
 hBS
 moj
 moj
-ixl
+xyi
 ixl
 eXH
 bmi
 bmi
 eXH
 ixl
-ixl
+xAI
 cAO
 cAO
 cAO
 cAO
-niV
+xoi
 niV
 xkH
 jFA
 xkH
 xkH
-xkH
+jFA
 jFA
 jFA
 jFA
@@ -219738,7 +222255,7 @@ jFA
 jFA
 jFA
 jFA
-jFA
+sZa
 jFA
 jFA
 niV
@@ -219766,7 +222283,7 @@ cAO
 cAO
 cAO
 cAO
-niV
+sni
 niV
 xkH
 xkH
@@ -220219,11 +222736,11 @@ cAO
 cAO
 cAO
 cAO
-niV
+hlK
 xkH
 xkH
-xkH
-xkH
+jFA
+jFA
 jFA
 jFA
 jFA
@@ -220658,7 +223175,7 @@ moj
 cAO
 cAO
 cAO
-ixl
+lZD
 ixl
 ixl
 eXH
@@ -220672,9 +223189,9 @@ cAO
 cAO
 cAO
 niV
+eTA
 xkH
-xkH
-xkH
+jFA
 jFA
 jFA
 jFA
@@ -221099,16 +223616,16 @@ xkH
 jFA
 niV
 niV
-cAO
+pHp
 cAO
 moj
-moj
-xkH
-jFA
-jFA
-jFA
-cAO
-cAO
+pHp
+eTA
+dwp
+sZa
+tfT
+hlK
+hlK
 cAO
 cAO
 cAO
@@ -221126,7 +223643,7 @@ cAO
 niV
 xkH
 jFA
-xkH
+jFA
 jFA
 jFA
 eTA
@@ -221552,15 +224069,15 @@ xkH
 niV
 niV
 vWm
-cAO
+pHp
 moj
-xkH
+lue
 jFA
 jFA
-jFA
-xkH
+rIw
+dpQ
 mHL
-cAO
+hlK
 cAO
 cAO
 cAO
@@ -221574,11 +224091,11 @@ cAO
 cAO
 cAO
 cAO
-niV
+hlK
 xkH
 jFA
 jFA
-xkH
+jFA
 jFA
 jFA
 xkH
@@ -222004,13 +224521,13 @@ niV
 niV
 niV
 niV
-wZR
+bDu
+xPA
 niV
 niV
 niV
 niV
-niV
-niV
+bDu
 jVX
 cAO
 cAO
@@ -222026,11 +224543,11 @@ cAO
 cAO
 cAO
 cAO
-niV
-xkH
+hlK
+eTA
 jFA
 xkH
-xkH
+jFA
 jFA
 jFA
 xkH
@@ -222462,7 +224979,7 @@ niV
 niV
 niV
 niV
-wZR
+niV
 jVX
 cAO
 cAO
@@ -222911,11 +225428,11 @@ niV
 niV
 niV
 niV
-niV
+dIr
 xkH
 xkH
-xkH
-xkH
+dpQ
+xdh
 cAO
 cAO
 cAO
@@ -223363,11 +225880,11 @@ niV
 niV
 niV
 niV
-wZR
-niV
-jFA
-jFA
-xkH
+xoi
+xoi
+sZa
+dSw
+eTA
 cAO
 cAO
 cAO
@@ -223380,13 +225897,13 @@ eXH
 ixl
 cAO
 cAO
+xoi
 niV
-niV
-xkH
+eTA
 jFA
 xkH
 xkH
-xkH
+eTA
 jFA
 jFA
 xkH
@@ -223816,9 +226333,9 @@ xkH
 xkH
 xkH
 niV
-xkH
-jFA
-jFA
+eTA
+ojF
+dwp
 cAO
 cAO
 cAO
@@ -223831,13 +226348,13 @@ lal
 eXH
 ixl
 cAO
-niV
+hlK
 niV
 xkH
 xkH
 jFA
 jFA
-xkH
+eTA
 xkH
 jFA
 xkH
@@ -224264,11 +226781,11 @@ xkH
 xkH
 xkH
 xkH
+dpQ
 xkH
 xkH
 xkH
-xkH
-xkH
+sdo
 xkH
 xkH
 cAO
@@ -224282,12 +226799,12 @@ bmi
 bmi
 bmi
 eXH
-xkH
-niV
+hlK
+sni
 wZR
 xkH
 jFA
-jFA
+sZa
 jFA
 xkH
 xkH
@@ -224717,24 +227234,24 @@ xkH
 xkH
 xkH
 eTA
+dpQ
 xkH
 xkH
 xkH
 xkH
-xkH
-jFA
+sZa
 cAO
 cAO
 cAO
 cAO
-ixl
+xAI
 ixl
 cAO
 eXH
 bmi
 bmi
 eXH
-xkH
+hlK
 niV
 xkH
 xkH
@@ -225171,7 +227688,7 @@ jFA
 jFA
 xkH
 xkH
-xkH
+xbS
 xkH
 xkH
 xkH
@@ -225186,7 +227703,7 @@ eXH
 bmi
 bmi
 eXH
-xkH
+dpQ
 xkH
 xkH
 jFA
@@ -225630,7 +228147,7 @@ jFA
 jFA
 cAO
 cAO
-xkH
+dpQ
 xkH
 cAO
 cAO
@@ -226080,12 +228597,12 @@ xkH
 xkH
 niV
 niV
-jFA
-jFA
+hlK
+hlK
 jFA
 smb
-xkH
-xkH
+hlK
+eTA
 eXH
 bmi
 bmi
@@ -226098,7 +228615,7 @@ niV
 xkH
 xkH
 xkH
-jFA
+sZa
 jFA
 jFA
 jFA
@@ -226536,7 +229053,7 @@ xkH
 xkH
 xkH
 xkH
-xkH
+dpQ
 xkH
 eXH
 bmi
@@ -226548,7 +229065,7 @@ xkH
 xkH
 xkH
 xkH
-xkH
+eTA
 xkH
 jFA
 jFA
@@ -227426,7 +229943,7 @@ jFA
 jFA
 jFA
 jFA
-xkH
+jFA
 xkH
 xkH
 jFA
@@ -227877,7 +230394,7 @@ sZa
 sZa
 jFA
 jFA
-xkH
+jFA
 xkH
 xkH
 xkH
@@ -228328,8 +230845,8 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
+jFA
+jFA
 xkH
 xkH
 jFA
@@ -228780,8 +231297,8 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
+jFA
+jFA
 xkH
 xkH
 xkH
@@ -229233,7 +231750,7 @@ jFA
 jFA
 jFA
 jFA
-xkH
+jFA
 xkH
 jFA
 xkH
@@ -229684,9 +232201,9 @@ jFA
 jFA
 jFA
 sZa
-xkH
-xkH
-xkH
+jFA
+jFA
+jFA
 xkH
 xkH
 xkH
@@ -230137,10 +232654,10 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-xkH
-xkH
+jFA
+jFA
+jFA
+jFA
 xkH
 xkH
 xkH
@@ -230589,9 +233106,9 @@ jFA
 jFA
 jFA
 jFA
-xkH
-xkH
-xkH
+jFA
+jFA
+jFA
 jFA
 jFA
 jFA
@@ -231041,8 +233558,8 @@ jFA
 sZa
 jFA
 jFA
-xkH
-xkH
+jFA
+jFA
 jFA
 jFA
 jFA
@@ -231492,8 +234009,8 @@ xkH
 jFA
 jFA
 jFA
-xkH
-xkH
+jFA
+jFA
 jFA
 sZa
 jFA
@@ -238988,13 +241505,13 @@ iMd
 iMd
 iMd
 iMd
+iMd
+iMd
+iMd
 fii
 fii
 fii
 fii
-fii
-fii
-fii
 pSg
 pSg
 pSg
@@ -239004,8 +241521,8 @@ pSg
 pSg
 pSg
 pSg
-pxF
-fVo
+pSg
+pSg
 crw
 fVo
 pxF
@@ -239438,10 +241955,15 @@ iMd
 iMd
 iMd
 iMd
+iMd
+iMd
 fii
 fii
 fii
 fii
+fii
+fii
+fii
 pSg
 pSg
 pSg
@@ -239450,13 +241972,8 @@ pSg
 pSg
 pSg
 pSg
-njV
-njV
 pSg
-pSg
-pSg
-pxF
-pxF
+mYM
 fVo
 crw
 fVo
@@ -239884,14 +242401,16 @@ fii
 fii
 fii
 fii
+iMd
+iMd
+iMd
+iMd
+iMd
+iMd
 fii
 fii
 fii
 fii
-fii
-fii
-fii
-fii
 pSg
 pSg
 pSg
@@ -239900,13 +242419,11 @@ pSg
 pSg
 pSg
 pSg
+njV
+njV
 pSg
 pSg
-rZO
-rZO
-pxF
-pxF
-pxF
+pSg
 pxF
 pxF
 fVo
@@ -240337,11 +242854,12 @@ fii
 fii
 fii
 fii
-pSg
-pSg
-pSg
-pSg
-pSg
+fii
+fii
+fii
+fii
+fii
+fii
 fii
 pSg
 pSg
@@ -240351,15 +242869,14 @@ pSg
 pSg
 pSg
 pSg
-pxF
-pxF
+pSg
+pSg
 rZO
 rZO
 pxF
-dYq
-sNZ
-seL
-xbo
+pxF
+pxF
+pxF
 pxF
 fVo
 crw
@@ -240788,30 +243305,30 @@ pSg
 pSg
 pSg
 pSg
+fii
 pSg
 pSg
-lRD
+pSg
+pSg
+pSg
+fii
+pSg
+pSg
+pSg
+pSg
+pSg
+pSg
+pSg
+pSg
+mYM
+pxF
+rZO
+rZO
+pxF
+dYq
 sNZ
-pSg
-pSg
-pSg
-pSg
-pSg
-pSg
-pxF
-faM
-pxF
-pxF
-pxF
-pxF
-pxF
-pxF
-pxF
-pxF
-pxF
-ibp
-sNZ
-sNZ
+seL
+xbo
 pxF
 fVo
 crw
@@ -241242,28 +243759,28 @@ pSg
 pSg
 pSg
 pSg
+lRD
 sNZ
-quW
+pSg
+pSg
+pSg
+pSg
+pSg
+pSg
+hon
+faM
+pxF
+pxF
+pxF
+pxF
+pxF
+rZO
+pxF
+pxF
+pxF
+ibp
 sNZ
-pxF
-pSg
-pSg
-pSg
-pxF
-emv
-pxF
-pxF
-pxF
-dfN
-bhg
-bhg
-bhg
-dfN
-pxF
-pxF
-aXW
-pxF
-dYq
+sNZ
 pxF
 fVo
 crw
@@ -241692,30 +244209,30 @@ pxF
 pxF
 pxF
 pxF
-pxF
+pSg
+pSg
+sNZ
 quW
 sNZ
-seL
 pxF
-faM
-quW
+pSg
+pSg
+pSg
+pxF
+emv
+pxF
+pxF
+aXW
+sNZ
+sNZ
+sNZ
+rZO
+sNZ
 pxF
 pxF
 aXW
 pxF
-pxF
-dfN
-bhg
-umH
-pqc
-mGK
-pqc
-umH
-umH
-bhg
-pxF
-pxF
-pxF
+dYq
 pxF
 fVo
 crw
@@ -242145,28 +244662,28 @@ pxF
 mGv
 pxF
 pxF
+quW
+sNZ
+seL
 pxF
+faM
 quW
 pxF
 pxF
-pxF
-pxF
-pxF
-pxF
-emv
-dfN
-umH
-umH
-pSM
-psV
-psV
-psV
-psV
-psV
-pSM
-umH
-bhg
-pxF
+aXW
+sNZ
+sNZ
+sNZ
+sNZ
+sNZ
+rZO
+rZO
+sNZ
+ibp
+ibp
+ibp
+sNZ
+sNZ
 pxF
 pxF
 fVo
@@ -242596,30 +245113,30 @@ pxF
 pxF
 pxF
 pxF
-mGv
 pxF
 pxF
+quW
+pxF
+pxF
+pxF
+pxF
+pxF
+pxF
+emv
 sNZ
+sNZ
+sNZ
+sNZ
+rZO
+rZO
+sNZ
+sNZ
+cFz
+ibp
+ibp
+sNZ
+seL
 pxF
-mGv
-pxF
-pxF
-pxF
-pxF
-bhg
-uBd
-qzg
-pfw
-pfw
-pfw
-pfw
-pfw
-pfw
-qzg
-pSM
-nWo
-bhg
-faM
 pxF
 fVo
 fVo
@@ -243048,32 +245565,32 @@ pxF
 faM
 pxF
 pxF
-sNZ
-wxw
-bsL
-sNZ
-quW
-sNZ
-quW
-emv
-pxF
-bQc
-umH
-dsA
-pfw
-pfw
-pfw
-pfw
-mlS
-pfw
-pfw
-pfw
-qzg
-eHC
-umH
-bQc
+mGv
 pxF
 pxF
+sNZ
+pxF
+mGv
+pxF
+pxF
+pxF
+pxF
+sNZ
+seL
+sNZ
+sNZ
+rZO
+sNZ
+sNZ
+cFz
+cFz
+omD
+sNZ
+sNZ
+sNZ
+faM
+pxF
+fVo
 fVo
 crw
 fVo
@@ -243500,30 +246017,30 @@ mGv
 pxF
 pxF
 pxF
-quW
+sNZ
+wxw
 bsL
-bsL
-cFz
-cFz
+sNZ
 quW
 sNZ
+quW
+emv
 pxF
-pxF
-gdz
-bhg
-uBd
-pfw
-pfw
-pfw
-dfN
+sNZ
+sNZ
+kTT
+sNZ
+rZO
+rZO
+quW
 nWo
-nWo
-dfN
-pfw
-pfw
-qzg
-umH
-gdz
+cFz
+cFz
+cFz
+sNZ
+seL
+sNZ
+sNZ
 pxF
 pxF
 fVo
@@ -243952,32 +246469,32 @@ rZO
 rZO
 mGv
 pxF
-rZO
+quW
+bsL
 bsL
 cFz
 cFz
-cFz
+quW
+sNZ
+pxF
+pxF
+sNZ
+sNZ
+sNZ
+wxw
+rZO
+rZO
+sNZ
+sNZ
+sNZ
 cFz
 sNZ
+sNZ
 quW
+quW
+sNZ
 pxF
-hjH
-apU
-pfw
-pfw
-pfw
-pfw
-nWo
-apU
-apU
-nWo
-bhg
-pfw
-pfw
-apU
-ntX
-rZO
-rZO
+pxF
 fVo
 crw
 fVo
@@ -244405,31 +246922,31 @@ rZO
 rZO
 rZO
 rZO
+bsL
+cFz
+cFz
+cFz
+cFz
+sNZ
+quW
+pxF
 rZO
 bsL
 bsL
+rZO
+rZO
+rZO
+rZO
+quW
+quW
+sNZ
 bsL
+rZO
+rZO
+rZO
 sNZ
-sNZ
-sNZ
-rZO
-rZO
-xLB
-pfw
-pfw
-pfw
-pfw
-snu
-pfw
-dqy
-pfw
-nWo
-pfw
-pfw
-xLB
-rZO
-rZO
-aDh
+bsL
+bsL
 flo
 flo
 flo
@@ -244858,27 +247375,27 @@ rZO
 rZO
 rZO
 rZO
-rZO
-rZO
+bsL
+bsL
+bsL
 sNZ
-quW
+sNZ
 sNZ
 rZO
 rZO
 rZO
-xLB
-pfw
-pfw
-pfw
-pfw
-nWo
-apU
-tzL
-pfw
-umH
-pfw
-pfw
-xLB
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+bsL
+bsL
+rZO
+rZO
+rZO
 rZO
 rZO
 aDh
@@ -245312,28 +247829,28 @@ rZO
 rZO
 rZO
 rZO
+sNZ
+quW
+sNZ
 rZO
 rZO
 rZO
 rZO
 rZO
-hjH
-apU
-pfw
-pfw
-pfw
-pfw
-nWo
-apU
-apU
-nWo
-bhg
-pfw
-pfw
-apU
-ntX
+rZO
+sNZ
 rZO
 rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+aDh
 fVo
 crw
 fVo
@@ -245760,30 +248277,30 @@ cFz
 cFz
 cFz
 cFz
-cFz
-cFz
-sNZ
-fqS
 rZO
 rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+quW
 sNZ
-sNZ
-pxF
-gdz
-bhg
-pSM
-pfw
-pfw
-pfw
-dfN
-nWo
-nWo
-dfN
-pfw
-pfw
-qzg
-umH
-gdz
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
+rZO
 rZO
 rZO
 fVo
@@ -246214,29 +248731,29 @@ cFz
 cFz
 cFz
 cFz
-kTT
 sNZ
-pxF
-sNZ
-quW
-pxF
-pxF
-bQc
-bhg
-eHC
-pfw
-pfw
-pfw
-pfw
-pfw
-dqy
-pfw
-pfw
-qzg
-eHC
-umH
-bQc
+fqS
 rZO
+rZO
+sNZ
+sNZ
+pxF
+sNZ
+sNZ
+sNZ
+sNZ
+sNZ
+bsL
+bsL
+bsL
+rZO
+rZO
+rZO
+ntX
+quW
+sNZ
+sNZ
+bsL
 rZO
 fVo
 dzs
@@ -246666,28 +249183,28 @@ cFz
 cFz
 cFz
 cFz
-cFz
+kTT
+sNZ
 pxF
-mGv
+sNZ
+quW
 pxF
 pxF
-ibp
-emv
-pxF
-tJh
-pSM
-qzg
-pfw
-pfw
-pfw
-pfw
-pfw
-pfw
-qzg
-pSM
-toh
-bhg
-pxF
+sNZ
+sNZ
+sNZ
+sNZ
+sNZ
+sNZ
+sNZ
+seL
+sNZ
+sNZ
+sNZ
+sNZ
+sNZ
+sNZ
+sNZ
 rZO
 rZO
 fVo
@@ -247120,25 +249637,25 @@ cFz
 cFz
 cFz
 pxF
+mGv
 pxF
 pxF
-xFw
 ibp
-faM
+emv
 pxF
-bQc
-bhg
-umH
-vIC
-psV
-psV
-psV
-psV
-psV
-pSM
-umH
-umH
-bQc
+sNZ
+sNZ
+quW
+sNZ
+quW
+kTT
+sNZ
+sNZ
+sNZ
+sNZ
+sNZ
+seL
+sNZ
 pxF
 rZO
 rZO
@@ -247568,31 +250085,31 @@ cFz
 cFz
 hjw
 bsL
-bsL
-bsL
-pxF
-mGv
-pxF
+cFz
+cFz
+cFz
 pxF
 pxF
+pxF
+xFw
 ibp
+faM
+pxF
+sNZ
+sNZ
+sNZ
+seL
+sNZ
+sNZ
 ibp
+seL
+sNZ
+sNZ
+sNZ
+sNZ
+sNZ
 pxF
-pxF
-pxF
-tJh
-bhg
-umH
-pqc
-mGK
-pqc
-umH
-umH
-bhg
-gdz
-pxF
-mGv
-pxF
+rZO
 rZO
 rZO
 mGv
@@ -248020,30 +250537,30 @@ iEx
 edl
 iEx
 iEx
-gkv
-pxF
-emv
-pxF
+iEx
+bsL
 pxF
 mGv
-pxF
-ibp
-pxF
-mGv
-pxF
-emv
-pxF
-pxF
-dfN
-umH
-umH
-umH
-dfN
-pxF
 pxF
 pxF
 pxF
 ibp
+ibp
+pxF
+sNZ
+sNZ
+sNZ
+sNZ
+sNZ
+seL
+dYq
+sNZ
+sNZ
+seL
+sNZ
+sNZ
+ibp
+mGv
 pxF
 rZO
 rZO
@@ -248472,29 +250989,29 @@ fje
 fje
 fje
 cDX
-nHW
+gkv
 pxF
-pxF
-pxF
-pxF
-pxF
-pxF
-mGv
 emv
 pxF
 pxF
-pxF
-pxF
-pxF
-pxF
-pxF
-pxF
-pxF
-pxF
-pxF
+mGv
 pxF
 ibp
-xbo
+pxF
+mGv
+sNZ
+sNZ
+seL
+sNZ
+sNZ
+ibp
+ibp
+ibp
+ibp
+sNZ
+sNZ
+ibp
+ibp
 ibp
 pxF
 rZO
@@ -248924,32 +251441,32 @@ phl
 phl
 pLh
 pLh
-pLh
+nHW
 pxF
 pxF
+pxF
+pxF
+pxF
+pxF
+mGv
+emv
+pxF
+pxF
+pxF
+pxF
+pxF
+pxF
+pxF
+pxF
+gkv
+gkv
+gkv
 pxF
 ibp
 xbo
-pxF
-pxF
-faM
-emv
-pxF
-mGv
-pxF
-pxF
-pxF
-pxF
-pxF
-pLh
-phl
-phl
 ibp
-ibp
-ibp
-ibp
-faM
 pxF
+rZO
 rZO
 rZO
 rZO
@@ -249377,30 +251894,30 @@ phl
 mMc
 phl
 pLh
-pLh
+gkv
 pxF
 pxF
+ibp
+xbo
+pxF
+pxF
+faM
 emv
 pxF
-pxF
-pxF
-pxF
-ibp
-ibp
-ibp
+mGv
 pxF
 pxF
 pxF
 pxF
-pLh
+gkv
 pLh
 phl
 phl
-phl
-ikY
-bQc
-pxF
-aXW
+gYo
+ibp
+ibp
+ibp
+faM
 pxF
 hjH
 sNZ
@@ -249828,32 +252345,32 @@ phl
 fwD
 mOY
 guS
-phl
-phl
-gyu
-cDX
-gyu
-gyu
-cDX
-gyu
-gyu
-cDX
-gyu
-gyu
-cDX
-gyu
-gyu
-phl
+pLh
+pLh
+gkv
+gkv
+iAh
+gkv
+gkv
+gkv
+gkv
+gYo
+gYo
+gYo
+gkv
+gkv
+gkv
+gkv
+pLh
 pLh
 phl
 phl
 phl
-phl
-phl
-hpb
-hpb
-hpb
-hpb
+aQJ
+bQc
+pxF
+aXW
+pxF
 hpb
 hmZ
 rZO
@@ -250282,30 +252799,30 @@ jdu
 lqb
 phl
 phl
-pqo
-lKo
-lKO
-pqo
-lKo
-lKO
-pqo
-lKo
-lKO
-pqo
-lKo
-lKO
-phl
-phl
-phl
-phl
+gyu
 cDX
-phl
+gyu
+gyu
+cDX
+gyu
+gyu
+cDX
+gyu
+gyu
+cDX
+gyu
+gyu
 phl
 pLh
+phl
+phl
+phl
+phl
+phl
 rDI
-cDX
-uBc
-uBc
+hjL
+hjL
+hjL
 uBc
 cDX
 nok
@@ -253446,7 +255963,7 @@ xhU
 avX
 pWT
 teB
-cne
+pWT
 puy
 teB
 pWT
@@ -253896,15 +256413,15 @@ dJN
 dJN
 taS
 taS
-scj
-scj
+sfa
 taS
+sfa
 taS
-scj
+sfa
 taS
-taS
-scj
-scj
+sfa
+arS
+sfa
 taS
 taS
 taS
@@ -254348,16 +256865,16 @@ dJN
 yjS
 taS
 nmH
-pvg
-pvg
+kDA
+taS
 fKH
-ezW
+qGz
 oZH
-nmH
+ocC
 fKH
-ezW
+sdr
 oZH
-nmH
+taS
 dJN
 avb
 hie
@@ -254799,18 +257316,18 @@ fge
 tSE
 rbu
 sPX
-pvg
-pvg
-pvg
-fKH
-eVJ
-oZH
-pvg
-fKH
-eVJ
-oZH
-pvg
-dTw
+rbu
+nmH
+taS
+oRq
+oRq
+oRq
+ocC
+oRq
+oRq
+oRq
+taS
+dJN
 hie
 hUM
 hie
@@ -255252,18 +257769,18 @@ fLM
 rbu
 taS
 mCR
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-dJN
-sYb
+rbu
+tSE
+rbu
+rbu
+rbu
+tSE
+rbu
+rbu
+rbu
+tSE
+dTw
+hie
 hie
 hie
 awF
@@ -255704,16 +258221,16 @@ tSq
 rbu
 taS
 pFU
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-gvx
-pvg
-pvg
+rbu
+rbu
+rbu
+rbu
+rbu
+rbu
+rbu
+cGN
+cGN
+rbu
 dJN
 anR
 hie
@@ -256156,14 +258673,14 @@ cGN
 rbu
 taS
 qXx
-gzY
-bPF
+rbu
+rbu
 icb
 icb
-pvg
-pvg
+rbu
+rbu
 mrF
-elw
+bSd
 elw
 yhL
 dJN
@@ -256264,7 +258781,7 @@ gcy
 tQf
 niV
 xkH
-jFA
+niV
 xye
 xkH
 wRg
@@ -256607,17 +259124,17 @@ ozR
 rbu
 rbu
 scj
-iaa
+nhM
 fRW
-iTx
+bPF
 ezW
 rHR
-pvg
-gvx
+rbu
+cGN
 lIR
-iaa
-iaa
-iaa
+pmJ
+pmJ
+pmJ
 rKo
 hie
 hie
@@ -256716,7 +259233,7 @@ xkp
 wEA
 niV
 xkH
-jFA
+niV
 xkH
 wRg
 wRg
@@ -257061,15 +259578,15 @@ rbu
 taS
 bYj
 iaa
-iTx
+aAv
 aLh
 aLh
-pvg
-pvg
+rbu
+cGN
 lIR
 gOz
-iaa
-iaa
+wSb
+hie
 pVk
 jPH
 hie
@@ -257168,7 +259685,7 @@ xkp
 apU
 xkH
 jFA
-jFA
+xkH
 xkH
 cYU
 wRg
@@ -257510,17 +260027,17 @@ oYq
 tYE
 tSq
 rbu
-scj
-iaa
-iaa
-iTx
-pvg
-pvg
-pvg
-gvx
+qdI
+sCr
+uSZ
+aAv
+npi
+npi
+rbu
+cGN
 lIR
-iaa
-iaa
+hie
+hie
 ros
 tvR
 qqF
@@ -257620,7 +260137,7 @@ bAs
 xkH
 xkH
 jFA
-xkH
+niV
 wRg
 wRg
 xkH
@@ -257960,19 +260477,19 @@ ntM
 qfA
 oYq
 eur
-cGN
+xAh
 rbu
-scj
-iaa
-iaa
-iTx
-pvg
-fdJ
-pvg
-pvg
-lIR
-iaa
-iaa
+qdI
+xNG
+uSZ
+aAv
+dcl
+taS
+oWZ
+rbu
+eGU
+hie
+hie
 bJd
 mrF
 dYx
@@ -258073,7 +260590,7 @@ xkH
 jFA
 jFA
 xye
-xkH
+niV
 xkH
 jFA
 jFA
@@ -258414,22 +260931,22 @@ oYq
 ybz
 rbu
 rbu
-scj
-iaa
-iaa
-iTx
-pvg
-pvg
-pvg
-gvx
+qdI
+sCr
+uSZ
+aAv
+fWu
+fWu
+rbu
+cGN
 lIR
-iaa
+hie
 oOu
 akK
 mrF
 weI
-uTU
-hie
+mEG
+tJh
 pvx
 hSO
 nlW
@@ -258524,8 +261041,8 @@ xkH
 jFA
 jFA
 jFA
-jFA
-jFA
+xkH
+niV
 sZa
 jFA
 xkH
@@ -258864,18 +261381,18 @@ qfA
 qfA
 oYq
 cns
-fLM
+cGN
 rbu
 taS
-bYj
-iaa
-iTx
+rxS
+mNN
+aAv
 icb
 icb
-pvg
-pvg
+rbu
+cGN
 lIR
-iaa
+hie
 oOu
 ogL
 mrF
@@ -258976,8 +261493,8 @@ xkH
 jFA
 jFA
 jFA
-jFA
-jFA
+niV
+xkH
 jFA
 eTA
 jFA
@@ -259319,16 +261836,16 @@ tYE
 tSq
 rbu
 scj
-iaa
+kjw
 jmL
-iTx
+pia
 ezW
 hBH
-pvg
-gvx
+rbu
+cGN
 lIR
-iaa
-oOu
+xXw
+mvn
 ayw
 tvR
 yfc
@@ -259420,7 +261937,7 @@ bhJ
 bhJ
 bhJ
 xkH
-jFA
+nMH
 uDZ
 jFA
 xkH
@@ -259428,7 +261945,7 @@ xkH
 jFA
 sZa
 uDZ
-jFA
+niV
 jFA
 xkH
 xkH
@@ -259768,16 +262285,16 @@ sns
 sns
 hpr
 cns
-cGN
+xAh
 rbu
 taS
 kYZ
-teV
-pia
+rbu
+rbu
 aLh
 aLh
-pvg
-pvg
+rbu
+rbu
 avR
 elw
 shL
@@ -259871,9 +262388,9 @@ bhJ
 bhJ
 bhJ
 bhJ
-xkH
-jFA
-jFA
+eXH
+eXH
+kVg
 sZa
 eTA
 xkH
@@ -259881,7 +262398,7 @@ jFA
 jFA
 jFA
 jFA
-jFA
+sZa
 xkH
 jFA
 xkH
@@ -260224,16 +262741,16 @@ iPZ
 rbu
 taS
 lBQ
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-gvx
-pvg
-pvg
+rbu
+rbu
+rbu
+rbu
+rbu
+rbu
+rbu
+cGN
+cGN
+rbu
 taS
 mWD
 mQr
@@ -260323,17 +262840,17 @@ bhJ
 bhJ
 bhJ
 bhJ
+dFv
+fjG
+fjG
+yim
 xkH
 xkH
 jFA
 jFA
-xkH
-xkH
 jFA
 jFA
-jFA
-jFA
-jFA
+niV
 xkH
 xkH
 jFA
@@ -260677,15 +263194,15 @@ taS
 taS
 gbj
 bPF
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
+rbu
+rbu
+rbu
 mdh
 gzY
-pvg
+rbu
 taS
 mQr
 hvv
@@ -260775,21 +263292,21 @@ bhJ
 bhJ
 bhJ
 bhJ
-xkH
-xkH
-jFA
-eTA
-xkH
-jFA
-jFA
+vIK
+fjG
+fjG
+fjG
+iiC
 jFA
 jFA
 jFA
-xkH
-xkH
 jFA
 xkH
+niV
+xkH
 jFA
+xkH
+sZa
 jFA
 jFA
 kRr
@@ -261128,16 +263645,16 @@ exD
 taS
 udU
 jqI
-pvg
-pvg
+rbu
+rbu
 nXL
 nXL
-pvg
+rbu
 gzY
-gzY
+tBw
 taS
 gSU
-pvg
+rbu
 sfa
 jiQ
 hvv
@@ -261227,16 +263744,16 @@ bhJ
 bhJ
 bhJ
 bhJ
-xkH
-xkH
+eXH
+eXH
+eXH
+bmi
+bmi
+eXH
 jFA
 jFA
-xkH
-jFA
-jFA
-jFA
-jFA
-jFA
+sZa
+niV
 jFA
 jFA
 xkH
@@ -261580,7 +264097,7 @@ wGI
 taS
 owJ
 xGt
-pvg
+rbu
 nXL
 nXL
 nXL
@@ -261680,15 +264197,15 @@ bhJ
 bhJ
 bhJ
 xkH
-xkH
-sZa
-xkH
-xkH
-jFA
+bbQ
+eXH
+bmi
+bmi
+eXH
 uDZ
 jFA
 xkH
-xkH
+niV
 xkH
 jFA
 dyg
@@ -262131,16 +264648,16 @@ bhJ
 bhJ
 bhJ
 bhJ
+xrP
+xkH
+qcy
+bmi
+bmi
+eXH
+jFA
 xkH
 xkH
 sZa
-xkH
-jFA
-jFA
-jFA
-xkH
-xkH
-jFA
 xkH
 jFA
 jFA
@@ -262585,14 +265102,14 @@ bhJ
 bhJ
 bhJ
 xkH
+eXH
+eXH
+bmi
+qcy
 jFA
+jST
 xkH
-jFA
-jFA
-jFA
-jFA
-xkH
-xkH
+niV
 jFA
 jFA
 jFA
@@ -263038,13 +265555,13 @@ bhJ
 bhJ
 xkH
 jFA
+eXH
+bmi
+eXH
+jFA
 xkH
 xkH
 jFA
-jFA
-xkH
-xkH
-xkH
 jFA
 jFA
 jFA
@@ -263489,14 +266006,14 @@ bhJ
 bhJ
 bhJ
 xkH
-jFA
-jFA
-xkH
-jFA
+mtt
+eXH
+bmi
+eXH
 sZa
 xkH
-xkH
-xkH
+niV
+jFA
 xkH
 jFA
 sZa
@@ -263941,15 +266458,15 @@ bhJ
 bhJ
 bhJ
 xkH
+vnx
+omv
+omv
+omv
+sBu
+niV
+eTA
 jFA
-jFA
-xkH
-jFA
-jFA
-xkH
-xkH
-jFA
-xkH
+niV
 sZa
 sZa
 jFA
@@ -264392,15 +266909,15 @@ bhJ
 bhJ
 bhJ
 bhJ
-jFA
-jFA
-jFA
 xkH
-jFA
-jFA
+dpz
+hMt
+hMt
+hMt
+dyB
 xkH
-xkH
-jFA
+niV
+niV
 xkH
 xkH
 jFA
@@ -264844,26 +267361,26 @@ bhJ
 bhJ
 bhJ
 bhJ
-niV
+tMy
+rcC
+lry
+bmi
+eXH
+sZa
+xkH
+jFA
+rLY
 jFA
 jFA
+xkH
+jFA
+jFA
+jFA
+xkH
 xkH
 sZa
-sZa
-xkH
-xkH
 jFA
-jFA
-jFA
-xkH
-jFA
-jFA
-jFA
-xkH
-xkH
-sZa
-jFA
-wRg
+wph
 wRg
 wRg
 xkH
@@ -265295,13 +267812,13 @@ bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-niV
-niV
-jFA
-jFA
-jFA
-jFA
+sxx
+gTh
+rQG
+eXH
+bmi
+eXH
+sFs
 jFA
 jFA
 jFA
@@ -265748,28 +268265,28 @@ bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-niV
+sxx
+uvu
+eXH
+bmi
+eXH
 jFA
-xkH
-jFA
-jFA
-jFA
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
 jFA
 xkH
 xkH
 xkH
+xkH
+xkH
+xkH
+sZa
+xkH
+xkH
+eTA
 xkH
 wRg
 jFA
 opm
-wRg
+wph
 wRg
 xkH
 jFA
@@ -266101,7 +268618,7 @@ sns
 sns
 vOG
 sns
-deZ
+rHc
 udL
 kzi
 sns
@@ -266201,15 +268718,15 @@ bhJ
 bhJ
 bhJ
 bhJ
-niV
-jFA
-jFA
-jFA
+byK
+qcy
+bmi
+eXH
 sZa
 xkH
 xkH
-wRg
-wRg
+qcy
+eXH
 xkH
 jFA
 jFA
@@ -266218,7 +268735,7 @@ xkH
 xkH
 jFA
 xkH
-wRg
+wph
 jFA
 wRg
 wRg
@@ -266653,26 +269170,26 @@ bhJ
 bhJ
 bhJ
 bhJ
-niV
-jFA
-jFA
-sZa
-sZa
-xkH
-wRg
-wRg
-wRg
-xkH
-xkH
-xkH
-xkH
-sZa
-jFA
-jFA
+xCw
+eXH
+bmi
+eXH
+eXH
+eXH
+eXH
+eXH
+eXH
+eXH
+eXH
+eXH
+eXH
+ocQ
+eXH
+eXH
 uDZ
 xkH
 wRg
-wRg
+wph
 xkH
 sZa
 jFA
@@ -267005,9 +269522,9 @@ ykm
 lgD
 vOG
 sns
-ogT
-dHP
-ykU
+oPJ
+btK
+pWT
 sns
 sns
 sns
@@ -267104,28 +269621,28 @@ bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-niV
-jFA
-xkH
-xkH
-xkH
-wRg
-wRg
-wRg
-wRg
-xkH
-xkH
-xkH
-xkH
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-xkH
-xkH
+sxx
+hJW
+eXH
+bmi
+bmi
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+bmi
+eXH
+eXH
+eXH
+eXH
+qcy
 xkH
 sZa
 jFA
@@ -267457,9 +269974,9 @@ fpx
 nJH
 vOG
 sns
-sns
-sns
-sns
+ogT
+doK
+ykU
 sns
 aWT
 aWT
@@ -267557,30 +270074,30 @@ bhJ
 bhJ
 bhJ
 bhJ
-niV
-jFA
-xkH
-wRg
-wRg
-xkH
-wRg
-jFA
-sZa
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-xkH
-jFA
-jFA
-xkH
-xkH
-jFA
-jFA
+uvu
+eXH
+fjG
+bmi
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+bmi
+eXH
+eXH
+eXH
 xkH
 eTA
 xkH
@@ -268009,31 +270526,31 @@ bhJ
 bhJ
 bhJ
 bhJ
-niV
-jFA
+hJW
 xkH
-wRg
-wRg
-wRg
-wRg
-jFA
-jFA
-jFA
-jFA
-sZa
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-xkH
-xkH
-xkH
+eXH
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+oZo
+eXH
+eXH
+eXH
+eXH
+eXH
+eXH
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+bmi
+eXH
 xkH
 niV
 xkH
@@ -268460,32 +270977,32 @@ bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-niV
+sxx
+uvu
 jFA
-xkH
+qcy
+eXH
 wRg
-wRg
-xkH
+eXH
+jFA
+sZa
+eXH
+eXH
+qcy
+jFA
+jFA
+jFA
 jFA
 sZa
 jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-sZa
-jFA
-xkH
-jFA
-jFA
-xkH
-eTA
-eTA
-xkH
-xkH
+qcy
+eXH
+eXH
+eXH
+eXH
+eXH
+fjG
+eXH
 xkH
 niV
 xkH
@@ -268911,9 +271428,9 @@ bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-niV
-niV
+sxx
+gTh
+oAo
 jFA
 xkH
 xkH
@@ -268934,11 +271451,11 @@ xkH
 jFA
 xkH
 eTA
-jFA
-sZa
 xkH
-xkH
-sZa
+eXH
+fjG
+bmi
+qcy
 xkH
 jFA
 jFA
@@ -269364,10 +271881,10 @@ bhJ
 bhJ
 bhJ
 bhJ
-niV
+klO
+xpJ
+fCm
 jFA
-jFA
-xkH
 sZa
 xkH
 xkH
@@ -269376,22 +271893,22 @@ xkH
 xkH
 xkH
 jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-xkH
-xkH
-jFA
-xkH
-xkH
-jFA
-jFA
-jFA
+sZa
 jFA
 jFA
 xkH
+xkH
+xkH
+xkH
+jFA
+xkH
+xkH
+jFA
+xkH
+eXH
+fjG
+eXH
+eXH
 jFA
 sZa
 jFA
@@ -269816,10 +272333,10 @@ bhJ
 bhJ
 bhJ
 bhJ
+niV
+niV
 jFA
 jFA
-jFA
-xkH
 jFA
 jFA
 xkH
@@ -269827,7 +272344,7 @@ eTA
 xkH
 xkH
 jFA
-jFA
+sZa
 jFA
 jFA
 xkH
@@ -269840,11 +272357,11 @@ xkH
 eTA
 xkH
 jFA
-jFA
-jFA
-xkH
-xkH
-xkH
+eXH
+fjG
+fjG
+bmi
+eXH
 jFA
 niV
 niV
@@ -270170,7 +272687,7 @@ kwU
 eKH
 eKH
 eKH
-rlj
+sns
 sns
 feG
 dGW
@@ -270293,18 +272810,18 @@ jFA
 sZa
 sZa
 uDZ
-jFA
-jFA
-xkH
-xkH
-xkH
-niV
-niV
-sni
-niV
-xkH
-xkH
-niV
+eXH
+fjG
+fjG
+eXH
+eXH
+eXH
+eXH
+eXH
+eXH
+eXH
+qcy
+eXH
 niV
 xkH
 xkH
@@ -270660,7 +273177,7 @@ phl
 phl
 pWT
 aZo
-fpx
+kwV
 fpx
 fpx
 pWT
@@ -270746,18 +273263,18 @@ jFA
 jFA
 sZa
 xkH
-xkH
-niV
-niV
-xkH
-niV
-niV
-xkH
-xkH
-niV
-xkH
-niV
-sni
+qcy
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+bmi
+eXH
 niV
 jFA
 jFA
@@ -271077,7 +273594,7 @@ eKH
 eBq
 uCs
 mPk
-llx
+waj
 llx
 llx
 mPk
@@ -271199,20 +273716,20 @@ niV
 xkH
 xkH
 niV
-niV
-niV
-niV
+eXH
+eXH
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+fjG
+bmi
+qcy
 xkH
-niV
-niV
-niV
-xkH
-xkH
-xkH
-xkH
-xkH
-jFA
-uDZ
+fOj
 jFA
 jFA
 jFA
@@ -271630,40 +274147,40 @@ jFA
 jFA
 xkH
 xkH
-xkH
-xkH
-xkH
-sZa
-sZa
-sZa
-jFA
-xkH
-xkH
-jFA
-jFA
-jFA
-xkH
-xkH
-niV
-xkH
-niV
-jFA
-jFA
-jFA
-xkH
-xkH
-jFA
-jFA
-jFA
-xkH
-vWm
-xkH
 eTA
+xkH
+xkH
+sZa
+sZa
+sZa
+jFA
+xkH
+xkH
 jFA
 jFA
 jFA
+xkH
+xkH
+niV
+xkH
+niV
 jFA
-vWm
+jFA
+jFA
+xkH
+xkH
+jFA
+eXH
+eXH
+eXH
+qcy
+eXH
+eXH
+eXH
+fjG
+fjG
+bmi
+eXH
 jFA
 eTA
 niV
@@ -272015,7 +274532,7 @@ lKo
 pqo
 lKo
 vXe
-fpx
+pBi
 sns
 sns
 sns
@@ -272078,7 +274595,7 @@ bhJ
 bhJ
 xkH
 xkH
-jFA
+sZa
 jFA
 xkH
 xkH
@@ -272108,14 +274625,14 @@ jFA
 sZa
 jFA
 xkH
+mHL
 xkH
+jFA
 xkH
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
+eXH
+eXH
+bmi
+eXH
 xkH
 niV
 jFA
@@ -272563,12 +275080,12 @@ jFA
 sZa
 sZa
 jFA
-jFA
 uDZ
-sZa
-jFA
-jFA
-jFA
+xkH
+eXH
+bmi
+bmi
+eXH
 jFA
 jFA
 xkH
@@ -272992,7 +275509,7 @@ jFA
 jFA
 xkH
 xkH
-xkH
+eTA
 xkH
 eTA
 eTA
@@ -273017,10 +275534,10 @@ sZa
 jFA
 jFA
 jFA
-jFA
-jFA
-jFA
-jFA
+eXH
+bmi
+bmi
+eXH
 sZa
 sZa
 niV
@@ -273440,7 +275957,7 @@ jFA
 jFA
 jFA
 jFA
-jFA
+sZa
 jFA
 xkH
 xkH
@@ -273468,11 +275985,11 @@ jFA
 jFA
 xkH
 xkH
-xkH
-jFA
-xkH
-jFA
-jFA
+bbQ
+eXH
+bmi
+bmi
+qcy
 sZa
 sZa
 niV
@@ -273921,10 +276438,10 @@ xkH
 xkH
 xkH
 eMx
-xkH
-xkH
-xkH
-xkH
+eXH
+bmi
+bmi
+kVg
 jFA
 xkH
 xkH
@@ -274375,7 +276892,7 @@ eMx
 eMx
 eMx
 eMx
-xkH
+bmi
 xkH
 xkH
 jFA
@@ -284621,7 +287138,7 @@ pww
 pww
 nTh
 njP
-ppQ
+wGa
 rMf
 jQE
 uMp
@@ -285073,7 +287590,7 @@ aHM
 aHM
 rni
 nTh
-rMf
+oei
 rMf
 jQE
 rAR
@@ -285977,7 +288494,7 @@ noW
 jjT
 noW
 pww
-rMf
+rGn
 rMf
 jQE
 weQ
@@ -286881,7 +289398,7 @@ cOh
 awz
 noW
 nTh
-rMf
+rGn
 rMf
 jQE
 weQ
@@ -287785,7 +290302,7 @@ eXA
 dNg
 noW
 pww
-rMf
+kve
 rMf
 jQE
 weQ
@@ -288237,7 +290754,7 @@ vQv
 heB
 noW
 pww
-rMf
+oei
 rMf
 jQE
 weQ
@@ -290954,7 +293471,7 @@ fXm
 vAw
 vAw
 vAw
-rMf
+pLV
 kAx
 rMf
 rMf
@@ -291402,15 +293919,15 @@ agp
 noW
 njP
 ppQ
-rMf
-rMf
-rMf
-rMf
-kAx
-rMf
-kAx
-rMf
-rMf
+xMz
+rZW
+rZW
+rZW
+uAa
+rZW
+uAa
+tMt
+jJH
 jQE
 weQ
 gJx
@@ -291858,10 +294375,10 @@ aJK
 aym
 hbr
 dYg
-fWu
-kAx
-rMf
-kAx
+dYg
+aTo
+cZA
+gEA
 vAw
 jQE
 weQ
@@ -292312,7 +294829,7 @@ oSt
 oSt
 oSt
 qQo
-jJH
+orZ
 vAw
 vAw
 vxV
@@ -292764,9 +295281,9 @@ pSa
 jGN
 drN
 oSt
-wjz
+fpq
 kAx
-rMf
+jJH
 jQE
 weQ
 gJx
@@ -294060,7 +296577,7 @@ qyR
 qyR
 pWT
 fpx
-fpx
+tXD
 exD
 exD
 exD
@@ -294964,7 +297481,7 @@ tFL
 pWT
 fpx
 rfc
-fpx
+exD
 exD
 exD
 fpx
@@ -319631,9 +322148,9 @@ aBB
 aBB
 aBB
 aBB
-oJW
-oJW
-oJW
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -320083,7 +322600,7 @@ aBB
 aBB
 aBB
 aBB
-oJW
+aBB
 aBB
 aBB
 aBB
@@ -320111,9 +322628,9 @@ aBB
 aBB
 aBB
 aBB
-oJW
-oJW
-oJW
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -320535,7 +323052,7 @@ aBB
 aBB
 aBB
 aBB
-oJW
+aBB
 aBB
 aBB
 aBB
@@ -320543,12 +323060,12 @@ aBB
 aBB
 aBB
 eMx
+hlK
+eGq
+eTA
+ukO
+lue
 eMx
-xkH
-xkH
-xkH
-xkH
-eMx
 eMx
 eMx
 aBB
@@ -320565,7 +323082,7 @@ aBB
 aBB
 aBB
 aBB
-oJW
+aBB
 aBB
 aBB
 aBB
@@ -320994,15 +323511,15 @@ aBB
 aBB
 aBB
 eMx
+hlK
+xdh
+aUe
+uDZ
+jLH
+aMK
+aUe
+xGB
 eMx
-xkH
-jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-eMx
 aBB
 aBB
 aBB
@@ -321017,7 +323534,7 @@ aBB
 aBB
 aBB
 aBB
-oJW
+aBB
 aBB
 aBB
 aBB
@@ -321446,15 +323963,15 @@ aBB
 aBB
 aBB
 eMx
+lue
+ttU
+eHC
+eXH
+hfu
+eXH
+eXH
 xkH
-xkH
-jFA
-jFA
-jFA
-xkH
-jFA
-xkH
-eMx
+hlK
 eMx
 eMx
 aBB
@@ -321898,16 +324415,16 @@ aBB
 aBB
 aBB
 eMx
-xkH
-xkH
-tbg
-cqn
-cqn
-cqn
-tbg
-xkH
-xkH
-xkH
+aUe
+eXH
+cjd
+aUe
+dMR
+aUe
+wUZ
+eHC
+wfE
+eTA
 eMx
 eMx
 eMx
@@ -321917,9 +324434,9 @@ aBB
 aBB
 aBB
 aBB
-eMx
-eMx
-xkH
+hlK
+hlK
+lue
 xkH
 eMx
 aBB
@@ -322350,17 +324867,17 @@ aBB
 aBB
 aBB
 eMx
+eMT
+eXH
+mhp
+niV
+niV
 xkH
-xkH
-iyR
-ksH
-ksH
-vAV
-qxa
-mHL
-xkH
-xkH
-xkH
+oMo
+eXH
+eMT
+dwp
+lue
 xkH
 eMx
 eMx
@@ -322369,10 +324886,10 @@ aBB
 eMx
 eMx
 eMx
-xkH
-jFA
-jFA
-jFA
+lue
+sZa
+hlK
+dwp
 eMx
 eMx
 aBB
@@ -322802,28 +325319,28 @@ aBB
 aBB
 aBB
 eMx
-xkH
-jFA
-iyR
-pUD
-ksH
-ksH
-mKO
+eTA
+hfu
+wWD
+niV
+nYW
 niV
 niV
+niV
 xkH
-xkH
-xkH
-xkH
+eTA
+mtt
+feV
+lue
 eMx
 eMx
 eMx
 eMx
-xkH
-xkH
-xkH
-jFA
-xkH
+sdo
+lue
+eXH
+eXH
+kRr
 jFA
 xkH
 eMx
@@ -323254,28 +325771,28 @@ aBB
 aBB
 aBB
 eMx
+feV
+eXH
+wWD
+niV
+niV
 xkH
-jFA
-iyR
-lQc
-heG
-ksH
-mKO
 niV
+xkH
 niV
-jFA
-jFA
+eMT
+nGj
 eTA
-xkH
-xkH
+feV
+lue
 sdo
+feV
+kRr
 xkH
 xkH
-sdo
-xkH
-xkH
-jFA
-jFA
+feV
+aWl
+sZa
 xkH
 xkH
 eMx
@@ -323706,29 +326223,29 @@ aBB
 aBB
 aBB
 eMx
-xkH
-jFA
-iyR
-bXk
-ksH
-ksH
-qxa
+feV
+eXH
+cOP
 xkH
 niV
 niV
-jFA
-jFA
-xkH
-xkH
-xkH
+aUe
+eXH
+niV
 niV
 xkH
-xkH
-xkH
+cni
+neM
+iXm
+iXm
+luC
+iXm
+lue
+lue
 jFA
-jFA
-jFA
-xkH
+aWl
+eXH
+lue
 xkH
 eMx
 aBB
@@ -324158,30 +326675,30 @@ aBB
 aBB
 eMx
 eMx
-xkH
-jFA
-tbg
-anC
-anC
-anC
-tbg
-jFA
-jFA
-xkH
-niV
-xkH
-jFA
-xkH
+wfE
+oxl
+jKU
+sfJ
+stb
+aUe
+cjd
+oxl
+uLg
 xkH
 niV
 niV
-xkH
-jFA
-jFA
-xkH
-xkH
+aWl
+eMT
+eMT
+iyc
+nKD
+iXm
+aWl
+hds
+iXm
+eXH
 eTA
-xkH
+lue
 eMx
 aBB
 aBB
@@ -324609,30 +327126,30 @@ aBB
 aBB
 aBB
 eMx
-xkH
-xkH
-jFA
-xkH
-xkH
-xkH
+sdo
 eTA
-xkH
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
+jGc
+oxl
+eXH
+eXH
+ocQ
+eXH
+gfu
+vxu
+aWl
+sFs
 xkH
 niV
-xkH
-xkH
-jFA
-jFA
-xkH
-xkH
-xkH
+aPu
+feV
+nGj
+eMT
+feV
+aWl
+aWl
+oYh
+dDi
+lue
 xkH
 eMx
 aBB
@@ -325061,29 +327578,29 @@ aBB
 aBB
 aBB
 eMx
+xdh
 xkH
-xkH
-jFA
-xkH
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-jFA
-niV
-xkH
-xkH
-xkH
-jFA
-xkH
-xkH
-xkH
+uDZ
+wfE
+vqR
+kqa
+aMK
+aUe
+ern
+azJ
+aWl
+dQi
+rsD
+qLA
+rjT
+jUT
+inM
+aTV
+gTC
+pSM
+pSM
+feV
+nAs
 xkH
 eMx
 eMx
@@ -325513,29 +328030,29 @@ aBB
 aBB
 aBB
 eMx
+lue
 xkH
-xkH
+eMT
+rsD
+gHx
+feV
 jFA
-jFA
-jFA
-xkH
-xkH
-jFA
-xkH
+sFs
+dpQ
 kqa
-jFA
-uDZ
-xkH
-niV
-niV
-sZa
-jFA
-jFA
-xkH
-jFA
-jFA
-xkH
-eMx
+dQi
+pvE
+veg
+tzL
+aYu
+hTd
+cEy
+ium
+bvM
+eHk
+kUO
+feV
+hds
 eMx
 eMx
 aBB
@@ -325966,29 +328483,29 @@ aBB
 aBB
 eMx
 eMx
-xkH
-xkH
-xkH
+lue
+hyF
+tBC
 sdo
 xkH
 jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-niV
-sdo
-xkH
-xkH
-xkH
-xkH
-jFA
-jFA
-xkH
-xkH
-eMx
-aBB
+sZa
+aWl
+gHx
+oYh
+inM
+uQv
+qzg
+aWd
+qzg
+dXq
+dXq
+pfw
+dXq
+mGK
+umH
+aWl
+kgg
 aBB
 aBB
 aBB
@@ -326418,29 +328935,29 @@ aBB
 aBB
 aBB
 eMx
-eMx
-xkH
+pHp
+eGq
+sFs
+lue
+sZa
 jFA
 xkH
+feV
 jFA
-jFA
-xkH
-xkH
-jFA
-xkH
-xkH
-niV
-xkH
-tbg
-cqn
-cqn
-tbg
-xkH
-jFA
-jFA
-jFA
-eMx
-aBB
+phD
+qLA
+cEy
+qzg
+kio
+wUE
+nUT
+dsA
+dXq
+psV
+mGK
+umH
+aWl
+kgg
 aBB
 aBB
 aBB
@@ -326870,29 +329387,29 @@ aBB
 aBB
 aBB
 aBB
-eMx
+pHp
+sIG
+sZa
+tgG
 xkH
 jFA
+ern
 jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-obK
 xkH
 niV
-ksH
+rWj
+btN
+btN
+btN
 kFg
-cPy
-qxa
-jFA
-jFA
-jFA
-jFA
-eMx
-aBB
+tNg
+bUW
+pfw
+psV
+mGK
+umH
+aWl
+kgg
 aBB
 aBB
 aBB
@@ -327322,29 +329839,29 @@ aBB
 aBB
 aBB
 aBB
-eMx
+pHp
+xdh
+nRo
+vSS
+niV
 xkH
-jFA
-jFA
-jFA
+niV
+niV
+ern
 xkH
-jFA
-jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-ksH
+rWj
+btN
+btN
+btN
 kFg
-cPy
-qxa
-xkH
-jFA
-jFA
-xkH
-eMx
-aBB
+tNg
+bUW
+dXq
+psV
+mGK
+umH
+aWl
+kgg
 aBB
 aBB
 aBB
@@ -327774,29 +330291,29 @@ aBB
 aBB
 aBB
 aBB
-eMx
-xkH
-jFA
-jFA
-jFA
-jFA
-jFA
-xkH
+pHp
 sdo
-xkH
-xkH
-xkH
-mHL
-tbg
-anC
-anC
-tbg
+sZa
+xBr
 xkH
 jFA
-xkH
-xkH
-eMx
-aBB
+jFA
+jFA
+jFA
+rSb
+qLA
+qzg
+qzg
+kDm
+sPd
+mBR
+foS
+dXq
+psV
+mGK
+umH
+aWl
+kgg
 aBB
 aBB
 aBB
@@ -328227,28 +330744,28 @@ aBB
 aBB
 aBB
 eMx
-xkH
-xkH
-xkH
-xkH
-xkH
+hlK
+eGq
 eTA
-xkH
-xkH
-xkH
+jFA
+jFA
+eTA
+jFA
+kRr
+oYh
 hds
 uQv
-niV
-niV
-xkH
-xkH
-xkH
-jFA
-jFA
-xkH
-eMx
-eMx
-aBB
+qzg
+qzg
+aWd
+dXq
+dXq
+pfw
+dXq
+mGK
+oCk
+aWl
+kgg
 aBB
 aBB
 aBB
@@ -328679,27 +331196,27 @@ aBB
 aBB
 eMx
 eMx
+hlK
+sZa
+sFs
+jFA
+jFA
 xkH
 jFA
 jFA
-jFA
-xkH
-xkH
-xkH
-xkH
-jFA
-jFA
+ern
+hds
 veg
-xkH
-xkH
-xkH
-xkH
-xkH
-jFA
-xkH
-eMx
-eMx
-aBB
+lmS
+dXq
+iko
+eHk
+snu
+pfw
+pfw
+ccY
+lNE
+kgg
 aBB
 aBB
 aBB
@@ -329130,29 +331647,29 @@ aBB
 aBB
 eMx
 eMx
-xkH
-xkH
+hlK
+lue
+dGk
 jFA
+psx
 jFA
+dGk
+iPf
+aWl
 jFA
-xkH
-xkH
-xkH
-jFA
-xkH
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-sZa
-jFA
-xkH
-eMx
-aBB
-aBB
-aBB
+ern
+bXk
+qhG
+wkq
+rjT
+gWt
+iLt
+iLt
+rjB
+eTF
+mxC
+veg
+rwq
 aBB
 aBB
 aBB
@@ -329581,29 +332098,29 @@ aBB
 aBB
 aBB
 eMx
-xkH
-xkH
-xkH
+pHp
+hlK
+oIC
+uPm
+hVz
+xCH
+psx
 jFA
-jFA
-jFA
-jFA
+ern
+ern
 xkH
-jFA
-jFA
-xkH
-xkH
-xkH
-xkH
-jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-eMx
-aBB
-aBB
+feV
+oYh
+oYh
+eMT
+hmM
+cni
+aWl
+lNE
+uXh
+tNg
+tNg
+lNE
 aBB
 aBB
 aBB
@@ -330033,29 +332550,29 @@ aBB
 aBB
 aBB
 eMx
-xkH
-xkH
-xkH
-jFA
-jFA
-uDZ
-jFA
-xkH
-sdo
-jFA
+pHp
+eTA
+sSN
+iCt
+xWb
+kRr
 sZa
-iOt
-jFA
-tmt
-jFA
-jFA
-jFA
-jFA
-jFA
+vVH
 xkH
-eMx
-aBB
-aBB
+obK
+sZa
+hds
+tfT
+tmt
+obK
+fHG
+aWl
+eMT
+hds
+nAs
+duw
+oyQ
+rwq
 aBB
 aBB
 aBB
@@ -330486,26 +333003,26 @@ aBB
 aBB
 eMx
 eMx
-xkH
-xkH
-jFA
-jFA
-jFA
-jFA
-jFA
+qro
+ixl
+fuj
+fuj
+uOG
+ppp
+sZa
 xkH
 jFA
 jFA
 jFA
 sZa
-tmt
-jFA
-jFA
-jFA
-jFA
+luC
+hds
+uWJ
+hds
+hds
 uDZ
-xkH
-eMx
+lue
+ivZ
 aBB
 aBB
 aBB
@@ -330939,22 +333456,22 @@ aBB
 aBB
 eMx
 eMx
+otv
+fuj
+fuj
+gRo
+ixl
 xkH
-jFA
-jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-jFA
-jFA
-dIr
-fBJ
+niV
+woL
+mtV
 jFA
 niV
+fBJ
+jFA
+uWJ
 obK
-xkH
+hHg
 xkH
 xkH
 eMx
@@ -331391,24 +333908,24 @@ aBB
 aBB
 aBB
 eMx
+cbE
+stY
+bJI
+fuj
+fuj
+uWS
+sZa
 xkH
-xkH
-jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-jFA
-iaM
+hds
+eCd
 nKD
+feV
+hds
+pBz
+tzq
 xkH
-jFA
-xkH
-xkH
-xkH
-xkH
-xkH
+feV
+kRr
 eMx
 aBB
 aBB
@@ -331843,24 +334360,24 @@ aBB
 aBB
 eMx
 eMx
+xTn
+xYX
+eTA
+fuj
+fuj
+ixl
+rDS
+kRr
+eTA
 xkH
-xkH
-jFA
-xkH
-xkH
-jFA
-xkH
-xkH
-xkH
-xkH
-niV
+oDa
 luC
+lue
 xkH
-xkH
-xkH
-jFA
-xkH
-xkH
+uWJ
+sZa
+feV
+lue
 eMx
 aBB
 aBB
@@ -332294,25 +334811,25 @@ aBB
 aBB
 eMx
 eMx
+jhf
 xkH
+fuj
+jST
+ksx
+fuj
+fuj
+uWS
+sZa
+apU
+dXq
+pfw
+apU
+iXm
 xkH
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-xkH
-tbg
-lQc
-ksH
-tbg
-xkH
-xkH
-niV
-jFA
-xkH
-xkH
+uWJ
+rLY
+eGq
+lue
 eMx
 aBB
 aBB
@@ -332745,25 +335262,25 @@ aBB
 aBB
 aBB
 eMx
+pHp
 xkH
+hJn
+fuj
 xkH
-xkH
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-xkH
-lQc
-ksH
-ksH
-lQc
-xkH
+eTA
+fuj
+stY
+ixl
+hds
+xZJ
+pfw
+pfw
+dXq
 niV
 niV
-xkH
-xkH
+fnG
+cSb
+eTA
 eMx
 eMx
 aBB
@@ -333197,25 +335714,25 @@ aBB
 aBB
 eMx
 xkH
-xkH
-xkH
-xkH
-jFA
-xkH
-xkH
-jFA
-jFA
-jFA
-xkH
-dpQ
-ksH
-ksH
-ksH
-xkH
-jFA
+pHp
+lue
+kmp
+fuj
+fuj
+oHL
+xYX
+sZa
+sFs
+cQR
+dXq
+pfw
+pfw
+pfw
 niV
 xkH
-xkH
+sni
+uWJ
+hlK
 eMx
 aBB
 aBB
@@ -333649,25 +336166,25 @@ aBB
 aBB
 eMx
 xkH
-xkH
-jFA
-jFA
-jFA
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-lQc
-ksH
-ksH
-lQc
-jFA
-jFA
+xdh
+qMb
+kBO
+gRo
+fuj
+iCt
+uWS
+lJO
+qYS
+rZa
+wDS
+pfw
+pfw
+fmC
+hds
+inL
 niV
-niV
-jFA
+uWJ
+hlK
 eMx
 aBB
 aBB
@@ -334101,25 +336618,25 @@ aBB
 aBB
 eMx
 xkH
-xkH
-jFA
-jFA
-jFA
-xkH
-xkH
-tbg
-cqn
-cqn
-cqn
-tbg
-mKO
-mKO
-tbg
-xkH
-xkH
-jFA
-jFA
-jFA
+hlK
+pHp
+sZa
+iCt
+uWS
+lue
+apU
+nus
+nus
+eYU
+veg
+xLB
+xLB
+veg
+iXm
+sad
+niV
+oDa
+dwp
 eMx
 eMx
 eMx
@@ -334553,27 +337070,27 @@ aBB
 aBB
 eMx
 xkH
+sZa
+pHp
+oEs
 jFA
 jFA
-jFA
-jFA
-xkH
 eTA
-iyR
+lMW
 vAV
-lQc
-lQc
-ksH
-ksH
-lQc
-qxa
+dXq
+dXq
+pfw
+pfw
+dXq
+nus
 eTA
 xkH
-jFA
-jFA
+vIC
+sZa
 xkH
-xkH
-xkH
+cTD
+lue
 eMx
 eMx
 aBB
@@ -335005,28 +337522,28 @@ aBB
 aBB
 eMx
 xkH
+qCf
+hlK
+hlK
+sZa
 jFA
-jFA
-xkH
-jFA
-xkH
-xkH
-iyR
-tbg
+dwp
+nus
+veg
 kFg
-ksH
-ksH
-ksH
-lQc
-qxa
+pfw
+pfw
+pfw
+dKU
+nus
+lue
 xkH
-xkH
-jFA
+uWJ
 niV
 jFA
 jFA
-jFA
-xkH
+hlK
+lue
 eMx
 eMx
 aBB
@@ -335456,30 +337973,30 @@ aBB
 aBB
 aBB
 eMx
+hlK
 xkH
-xkH
+qCf
+qCf
+hlK
+hlK
 jFA
-jFA
-xkH
-xkH
-xkH
-iyR
-tbg
+lMW
+veg
 kFg
-ksH
-heG
-ksH
+pfw
+mlS
+pfw
 iBx
-qxa
-xkH
-xkH
-jFA
+gOR
+feV
+lue
+uWJ
 niV
-jFA
-jFA
-jFA
 xkH
-xkH
+sZa
+dGk
+hlK
+hlK
 eMx
 aBB
 aBB
@@ -335908,30 +338425,30 @@ aBB
 aBB
 aBB
 eMx
+hlK
+eTA
 xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-tbg
-anC
-anC
-anC
-tbg
-anC
-anC
-tbg
-xkH
-jFA
-jFA
+sdo
+lue
+hlK
+lue
+apU
+nus
+nus
+ndL
+rbN
+bcf
+ndL
+apU
+feV
+fBJ
+dfN
 niV
-jFA
+xkH
 jFA
 jFA
 xkH
-xkH
+kRr
 eMx
 aBB
 aBB
@@ -336361,27 +338878,27 @@ aBB
 aBB
 eMx
 xkH
+rDS
 xkH
-xkH
-xkH
+lue
 eMx
 eMx
 eMx
 eMx
+cTD
+hlK
+lue
 xkH
 xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
+feV
+feV
+iXm
+iXm
+hWm
 niV
 jFA
-jFA
-jFA
-xkH
+eXH
+oYh
 eTA
 xkH
 eMx
@@ -336814,27 +339331,27 @@ aBB
 eMx
 eMx
 xkH
-xkH
+lue
 eMx
 eMx
-aBB
-aBB
 eMx
-xkH
+eMx
+eMx
 sdo
+hHg
 xkH
 xkH
 xkH
 xkH
 jFA
-jFA
+iOg
+aAs
+vIC
 xkH
-niV
-jFA
-jFA
-jFA
-jFA
-xkH
+fBJ
+eXH
+aWl
+lue
 eMx
 eMx
 aBB
@@ -337274,19 +339791,19 @@ aBB
 eMx
 eMx
 yhK
+uWJ
+vIC
+vIC
+mxB
 niV
-niV
-niV
-niV
-niV
-jFA
-jFA
-niV
-jFA
-jFA
-jFA
-xkH
-xkH
+hmM
+uWJ
+uWJ
+dwp
+eXH
+aWl
+lue
+lue
 eMx
 aBB
 aBB
@@ -337714,8 +340231,8 @@ aBB
 aBB
 aBB
 aBB
-oJW
-oJW
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -337727,18 +340244,18 @@ eMx
 eMx
 yhK
 niV
+uWJ
+uWJ
+uWJ
 niV
+tjL
+sad
 jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-xkH
+tfT
+dQi
+eTA
+hlK
+hlK
 eMx
 aBB
 aBB
@@ -338166,7 +340683,7 @@ aBB
 aBB
 aBB
 aBB
-oJW
+aBB
 aBB
 aBB
 aBB
@@ -338176,17 +340693,17 @@ aBB
 aBB
 aBB
 eMx
-xkH
 sdo
-xkH
-xkH
+hHg
+sFs
 jFA
 jFA
 jFA
+hlK
+hds
 jFA
-jFA
-xkH
-xkH
+xdh
+eTA
 xkH
 xkH
 xkH
@@ -338618,8 +341135,8 @@ aBB
 aBB
 aBB
 aBB
-oJW
-oJW
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -338629,17 +341146,17 @@ aBB
 aBB
 eMx
 eMx
-xkH
-xkH
+rIw
 jFA
 jFA
+hds
 uDZ
+hds
 jFA
-jFA
-jFA
+sZa
 xkH
-xkH
-xkH
+kWi
+eTA
 xkH
 eMx
 eMx
@@ -339080,18 +341597,18 @@ aBB
 aBB
 aBB
 eMx
-xkH
-xkH
+lue
+dGk
+sZa
 jFA
 jFA
 jFA
+sZa
+sFs
 jFA
-jFA
-jFA
-jFA
-xkH
-xkH
-xkH
+kRr
+hlK
+hlK
 eMx
 eMx
 aBB
@@ -339532,17 +342049,17 @@ aBB
 aBB
 aBB
 eMx
-xkH
-xkH
+kRr
+eXH
 jFA
 jFA
 jFA
-jFA
-jFA
-xkH
-xkH
-eMx
-eMx
+eXH
+dGk
+feV
+hlK
+hlK
+hlK
 eMx
 eMx
 aBB
@@ -339984,15 +342501,15 @@ aBB
 aBB
 aBB
 eMx
-xkH
-xkH
+lue
+xdh
 jFA
-jFA
+vEB
 xkH
+eTA
+feV
 xkH
-xkH
-xkH
-xkH
+hlK
 eMx
 aBB
 aBB
@@ -340435,16 +342952,16 @@ aBB
 aBB
 aBB
 aBB
+hlK
+hlK
+eTA
+lue
+hlK
+feV
+feV
+hlK
+xkH
 eMx
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-xkH
-eMx
 eMx
 aBB
 aBB
@@ -340452,7 +342969,7 @@ aBB
 aBB
 aBB
 aBB
-oJW
+aBB
 aBB
 aBB
 aBB
@@ -340887,14 +343404,14 @@ aBB
 aBB
 aBB
 aBB
-eMx
-eMx
-xkH
-xkH
-eMx
+hlK
 eMx
 xkH
-xkH
+hlK
+hlK
+eMx
+hlK
+hlK
 eMx
 eMx
 aBB
@@ -340904,7 +343421,7 @@ aBB
 aBB
 aBB
 aBB
-oJW
+aBB
 aBB
 aBB
 aBB
@@ -341345,18 +343862,18 @@ eMx
 eMx
 eMx
 eMx
+hlK
 eMx
 eMx
-eMx
 aBB
 aBB
 aBB
 aBB
 aBB
 aBB
-oJW
-oJW
-oJW
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -356969,9 +359486,9 @@ aBB
 aBB
 aBB
 aBB
-mBR
-pvE
-feV
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -357420,11 +359937,11 @@ aBB
 aBB
 aBB
 aBB
-mBR
-pvE
-pvE
-hfu
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -357871,13 +360388,13 @@ aBB
 aBB
 aBB
 aBB
-apU
-lWf
-nNP
-nNP
-dwp
-apU
-rIw
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -358323,14 +360840,14 @@ aBB
 aBB
 aBB
 aBB
-vVH
-byw
-rub
-rub
-lXx
-vVH
-oCL
-rIw
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -358775,16 +361292,16 @@ aBB
 aBB
 aBB
 aBB
-vVH
-hHG
-qOD
-qOD
-mel
-vVH
-hHg
-pvE
-pvE
-rIw
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -359225,18 +361742,18 @@ aBB
 aBB
 aBB
 aBB
-vVH
-wDS
-vVH
-qOD
-qOD
-eDq
-wfE
-vVH
-qOD
-vVH
-apU
-tNg
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -359676,19 +362193,19 @@ aBB
 aBB
 aBB
 aBB
-pvE
-vVH
-vzE
-vVH
-xTn
-kZU
-apU
-vVH
-vVH
-qOD
-qOD
-gLC
-mlR
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -360128,20 +362645,20 @@ aBB
 aBB
 aBB
 aBB
-pvE
-mxB
-dTG
-gnN
-qOD
-cme
-tNg
-umA
-qOD
-qOD
-eDq
-qdI
-mlR
-rIw
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -360579,21 +363096,21 @@ aBB
 aBB
 aBB
 aBB
-bAZ
-fKJ
-vVH
-qGH
-qOD
-qOD
-apU
-apU
-umA
-xTn
-umA
-vVH
-apU
-oCk
-xyi
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -361032,20 +363549,20 @@ aBB
 aBB
 aBB
 aBB
-pvE
-mxB
-dTG
-qOD
-qOD
-qOD
-qOD
-gnN
-qOD
-qOD
-xAh
-mlR
-pvE
-cZA
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -361484,19 +364001,19 @@ aBB
 aBB
 aBB
 aBB
-pvE
-vVH
-eOe
-uii
-uii
-xoi
-uii
-oUJ
-hOX
-uii
-aAv
-mlR
-ppp
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -361937,18 +364454,18 @@ aBB
 aBB
 aBB
 aBB
-apU
-vVH
-nNP
-nNP
-vVH
-nNP
-vVH
-apU
-pHp
-pHp
-aWl
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -362036,7 +364553,7 @@ ijg
 aBB
 aBB
 aBB
-lpW
+aBB
 aBB
 aBB
 aBB
@@ -362391,16 +364908,16 @@ aBB
 aBB
 aBB
 aBB
-qzF
-pvE
-mlR
-ppp
-pvE
-pvE
-pvE
-ppp
-pvE
-cZA
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -362844,10 +365361,10 @@ aBB
 aBB
 aBB
 aBB
-qzF
-xYX
-pvE
-cZA
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -367008,7 +369525,7 @@ hiH
 aBB
 aBB
 aBB
-lpW
+aBB
 aBB
 aBB
 aBB
@@ -369609,14 +372126,14 @@ bmv
 xGN
 tvR
 oxi
-pvg
-pvg
+rbu
+rbu
 fVj
 dJN
 lpV
 gwD
-pvg
-kfA
+xVA
+iaM
 tvR
 hEb
 hiM
@@ -369718,7 +372235,7 @@ aBB
 aBB
 aBB
 aBB
-lpW
+aBB
 aBB
 aBB
 aBB
@@ -370060,15 +372577,15 @@ fbg
 uhn
 uhn
 aVq
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
 fVj
 dJN
 vDZ
 uKP
-pvg
-pvg
+cGN
+rbu
 jlo
 uyR
 kUG
@@ -370512,15 +373029,15 @@ tvR
 aJy
 dte
 tvR
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
 teV
 niU
-pvg
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
+rbu
 tvR
 uyR
 kUG
@@ -370972,7 +373489,7 @@ gzY
 gzY
 gzY
 bPF
-pvg
+rbu
 tvR
 lUf
 kUG
@@ -371416,7 +373933,7 @@ tvR
 fcI
 pFq
 tvR
-pvg
+rbu
 rMT
 oKQ
 oKQ
@@ -371424,7 +373941,7 @@ oKQ
 oKQ
 oKQ
 iTx
-pvg
+rbu
 tvR
 uyR
 kUG
@@ -371868,7 +374385,7 @@ fbg
 xdW
 xdW
 qWJ
-pvg
+rbu
 rMT
 oKQ
 oKQ
@@ -371876,7 +374393,7 @@ oKQ
 oKQ
 oKQ
 iTx
-pvg
+rbu
 tvR
 hEb
 tUu
@@ -371978,7 +374495,7 @@ nRO
 nRO
 aBB
 aBB
-lpW
+aBB
 aBB
 aBB
 aBB
@@ -372320,7 +374837,7 @@ tvR
 hsY
 gfJ
 tvR
-pvg
+rbu
 rMT
 oKQ
 oKQ
@@ -372780,7 +375297,7 @@ oKQ
 oKQ
 oKQ
 iTx
-pvg
+rbu
 tvR
 yds
 ukN
@@ -373224,15 +375741,15 @@ tvR
 kWj
 lLu
 tvR
-pvg
+rbu
 rMT
 oKQ
-oKQ
+hSt
 oKQ
 oKQ
 oKQ
 iTx
-pvg
+rbu
 tvR
 pJg
 fmF
@@ -373676,7 +376193,7 @@ fbg
 xQM
 xQM
 vja
-pvg
+rbu
 rMT
 oKQ
 oKQ
@@ -373684,7 +376201,7 @@ oKQ
 oKQ
 oKQ
 iTx
-pvg
+rbu
 tvR
 cVp
 uyR
@@ -374128,7 +376645,7 @@ tvR
 asP
 qWm
 tvR
-pvg
+rbu
 rMT
 oKQ
 oKQ
@@ -374136,7 +376653,7 @@ aQB
 oKQ
 oKQ
 iTx
-pvg
+rbu
 cEk
 uyR
 uyR
@@ -374588,7 +377105,7 @@ oKQ
 oKQ
 oKQ
 iTx
-pvg
+rbu
 dJN
 idm
 kvh
@@ -374674,8 +377191,8 @@ vvB
 vvB
 vvB
 vvB
-vvB
-vvB
+umA
+dqy
 vvB
 vvB
 vvB
@@ -375032,7 +377549,7 @@ tvR
 tkf
 xHf
 tvR
-pvg
+rbu
 rMT
 oKQ
 oKQ
@@ -375040,7 +377557,7 @@ oKQ
 oKQ
 oKQ
 iTx
-pvg
+rbu
 dJN
 dJN
 tvR
@@ -375124,12 +377641,12 @@ vvB
 vvB
 vvB
 vvB
-vvB
-vvB
-vvB
-vvB
-vvB
-vvB
+umA
+dqy
+dqy
+dqy
+dqy
+umA
 vvB
 vvB
 aBB
@@ -375484,7 +378001,7 @@ fbg
 kUG
 kUG
 rIv
-pvg
+rbu
 wLN
 teV
 teV
@@ -375492,7 +378009,7 @@ teV
 teV
 teV
 pia
-pvg
+rbu
 oDG
 tvR
 kSK
@@ -375576,14 +378093,14 @@ vvB
 vvB
 vvB
 vvB
-vvB
-vvB
-vvB
-vvB
-vvB
-vvB
-vvB
-vvB
+dqy
+dqy
+dqy
+dqy
+dqy
+dqy
+uuE
+eOe
 aBB
 aBB
 aBB
@@ -375936,13 +378453,13 @@ tvR
 tXl
 ruG
 tvR
-pvg
-pvg
-pvg
-vya
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
+gLC
+rbu
+rbu
+rbu
 gWE
 gzY
 gzY
@@ -376029,13 +378546,13 @@ vvB
 vvB
 vvB
 vvB
-vvB
-vvB
-vvB
-vvB
-vvB
-vvB
-vvB
+dqy
+dqy
+dqy
+dqy
+dqy
+uBd
+uuE
 aBB
 aBB
 aBB
@@ -376392,10 +378909,10 @@ iDZ
 jNc
 iDZ
 dJN
-pvg
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
+rbu
 klx
 oKQ
 tvR
@@ -376481,11 +378998,11 @@ vvB
 vvB
 vvB
 vvB
-vvB
-vvB
-vvB
-vvB
-vvB
+umA
+dqy
+dqy
+dqy
+dqy
 vvB
 vvB
 aBB
@@ -376845,9 +379362,9 @@ uyR
 uyR
 tvR
 gwi
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
 klx
 oKQ
 tvR
@@ -376934,9 +379451,9 @@ vvB
 vvB
 vvB
 vvB
-vvB
-vvB
-vvB
+dqy
+dqy
+umA
 vvB
 vvB
 vvB
@@ -377297,8 +379814,8 @@ udU
 udU
 tvR
 dzd
-pvg
-pvg
+rbu
+rbu
 wLN
 teV
 teV
@@ -377753,7 +380270,7 @@ udU
 nXL
 nXL
 udU
-pvg
+rbu
 eQT
 kSK
 kSK
@@ -380106,7 +382623,7 @@ vvB
 vvB
 vvB
 aBB
-aBB
+qzF
 aBB
 aBB
 aBB
@@ -380556,10 +383073,10 @@ vvB
 vvB
 vvB
 vvB
-fZN
-aBB
-aBB
-aBB
+rep
+uov
+uJe
+nRO
 aBB
 aBB
 aBB
@@ -381009,9 +383526,9 @@ vvB
 vvB
 vvB
 fZN
-fZN
-aBB
-aBB
+rep
+uJe
+nRO
 aBB
 aBB
 aBB
@@ -381459,11 +383976,11 @@ vvB
 vvB
 vvB
 vvB
-vvB
 fZN
 fZN
-aBB
-aBB
+fZN
+uJe
+nRO
 aBB
 aBB
 aBB
@@ -381911,11 +384428,11 @@ vvB
 vvB
 vvB
 vvB
-vvB
 fZN
 fZN
-aBB
-aBB
+fZN
+uJe
+nRO
 aBB
 aBB
 aBB
@@ -382363,11 +384880,11 @@ vvB
 vvB
 vvB
 vvB
-vvB
 fZN
 fZN
-aBB
-aBB
+qGH
+uJe
+nRO
 aBB
 aBB
 aBB
@@ -382815,11 +385332,11 @@ vvB
 vvB
 vvB
 vvB
-vvB
 fZN
 fZN
-aBB
-aBB
+fZN
+uJe
+nRO
 aBB
 aBB
 aBB
@@ -383267,11 +385784,11 @@ vvB
 vvB
 vvB
 vvB
-vvB
 fZN
 fZN
-aBB
-aBB
+fZN
+uJe
+nRO
 aBB
 aBB
 aBB
@@ -383721,9 +386238,9 @@ vvB
 vvB
 vvB
 fZN
-fZN
-aBB
-aBB
+rep
+uJe
+nRO
 aBB
 aBB
 aBB
@@ -384172,10 +386689,10 @@ vvB
 vvB
 vvB
 vvB
-fZN
-aBB
-aBB
-aBB
+rep
+vNC
+uJe
+nRO
 aBB
 aBB
 aBB
@@ -384626,7 +387143,7 @@ vvB
 vvB
 vvB
 aBB
-aBB
+pqc
 aBB
 aBB
 aBB
@@ -435804,7 +438321,7 @@ aBB
 aBB
 aBB
 aBB
-aBB
+lXx
 aBB
 aBB
 aBB
@@ -436255,12 +438772,12 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+lXx
+rwq
+rwq
+lXx
+lXx
+lXx
 aBB
 aBB
 aBB
@@ -436708,14 +439225,14 @@ aBB
 aBB
 aBB
 aBB
+lXx
 aBB
 aBB
 aBB
+lXx
+rwq
 aBB
-aBB
-aBB
-aBB
-aBB
+lXx
 aBB
 aBB
 aBB
@@ -437160,19 +439677,19 @@ aBB
 aBB
 aBB
 aBB
-aBB
-rbN
-eYU
-eYU
-eYU
-rbN
-aBB
-aBB
-aBB
+lXx
+tNg
+tNg
+tNg
+tNg
+hAp
+lXx
 aBB
 aBB
 aBB
 aBB
+aBB
+iiA
 aBB
 aBB
 aBB
@@ -437611,21 +440128,21 @@ aBB
 aBB
 aBB
 aBB
+lXx
 aBB
+tNg
+tNg
+tNg
+tNg
+tNg
+lXx
+iiA
+oCL
+mSR
 aBB
-lMW
-hEY
-tlX
-tlX
-tlX
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+iiA
+mSR
+iiA
 aBB
 aBB
 aBB
@@ -438065,20 +440582,20 @@ aBB
 aBB
 aBB
 aBB
-lMW
-wsv
-tlX
-tlX
-tlX
-oJW
+tNg
+tNg
+tNg
+tNg
+tNg
 aBB
+oCL
 aBB
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
+sYb
+iiA
+mSR
+sYb
+iiA
+iiA
 aBB
 aBB
 aBB
@@ -438515,27 +441032,27 @@ aBB
 aBB
 aBB
 aBB
+lXx
 aBB
+tNg
+tNg
+tNg
+tNg
+tNg
+oBU
+hDG
+kZU
+kDV
 aBB
-lMW
-tlX
-tlX
-tlX
-tlX
-oJW
-oJW
-oJW
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+sYb
+fVL
+oCL
+iiA
+mSR
+iiA
+mSR
+iiA
+mSR
 aBB
 aBB
 aBB
@@ -438967,28 +441484,28 @@ aBB
 aBB
 aBB
 aBB
+lXx
 aBB
+tNg
+tNg
+tNg
+tNg
+tNg
 aBB
-lMW
-iAh
-tlX
-tlX
-tlX
-oJW
-aBB
-aBB
-oJW
+rGN
 oJW
 oJW
 oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+kZU
+kZU
+tso
+fKJ
+fKJ
+iiA
+fVL
+iiA
+sYb
+iiA
 aBB
 aBB
 aBB
@@ -439419,28 +441936,28 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-rbN
-uvu
-tlX
-tlX
-tlX
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+rwq
+rwq
+tNg
+tNg
+tNg
+tNg
+tNg
+lXx
+mNc
+oJW
+mNc
+eTR
+tWF
+oJW
+ilj
+iiA
+iiA
+fKJ
+fKJ
+fKJ
+fKJ
+uyS
 aBB
 aBB
 aBB
@@ -439875,24 +442392,24 @@ aBB
 aBB
 aBB
 aBB
+rwq
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+lXx
+asA
+rib
+srr
+eTR
+jrR
+tWF
+ilj
+pPf
+pKX
+iiA
+iiA
+oCL
+iiA
+iiA
 aBB
 aBB
 aBB
@@ -440323,29 +442840,29 @@ aBB
 aBB
 aBB
 aBB
+lXx
+lXx
+aBB
+rwq
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+lXx
+iiA
+yiG
+eTR
+eTR
+gXi
+rGQ
+pyX
+uQR
+gXi
+eTR
+eTR
+pYc
+eTR
+oCk
+iiA
+iiA
 aBB
 aBB
 aBB
@@ -440775,29 +443292,29 @@ aBB
 aBB
 aBB
 aBB
+lXx
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+lXx
+lXx
+vzE
+pgb
+pPf
+eTR
+qOD
+cme
+tNg
+tNg
+rbX
+veg
+mKO
+hEY
+qOD
+ehr
+wvi
+oCk
+uyS
 aBB
 aBB
 aBB
@@ -441226,31 +443743,31 @@ aBB
 aBB
 aBB
 aBB
+lXx
 aBB
 aBB
 aBB
 aBB
 aBB
 aBB
+pUD
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+yiG
+pRv
+qWI
+rub
+eTR
+lca
+qOD
+qOD
+qOD
+gnN
+rbX
+qOD
+ehr
+wvi
+fPD
+iiA
 aBB
 aBB
 aBB
@@ -441678,31 +444195,31 @@ aBB
 aBB
 aBB
 aBB
+lXx
+lZK
+aBB
+aBB
+aBB
+pUD
 aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-oJW
-oJW
-oJW
-xRV
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+xbM
+qOD
+kHS
+lca
+gnN
+hOX
+iiV
+uii
+eMp
+qOD
+hEY
+pkz
+wvi
+jjR
+uyS
 aBB
 aBB
 aBB
@@ -442131,31 +444648,31 @@ aBB
 aBB
 aBB
 aBB
+lZK
+aBB
+pUD
 aBB
 aBB
 aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-oJW
-oJW
-oJW
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+rOR
+qOD
+qOD
+rbX
+qOD
+gpd
+tNg
+tNg
+dTG
+qOD
+apU
+veg
+eTR
+fPD
+iiA
+iiA
 aBB
 aBB
 aBB
@@ -442583,6 +445100,7 @@ aBB
 aBB
 aBB
 aBB
+lZK
 aBB
 aBB
 aBB
@@ -442590,24 +445108,23 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-oJW
-oJW
-oJW
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+oBU
+rOR
+qOD
+qOD
+rbX
+qOD
+gpd
+tNg
+tNg
+dTG
+qOD
+apU
+veg
+eTR
+fPD
+pPf
+uyS
 aBB
 aBB
 aBB
@@ -443035,31 +445552,31 @@ aBB
 aBB
 aBB
 aBB
+lZK
+aBB
+pUD
 aBB
 aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-oJW
-oJW
-oJW
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+iiA
+xbM
+qOD
+kHS
+lca
+eDq
+qWI
+emf
+rub
+hiu
+qOD
+hEY
+pkz
+wvi
+jjR
+uyS
+iiA
 aBB
 aBB
 aBB
@@ -443490,27 +446007,27 @@ aBB
 aBB
 aBB
 aBB
+pUD
 aBB
 aBB
-aBB
-aBB
+pUD
 oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+yiG
+pRv
+hOX
+uii
+eTR
+lca
+qOD
+qOD
+qOD
+eDq
+rbX
+qOD
+ehr
+wvi
+fPD
+iiA
 aBB
 aBB
 aBB
@@ -443946,23 +446463,23 @@ aBB
 aBB
 aBB
 oJW
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-oJW
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+heG
+pgb
+eTR
+qOD
+cme
+tNg
+eTR
+xsx
+veg
+mKO
+hEY
+qOD
+ehr
+wvi
+oCk
+iiA
+iiA
 aBB
 aBB
 aBB
@@ -444398,22 +446915,22 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-oJW
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+pUD
+yiG
+eTR
+eTR
+gXi
+mKO
+szH
+qOD
+qHJ
+gXi
+gXi
+pYc
+eTR
+eTR
+iiA
+iiA
 aBB
 aBB
 aBB
@@ -444842,6 +447359,7 @@ aBB
 aBB
 aBB
 aBB
+lZK
 aBB
 aBB
 aBB
@@ -444850,22 +447368,21 @@ aBB
 aBB
 aBB
 aBB
+iiA
+eTR
+acQ
+szH
+gnN
+qOD
+qOD
+szH
+eTR
+fKJ
 aBB
 aBB
-aBB
-oJW
-oJW
-aBB
-aBB
-oJW
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+pUD
+pgb
+uyS
 aBB
 aBB
 aBB
@@ -445294,30 +447811,30 @@ aBB
 aBB
 aBB
 aBB
+lZK
 aBB
 aBB
 aBB
 aBB
 aBB
+pUD
 aBB
+iiA
+iiA
+gXi
+fyO
+qOD
+qOD
+qOD
+szH
+eTR
+tNg
+fKJ
 aBB
-aBB
-aBB
-aBB
-aBB
-oJW
-oJW
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+fKJ
+fKJ
+iiA
+iiA
 aBB
 aBB
 aBB
@@ -445747,28 +448264,28 @@ aBB
 aBB
 aBB
 aBB
+lZK
 aBB
 aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
+pUD
+iiA
+iiA
 xRV
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+szH
+qOD
+qOD
+asu
+toh
+eTR
+eTR
+pPf
+uyS
+iiA
+iiA
+iiA
 aBB
 aBB
 aBB
@@ -446202,24 +448719,24 @@ aBB
 aBB
 aBB
 aBB
+ozv
 aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+tUg
+lop
+qOD
+qOD
+szH
+brh
+iiA
+iiA
+sYb
+iiA
+iiA
+iiA
+iiA
 aBB
 aBB
 aBB
@@ -446654,23 +449171,23 @@ aBB
 aBB
 aBB
 aBB
+rLo
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+iiA
+oCL
+eTR
+qOD
+qOD
+unb
+eTR
+qei
+iiA
+sse
+iiA
+iiA
+iiA
 aBB
 aBB
 aBB
@@ -447106,21 +449623,21 @@ aBB
 aBB
 aBB
 aBB
+pUD
+ozv
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-oJW
-oJW
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+iiA
+iiA
+fVL
+lmg
+qOD
+qOD
+eTR
+sYb
+iiA
+iiA
+pUD
+iiA
 aBB
 aBB
 aBB
@@ -447559,19 +450076,19 @@ aBB
 aBB
 aBB
 aBB
+rLo
 aBB
-aBB
-aBB
-aBB
-aBB
-rbN
-tlX
+oCL
+yiG
+pUD
+apU
+rbX
 eYU
-rbN
-aBB
-aBB
-aBB
-aBB
+apU
+hxC
+iiA
+oCL
+iiA
 aBB
 aBB
 aBB
@@ -448006,23 +450523,23 @@ aBB
 aBB
 aBB
 aBB
+lZK
 aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+pUD
+iiA
+sYb
+iiA
+sYb
 lMW
 tlX
-tlX
+iZR
 gOR
-aBB
-aBB
-aBB
+iiA
+iiA
+fVL
 aBB
 aBB
 aBB
@@ -448458,23 +450975,23 @@ aBB
 aBB
 aBB
 aBB
+lZK
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+iiA
+iiA
+iiA
+iiA
+pUD
+iiA
+sse
 lMW
 tlX
 tlX
 gOR
-aBB
-aBB
-aBB
+mSR
+iiA
+pUD
 aBB
 aBB
 aBB
@@ -448911,22 +451428,22 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+lZK
+oCL
+oCL
+iiA
+oCL
+iiA
+iiA
+iiA
+iiA
 lMW
 tlX
 tlX
-gOR
-aBB
-aBB
-aBB
+veg
+sYb
+mSR
+sse
 aBB
 aBB
 aBB
@@ -449363,24 +451880,24 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-rbN
+tFJ
+pUD
+fVL
+kVi
+sYb
+apU
 eYU
 eYU
 eYU
-rbN
+veg
 tlX
 tlX
 tlX
-oJW
-oJW
-aBB
-aBB
-aBB
+kZU
+cvP
+iiA
+iiA
+iiA
 aBB
 aBB
 aBB
@@ -449814,25 +452331,25 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+pUD
+lZK
+sse
+sYb
+kZU
+pUD
+jdg
+hMM
+hMM
+hMM
+jdg
 tlX
 tlX
-tlX
-tlX
-tlX
-tlX
-tlX
-tlX
-aBB
-oJW
-aBB
-aBB
-aBB
+vNA
+pUD
+ilj
+uyS
+pUD
+iiA
 aBB
 aBB
 aBB
@@ -450267,26 +452784,26 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+oBU
+vGk
+pUD
+oJW
+gCO
 tlX
 nde
 tNg
 tNg
+jKc
 tlX
 tlX
 tlX
-tlX
-oJW
-oJW
-oJW
-aBB
-aBB
-aBB
-aBB
+vtD
+kwi
+iiA
+lXx
+iiA
+iiA
+iiA
 aBB
 aBB
 aBB
@@ -450720,26 +453237,26 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-tlX
+iiA
+mgZ
+oJW
+oJW
+iaY
 nde
 tNg
 tNg
-tlX
-tlX
-tlX
-gOR
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+haW
+ged
+acn
+veg
+hxC
+sYb
+iiA
+lXx
+lXx
+pUD
+iiA
+lXx
 aBB
 aBB
 aBB
@@ -451170,28 +453687,28 @@ aBB
 aBB
 aBB
 aBB
+pUD
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-rbN
+iiA
+rJh
+dUx
+ghB
+apU
 ndL
 ndL
 ndL
+apU
 ndL
 ndL
-ndL
-rbN
+apU
+iiA
+hxC
+iiA
 aBB
-aBB
-aBB
-aBB
-aBB
-oJW
-oJW
-oJW
+lXx
+lXx
+lXx
+lXx
 aBB
 aBB
 aBB
@@ -451623,26 +454140,26 @@ aBB
 aBB
 aBB
 aBB
+vzE
+pgb
+pUD
+sse
+pUD
+iiA
+iiA
+iiA
+hxC
+sYb
+fVL
+hxC
+iiA
+iiA
+iiA
+iiA
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-oJW
+lXx
 aBB
 aBB
 aBB
@@ -452076,6 +454593,18 @@ aBB
 aBB
 aBB
 aBB
+iiA
+sYb
+iiA
+sse
+iiA
+aBB
+iiA
+iiA
+fVL
+sYb
+iiA
+iiA
 aBB
 aBB
 aBB
@@ -452083,19 +454612,7 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+lXx
 aBB
 aBB
 aBB
@@ -452529,6 +455046,15 @@ aBB
 aBB
 aBB
 aBB
+sse
+aBB
+iiA
+aBB
+aBB
+aBB
+aBB
+hxC
+hxC
 aBB
 aBB
 aBB
@@ -452537,17 +455063,8 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+lXx
+lXx
 aBB
 aBB
 aBB
@@ -452996,7 +455513,7 @@ aBB
 aBB
 aBB
 aBB
-aBB
+fKJ
 aBB
 aBB
 aBB
@@ -453444,7 +455961,7 @@ aBB
 aBB
 aBB
 aBB
-aBB
+fKJ
 aBB
 aBB
 aBB
@@ -453893,9 +456410,9 @@ aBB
 aBB
 aBB
 aBB
+fKJ
 aBB
-aBB
-aBB
+fKJ
 aBB
 aBB
 aBB
@@ -454352,7 +456869,7 @@ aBB
 aBB
 aBB
 aBB
-aBB
+lXx
 aBB
 aBB
 aBB
@@ -454801,10 +457318,10 @@ aBB
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
+lXx
+lXx
+lXx
+lXx
 aBB
 aBB
 aBB
@@ -455242,18 +457759,18 @@ aBB
 aBB
 aBB
 aBB
+lXx
+aBB
+aBB
+lXx
+lXx
+lXx
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+lXx
+lXx
+lXx
 aBB
 aBB
 aBB
@@ -455695,15 +458212,15 @@ aBB
 aBB
 aBB
 aBB
+lXx
+lXx
+aBB
+aBB
+lXx
 aBB
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+lXx
 aBB
 aBB
 aBB
@@ -456148,14 +458665,14 @@ aBB
 aBB
 aBB
 aBB
+lXx
 aBB
 aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+lXx
+lXx
+lXx
+lXx
+lXx
 aBB
 aBB
 aBB
@@ -471323,16 +473840,16 @@ tCE
 aBB
 aBB
 aBB
-pvE
-pvE
-pvE
 aBB
 aBB
 aBB
 aBB
 aBB
-pvE
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -471774,17 +474291,17 @@ kgg
 aBB
 aBB
 aBB
-pvE
-pvE
-sse
-sCr
-pvE
 aBB
 aBB
-pvE
-pvE
-sCr
-sCr
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -472226,18 +474743,18 @@ aBB
 aBB
 aBB
 aBB
-bAZ
-uWJ
-btN
-eTR
-pHp
-pHp
-pHp
-pHp
-eTR
-btN
-dQi
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -472678,17 +475195,17 @@ aBB
 aBB
 aBB
 aBB
-pvE
-pvE
-eTR
-hqA
-rub
-rub
-rub
-rub
-hiu
-eTR
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -473130,17 +475647,17 @@ aBB
 aBB
 aBB
 aBB
-pvE
-pvE
-eTR
-xdh
-qOD
-qOD
-qOD
-umA
-dGk
-eTR
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -473581,19 +476098,19 @@ aBB
 aBB
 aBB
 aBB
-pvE
-pvE
-sCr
-eTR
-xdh
-qOD
-qOD
-eDq
-umA
-fZe
-eTR
-pvE
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -474032,21 +476549,21 @@ aBB
 aBB
 aBB
 aBB
-bAZ
-pHp
-btN
-eTR
-eTR
-umA
-umA
-xTn
-umA
-umA
-tNg
-eTR
-btN
-pHp
-oei
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -474485,19 +477002,19 @@ aBB
 aBB
 aBB
 aBB
-pvE
-eTR
-wuP
-qOD
-qOD
-qOD
-qOD
-qOD
-apU
-umA
-umA
-eTR
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -474937,19 +477454,19 @@ aBB
 aBB
 aBB
 aBB
-pvE
-mlR
-iXm
-qOD
-tlX
-tlX
-tlX
-tlX
-tlX
-qOD
-brh
-oCk
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -475389,19 +477906,19 @@ aBB
 aBB
 aBB
 aBB
-tNg
-mlR
-iXm
-qOD
-tlX
-tlX
-tlX
-tlX
-tlX
-qOD
-oBU
-oCk
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -475841,19 +478358,19 @@ aBB
 aBB
 aBB
 aBB
-pvE
-sFs
-hiu
-eDq
-tlX
-szH
-szH
-szH
-tlX
-eDq
-brh
-sPd
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -476292,21 +478809,21 @@ aBB
 aBB
 aBB
 aBB
-pvE
-bAZ
-btN
-eTR
-apU
-ehr
-hlK
-nus
-nAQ
-szH
-eTR
-eTR
-btN
-pHp
-oei
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -476745,19 +479262,19 @@ aBB
 aBB
 aBB
 aBB
-pvE
-pvE
-pvE
-eTR
-gpd
-vqR
-oRq
-vtD
-eGq
-eTR
-oCk
-xYX
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -477198,17 +479715,17 @@ aBB
 aBB
 aBB
 aBB
-qKN
-pHp
-btN
-eTR
-pHp
-pHp
-pHp
-eTR
-btN
-oei
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -477651,15 +480168,15 @@ aBB
 aBB
 aBB
 aBB
-sCr
-hMt
-pvE
-pvE
-sCr
-pvE
-pvE
-mlR
-pvE
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -478103,14 +480620,14 @@ aBB
 aBB
 aBB
 aBB
-pvE
-xYX
 aBB
 aBB
-pvE
 aBB
 aBB
-xYX
+aBB
+aBB
+aBB
+aBB
 aBB
 aBB
 aBB
@@ -484874,9 +487391,9 @@ kSK
 tvR
 oKQ
 vuu
-kfA
-pvg
-pvg
+iaM
+rbu
+rbu
 udU
 tvR
 xHb
@@ -484947,7 +487464,7 @@ aBB
 aBB
 aBB
 aBB
-aBB
+ycv
 aBB
 aBB
 aBB
@@ -485326,15 +487843,15 @@ kSK
 tvR
 oKQ
 vuu
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
 ezW
 tvR
 jlW
-qcy
-kUG
-kUG
+tCw
+pvg
+pvg
 ygG
 tvR
 kSK
@@ -485403,7 +487920,7 @@ bxz
 bxz
 bxz
 aBB
-aBB
+ycv
 aBB
 aBB
 aBB
@@ -485780,13 +488297,13 @@ tvR
 tvR
 dJN
 dzd
-pvg
+rbu
 jSr
 tvR
 pvg
-kUG
-kUG
-kUG
+pvg
+rlj
+pvg
 cnL
 jIV
 kSK
@@ -485857,7 +488374,7 @@ jWD
 jWD
 jWD
 aBB
-aBB
+ycv
 aBB
 aBB
 aBB
@@ -486231,14 +488748,14 @@ tvR
 pBl
 gvx
 tvR
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
 hgo
 pvg
-kUG
-kUG
-kUG
+pvg
+pvg
+pvg
 pvg
 tvR
 kSK
@@ -486302,19 +488819,19 @@ aBB
 bxz
 bxz
 bxz
-scU
+byw
 dif
 uJM
-osI
+unz
 lkD
-rQD
+rox
 jWD
 jWD
 aBB
 aBB
+ycv
 aBB
-aBB
-aBB
+ycv
 jWD
 kGU
 kGU
@@ -486683,13 +489200,13 @@ fbg
 pvg
 pvg
 phH
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
 tvR
 imq
 imq
-vya
+lZj
 rvn
 eKx
 tvR
@@ -486757,14 +489274,14 @@ bxz
 uyq
 hFR
 rQP
-cGL
+tdO
 cxC
 cxC
-lPL
+lVI
 jWD
 jWD
-bxz
-bxz
+jWD
+jWD
 bxz
 bxz
 jWD
@@ -487133,11 +489650,11 @@ kSK
 kSK
 tvR
 kat
-eKx
+bPB
 tvR
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
 dJN
 tvR
 tvR
@@ -487214,16 +489731,16 @@ cxC
 cxC
 cxC
 cxC
-fNs
-lkD
-qTi
-bIK
+vIo
+cxC
+wSG
+cxC
 gjk
 gXN
 nKE
 vJA
 vJA
-uhs
+hbH
 dif
 bxz
 aBB
@@ -487588,8 +490105,8 @@ tvR
 tvR
 dJN
 dzd
-pvg
-pvg
+rbu
+rbu
 tvR
 imq
 imq
@@ -487668,8 +490185,8 @@ cxC
 cxC
 cxC
 cxC
-lNW
-qTi
+cxC
+cxC
 oeX
 ujZ
 nKE
@@ -488039,14 +490556,14 @@ tvR
 pBl
 gvx
 tvR
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
 bQY
 pvg
-xdW
-xdW
-xdW
+pvg
+pvg
+pvg
 vbV
 tvR
 kSK
@@ -488110,25 +490627,25 @@ aBB
 aBB
 aBB
 kGU
-jOp
+bNB
 gyl
 tYQ
-xlK
-jOp
+xnn
+dHy
 wtI
 fQS
-rQD
+mlR
 cxC
 cxC
 cxC
 cxC
-dLa
-nKE
-nKE
-nKE
-nKE
+uZy
+fZe
+mel
+mel
+cot
 smT
-hmM
+uWq
 qTi
 teA
 bxz
@@ -488484,21 +491001,21 @@ kSK
 fbg
 gvx
 pvg
-tvR
+pKo
 pvg
 gvx
-tvR
+msQ
 pvg
 pvg
 ePp
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
 tvR
 pvg
-xdW
-xdW
-xdW
+pvg
+oCV
+pvg
 cnL
 jIV
 kSK
@@ -488571,17 +491088,17 @@ xlK
 wYH
 cjY
 rCh
-ntY
+xkz
 cxC
 cxC
 cxC
-jUF
+ehR
 gPm
-vob
-vob
+cxH
+qUO
 cDc
-nKE
-dLa
+xGW
+tKY
 xoe
 bxz
 aBB
@@ -488941,16 +491458,16 @@ pvg
 kat
 tvR
 kat
-eKx
+bPB
 tvR
-pvg
-pvg
+rbu
+rbu
 udU
 tvR
 edi
-uZy
-xdW
-xdW
+tCw
+pvg
+pvg
 pvg
 tvR
 kSK
@@ -489021,7 +491538,7 @@ kGU
 kGU
 bxz
 sBb
-qTi
+xoe
 nKE
 nKE
 cWq
@@ -489396,7 +491913,7 @@ tvR
 tvR
 dJN
 dzd
-pvg
+rbu
 rtm
 tvR
 qEt
@@ -489477,16 +491994,16 @@ qTi
 vJA
 vJA
 mSD
-cxC
+oaH
 cxC
 rfR
 ygf
 ygf
+lWf
 ygf
-ygf
-ygf
-pBu
-lgU
+nNa
+pvK
+nZu
 rdr
 jWD
 aBB
@@ -489838,17 +492355,17 @@ bGf
 bGf
 kSK
 tvR
-pvg
-pvg
-kfA
-pvg
-pvg
-kfA
-pvg
+rbu
+rbu
+iaM
+rbu
+rbu
+iaM
+rbu
 kGT
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
 jSr
 dJN
 tvR
@@ -489928,14 +492445,14 @@ jWD
 vJA
 vJA
 vJA
-uhs
+oKj
 cxC
 llc
 rfR
 ygf
-mdB
-ygf
-nNa
+cRQ
+xeJ
+rkg
 ygf
 wMc
 cDc
@@ -490290,18 +492807,18 @@ bGf
 bGf
 kSK
 fbg
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
-pvg
+rbu
+rbu
+rbu
+rbu
+rbu
+rbu
+rbu
+rbu
+rbu
+rbu
+rbu
+rbu
 tvR
 kSK
 kSK
@@ -490378,19 +492895,19 @@ aBB
 aBB
 aBB
 kGU
+frC
 vJA
-vJA
-sMv
-cxC
+wbv
+sTA
 odv
 rfR
-ygf
-ygf
+mdB
+wCu
 mTs
+hTS
 ygf
 ygf
-ygf
-pBu
+pvK
 dLx
 jWD
 aBB
@@ -490742,17 +493259,17 @@ bGf
 bGf
 kSK
 tvR
-pvg
-pvg
-pvg
-vya
-pvg
-pvg
-pvg
-pvg
-vya
-pvg
-pvg
+rbu
+rbu
+rbu
+gLC
+rbu
+rbu
+rbu
+rbu
+gLC
+rbu
+rbu
 gSn
 tvR
 kSK
@@ -490832,19 +493349,19 @@ aBB
 jWD
 vEO
 bwx
-xlK
+nUJ
 cxC
 nhl
-rfR
+uRn
 ygf
-nNa
-ygf
-lGD
-ygf
+iOt
+qaY
+bri
+lWf
 nNa
 pBu
-rQD
-jWD
+oJn
+maO
 aBB
 aBB
 aBB
@@ -491285,18 +493802,18 @@ aBB
 jWD
 vEO
 eJR
-cxC
+wSG
 cxC
 rfR
+nNa
+lWf
 ygf
 ygf
 ygf
 ygf
-oCV
-ygf
-pBu
-rdr
-jWD
+pvK
+oJn
+gby
 aBB
 aBB
 aBB
@@ -491647,7 +494164,7 @@ bGf
 kSK
 tvR
 ruI
-uhn
+pvg
 pBl
 tvR
 lNe
@@ -491655,8 +494172,8 @@ xdW
 jZF
 pBl
 tvR
-xXw
-kUG
+xHb
+pvg
 pBl
 tvR
 kSK
@@ -491737,16 +494254,16 @@ aBB
 aBB
 jWD
 qtu
-ntY
+qRm
 cxC
 ivn
-oyB
+fjp
 ygf
 ygf
 mdB
 ygf
 tBQ
-jTc
+eQf
 uWq
 kGU
 aBB
@@ -492098,8 +494615,8 @@ bGf
 bGf
 kSK
 fbg
-cHP
-uhn
+qEt
+eJz
 cnL
 tvR
 fVT
@@ -492108,7 +494625,7 @@ xdW
 cnL
 tvR
 ndh
-kUG
+lPz
 cnL
 rRi
 kSK
@@ -492194,11 +494711,11 @@ dLa
 cxC
 ivn
 oyB
-ygf
+nNa
 ygf
 tBQ
 jTc
-jUF
+xkz
 bwx
 kGU
 aBB
@@ -492550,8 +495067,8 @@ bGf
 bGf
 kSK
 tvR
-rwq
-uhn
+pxl
+pvg
 pvg
 tvR
 qWH
@@ -492560,7 +495077,7 @@ xdW
 pvg
 tvR
 pxl
-kUG
+pvg
 pvg
 tvR
 kSK
@@ -492648,9 +495165,9 @@ cxC
 ivn
 jCB
 jCB
-jTc
-dLa
-ntY
+eQf
+bDe
+pkU
 eJR
 kGU
 aBB
@@ -493100,7 +495617,7 @@ nKE
 rkU
 cxC
 cxC
-nKE
+xkz
 osI
 fnp
 qJU
@@ -494907,7 +497424,7 @@ eZk
 scU
 nKE
 cxC
-cxC
+xkz
 vut
 lPL
 vJA
@@ -495356,7 +497873,7 @@ aBB
 aBB
 jWD
 qtu
-ntY
+lPL
 cxC
 cxC
 nKE
@@ -495815,10 +498332,10 @@ nKE
 aRu
 cgn
 rQD
-nKE
 dLa
+vUC
+wef
 wpd
-aBB
 aBB
 aBB
 aBB
@@ -496263,14 +498780,14 @@ jWD
 jAc
 cxC
 cxC
-nKE
+uZy
 uWq
 hVR
 nKE
-nKE
-cxC
-wpd
-aBB
+uZy
+wuP
+cHP
+bef
 aBB
 aBB
 aBB
@@ -496713,17 +499230,17 @@ aBB
 aBB
 jWD
 fNs
-nKE
+dLa
 cxC
 cxC
 cxC
-nKE
-nKE
+uZy
+qFK
 cxC
-cxC
-wpd
-aBB
-aBB
+mMD
+brR
+brR
+mCw
 aBB
 aBB
 aBB
@@ -497172,10 +499689,10 @@ cxC
 cxC
 cxC
 cxC
-cxC
-wpd
-aBB
-aBB
+brT
+rsN
+cak
+oUJ
 aBB
 aBB
 aBB
@@ -497624,10 +500141,10 @@ cxC
 cxC
 cxC
 cxC
-cxC
-wpd
-aBB
-aBB
+brT
+tDB
+pmv
+plQ
 aBB
 aBB
 aBB
@@ -498072,14 +500589,14 @@ jWD
 qtu
 nKE
 nKE
-nKE
+lNW
 mHw
 cxC
 cxC
-cxC
-wpd
-aBB
-aBB
+brT
+ikY
+wkM
+ciL
 aBB
 aBB
 aBB
@@ -498526,12 +501043,12 @@ nKE
 nKE
 nKE
 aRu
-nKE
+ehh
 cxC
-cxC
-wpd
-aBB
-aBB
+mkb
+brR
+brR
+cDJ
 aBB
 aBB
 aBB
@@ -498979,10 +501496,10 @@ nKE
 nKE
 aRu
 lgU
-nKE
-cxC
-wpd
-aBB
+nNP
+wuP
+cHP
+fGf
 aBB
 aBB
 aBB
@@ -499431,10 +501948,10 @@ qTi
 qTi
 wYH
 ntY
-nKE
 dLa
+ceO
+sXF
 wpd
-aBB
 aBB
 aBB
 aBB
@@ -503951,7 +506468,7 @@ aBB
 aBB
 aBB
 bxz
-wYH
+sgq
 qTi
 lgU
 jWD
@@ -504858,7 +507375,7 @@ aBB
 aBB
 jWD
 nKE
-nKE
+jxy
 jWD
 aBB
 aBB
@@ -505309,9 +507826,9 @@ aBB
 aBB
 aBB
 kGU
+wUK
 vJA
-xlK
-xlK
+wUK
 kGU
 aBB
 aBB
@@ -506217,7 +508734,7 @@ aBB
 kGU
 vJA
 vJA
-eLx
+kGU
 aBB
 aBB
 aBB
@@ -506669,7 +509186,7 @@ aBB
 kGU
 kGU
 jpO
-eLx
+kGU
 aBB
 aBB
 aBB
@@ -507121,7 +509638,7 @@ aBB
 aBB
 kGU
 kGU
-eLx
+kGU
 aBB
 aBB
 aBB


### PR DESCRIPTION
The Eoran Shrine Changes
PR seen by @ConstantineII , with revised staircase.
(featured picture of gone staircase as proofz)
<img width="377" height="450" alt="image" src="https://github.com/user-attachments/assets/f30bc424-9ce5-4c60-a9c1-92b760ee9eb0" />


<img width="758" height="527" alt="image" src="https://github.com/user-attachments/assets/de364dee-2a0e-4722-8322-7b30e90740b6" />


<img width="769" height="497" alt="image" src="https://github.com/user-attachments/assets/2dc75049-8c0f-4044-8467-28057233bf14" />

<img width="415" height="442" alt="image" src="https://github.com/user-attachments/assets/15b09ed7-ba57-4ca4-a81e-55fba2256dd5" />

 
 Cute stairway to a sitting area. Has a little bridge and garden. The path to it is not very evident. 
 
<img width="784" height="679" alt="image" src="https://github.com/user-attachments/assets/7302af15-f579-4b0e-b9b3-c6e672f385ef" />

<img width="859" height="630" alt="image" src="https://github.com/user-attachments/assets/b8590b62-01a4-4092-9c6f-e61fd58981a8" />



A large different in terraforming is the addition of the river I created for aesthetics. It has a waterfall that leads off the cliffside. 

<img width="582" height="649" alt="image" src="https://github.com/user-attachments/assets/0d8b5e1e-2f55-46b3-af80-529c7d8e6710" />

<img width="974" height="635" alt="image" src="https://github.com/user-attachments/assets/323ae6e5-9ead-4624-b634-f7aac9f34ba8" />



###  The Tavern + Bath-House Changes

- Features a  mostly aesthetic front-house redesign of the tavern to fit scarlet reaches themes. I went with a gothique victorian sort of hunters lodge idea. I wish I had more table-color variations and details.

<img width="681" height="678" alt="image" src="https://github.com/user-attachments/assets/c517f4e1-7e23-43cd-837e-d771c1dabb91" />

I also touched up the luxury rooms with carpets and added some worthwhile loot for rogues to find in them. (it's just candlesticks, bro.)

<img width="735" height="690" alt="image" src="https://github.com/user-attachments/assets/f4e2ea96-00d7-4f41-b337-6be0c54d88f0" />



- The bath-house is mostly untouched beyond the main pool for now as stands.

Added a bit more 'Eora' To this locale; to make it feel more divine. Despite it's dirty secrets. ;)

<img width="405" height="388" alt="image" src="https://github.com/user-attachments/assets/2a0e1896-cbe7-429a-8232-7daff8393f26" />



- Noticeboards have been changed. largest and most noticeable changes are the central fountain noticeboard.

I also put one near the church, mercenaries guild (closer) and in the keep to try and faciliate more use of this awesome feature.

<img width="379" height="332" alt="image" src="https://github.com/user-attachments/assets/0377cdca-2687-4440-8d2b-766f7782398d" />

<img width="248" height="221" alt="image" src="https://github.com/user-attachments/assets/591364a0-5492-406f-92b0-9697e92aa556" />

<img width="321" height="279" alt="image" src="https://github.com/user-attachments/assets/7c309254-4fbe-4818-b952-9aeecb4c4c87" />

<img width="326" height="233" alt="image" src="https://github.com/user-attachments/assets/601425a6-2430-4521-9fd1-6d0cf82e101d" />

<img width="703" height="453" alt="image" src="https://github.com/user-attachments/assets/6fdec9a4-a21b-4fbe-863f-a4ffe491d1a4" />

<img width="192" height="202" alt="image" src="https://github.com/user-attachments/assets/3a39d3ab-2b5c-4799-83b1-3cbceed8a631" />



### The Dendorite Changes:

Original location: Moved (Huge!)

<img width="844" height="758" alt="image" src="https://github.com/user-attachments/assets/176fb8e9-54f7-45eb-9dd7-976068004b81" />

New location to the far south, near adventurer spawn where a goblin outpost used to be. 
This locale has been made to look more wild and ruinous; like an outpost of old that was overtaken by dendorite druids long ago. It was inspired heavily by the old tree-house.

It features many Z-layers, and still has access to the goblin/troll dungeon below. The base reflects druids and nature-types, with places to hone all the skills of the wild and find refuge; whilst feeling secluded and secular enough it might actually establish the druids as a unique neutral party and bring intrigue to dendor!

Top Z-layer:

<img width="1016" height="662" alt="image" src="https://github.com/user-attachments/assets/3da5ac81-6905-4b83-97fb-8acfc15d2d6b" />

Ground-Level (On a peak)

<img width="1039" height="690" alt="image" src="https://github.com/user-attachments/assets/7c8f905c-17f9-401e-a0d4-be4599821632" />

Actual Ground Level: (Underground Mushroom River Nexus W/ Caverns and the original path below the tree leading to the dungeon. (It's barred, as if it's been locked up!)

<img width="1025" height="623" alt="image" src="https://github.com/user-attachments/assets/209fd95c-97f1-4363-b04a-1289e211668c" />




## Testing Evidence

it works.. because I says so.. ya.. 

## Why It's Good For The Game

Life is temporary. The senses a feast. Let us diverge from the normality of how it has been and embrace the new. 
