### PR TITLE
golem skill exhibitor tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/golem/golem.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/golem/golem.dm
@@ -163,7 +163,7 @@
 	if(user.construct && !self_usable)
 		to_chat(user, span_warning("I am unable to modify Golems. I must ask another."))//Golems NEED to ask organics to modify them.
 		return
-	if(user.get_skill_level(/datum/skill/craft/engineering) < 3 && !self_usable) //need to be at least level 3 skill level in engineering to use this
+	if(user.get_skill_level(/datum/skill/craft/engineering) < SKILL_LEVEL_APPRENTICE && !self_usable) //need to be at least level 2 skill level in engineering to use this
 		to_chat(user, span_warning("I fiddle around trying to properly insert [src] into [M], but I'm not skilled enough."))
 		return
 	if(in_use)

--- a/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
+++ b/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
@@ -201,4 +201,4 @@
 	created_item = /obj/item/golem_skill_core
 	req_bar = /obj/item/ingot/copper
 	additional_items = list(/obj/item/roguegear, /obj/item/roguegear)
-	craftdiff = 4
+	craftdiff = 3


### PR DESCRIPTION
## About The Pull Request

makes them easier skill-wise to make and install

## Testing Evidence

trust me bro!

## Why It's Good For The Game

anvil recipes are NOT crafting recipes, meaning they can't be easily brute-forced without losing a ton of resources- this wasn't my intention and it resulted in basically locking skill exhibitor creation and installation behind the existence of an artificer (which I _do_ think needs a bit of reason to exist, just not in this way)
Hopefully this allows golem and doll players to actually access the content designed for them to be able to access