### PR TITLE
Passive Grab Nerf + Grab Resist CD change

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -486,7 +486,8 @@
 	if(isliving(AM))
 		var/mob/living/M = AM
 		if(M.cmode && M.stat == CONSCIOUS)
-			M.resist_grab(freeresist = TRUE) //Automatically attempt to break a passive grab if defender's combat mode is on. Anti-grabspam measure.
+			if(M.get_skill_level(/datum/skill/combat/wrestling) > 4 || src.get_skill_level(/datum/skill/combat/wrestling) < 5) //Grabber skill less than Master OR grabbed skill at Master or above.
+				M.resist_grab(freeresist = TRUE) //Automatically attempt to break a passive grab if defender's combat mode is on. Anti-grabspam measure.
 
 /mob/living/proc/send_pull_message(mob/living/target)
 	target.visible_message(span_warning("[src] grabs [target]."), \

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -485,9 +485,10 @@
 
 	if(isliving(AM))
 		var/mob/living/M = AM
-		if(M.cmode && M.stat == CONSCIOUS && !M.restrained(ignore_grab = TRUE))
-			if(M.get_skill_level(/datum/skill/combat/wrestling) > 4 || src.get_skill_level(/datum/skill/combat/wrestling) < 5) //Grabber skill less than Master OR grabbed skill at Master or above.
-				M.resist_grab(freeresist = TRUE) //Automatically attempt to break a passive grab if defender's combat mode is on. Anti-grabspam measure.
+		if(M.mind)
+			if(M.cmode && M.stat == CONSCIOUS && !M.restrained(ignore_grab = TRUE))
+				if(M.get_skill_level(/datum/skill/combat/wrestling) > 4 || src.get_skill_level(/datum/skill/combat/wrestling) < 5) //Grabber skill less than Master OR grabbed skill at Master or above.
+					M.resist_grab(freeresist = TRUE) //Automatically attempt to break a passive grab if defender's combat mode is on. Anti-grabspam measure.
 
 /mob/living/proc/send_pull_message(mob/living/target)
 	target.visible_message(span_warning("[src] grabs [target]."), \

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -420,7 +420,7 @@
 				log_combat(src, M, "tried grabbing", addition="passive grab")
 				stop_pulling()
 				return
-
+		
 		// Makes it so people who recently broke out of grabs cannot be grabbed again
 		if(TIMER_COOLDOWN_RUNNING(M, "broke_free") && M.stat == CONSCIOUS)
 			M.visible_message(span_warning("[M] slips from [src]'s grip."), \
@@ -482,6 +482,11 @@
 		src.put_in_hands(O)
 		O.update_hands(src)
 		update_grab_intents()
+
+	if(isliving(AM))
+		var/mob/living/M = AM
+		if(M.cmode && M.stat == CONSCIOUS)
+			M.resist_grab(freeresist = TRUE) //Automatically attempt to break a passive grab if defender's combat mode is on. Anti-grabspam measure.
 
 /mob/living/proc/send_pull_message(mob/living/target)
 	target.visible_message(span_warning("[src] grabs [target]."), \
@@ -1010,14 +1015,13 @@
 	if(!can_resist() || surrendering)
 		return
 
-	changeNext_move(CLICK_CD_RESIST)
-
 	if(atkswinging)
 		stop_attack(FALSE)
 
 	SEND_SIGNAL(src, COMSIG_LIVING_RESIST, src)
 	//resisting grabs (as if it helps anyone...)
 	if(pulledby)
+		changeNext_move(8)
 		var/mob/living/P
 		if(isliving(pulledby))
 			P = pulledby
@@ -1032,27 +1036,26 @@
 
 	//unbuckling yourself
 	if(buckled && last_special <= world.time)
+		changeNext_move(CLICK_CD_RESIST)
 		resist_buckle()
 
 	//Breaking out of a container (Locker, sleeper, cryo...)
 	else if(isobj(loc))
+		changeNext_move(CLICK_CD_RESIST)
 		var/obj/C = loc
 		C.container_resist(src)
 
 	else if(mobility_flags & MOBILITY_MOVE)
 		if(on_fire)
 			resist_fire() //stop, drop, and roll
+			changeNext_move(CLICK_CD_RESIST)
 		else if(has_status_effect(/datum/status_effect/leash_pet))
 			if(istype(src, /mob/living/carbon))
 				src:resist_leash()
+				changeNext_move(CLICK_CD_RESIST)
 		else if(last_special <= world.time)
 			resist_restraints() //trying to remove cuffs.
-
-	else if(mobility_flags & MOBILITY_MOVE)
-		if(on_fire)
-			resist_fire() //stop, drop, and roll
-		else if(last_special <= world.time)
-			resist_restraints() //trying to remove cuffs.
+			changeNext_move(CLICK_CD_RESIST)
 
 /mob/living/proc/submit(var/instant = FALSE)
 	set name = "Yield"
@@ -1127,7 +1130,7 @@
 /mob/proc/resist_grab(moving_resist)
 	return TRUE //returning 0 means we successfully broke free
 
-/mob/living/resist_grab(moving_resist)
+/mob/living/resist_grab(moving_resist, freeresist = FALSE)
 	. = TRUE
 
 	var/wrestling_diff = 0
@@ -1164,7 +1167,8 @@
 
 	if(moving_resist && client) //we resisted by trying to move
 		client.move_delay = world.time + 20
-	stamina_add(rand(5,15))
+	if(!freeresist)
+		stamina_add(rand(5,15))
 
 	if(!prob(resist_chance))
 		var/rchance = ""

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -485,7 +485,7 @@
 
 	if(isliving(AM))
 		var/mob/living/M = AM
-		if(M.cmode && M.stat == CONSCIOUS)
+		if(M.cmode && M.stat == CONSCIOUS && !M.restrained(ignore_grab = TRUE))
 			if(M.get_skill_level(/datum/skill/combat/wrestling) > 4 || src.get_skill_level(/datum/skill/combat/wrestling) < 5) //Grabber skill less than Master OR grabbed skill at Master or above.
 				M.resist_grab(freeresist = TRUE) //Automatically attempt to break a passive grab if defender's combat mode is on. Anti-grabspam measure.
 


### PR DESCRIPTION
## About The Pull Request
Before, all 'resists' (be they putting out fire, or trying to break a grab) had an unreasonable cooldown of two (2) whole seconds in between them. For comparison, a pick intent hit is 1.4 seconds of click delay. This made breaking out of even the most pitiful passive grab a herculean effort in combat and enabled people to disable others by spamming passive grabs.

This PR reduces the CD on grab resisting to 0.8 seconds, the same as a dagger stab (and close to the 1 second of click CD for grabbing), and makes it so whenever you passively grab someone who is actively resisting, they get an automatic, free attempt at breaking the grab. 

In practice this means that grabbing someone in combat will be ineffectual if you don't have the stats or skills to actually properly grab them, and that resisting out of passive grabs isn't taking you twice as long as it takes for them to grab you right back.

**Note: Putting out fires still prompts a 2 second click CD. That wasn't changed. This does not touch fire.**

## Testing Evidence
<img width="194" height="55" alt="image" src="https://github.com/user-attachments/assets/935aec01-fecc-40d2-a1de-40b23e4418b5" />

## Why It's Good For The Game
Passive grab spam is incredibly zozozexual and makes fighting at a numerical disadvantage very unfun if any of them remembers to just grab your arm repeatedly.

Because resisting a grab manually still costs you stamina, it shouldn't be a problem if people can resist out of them at reasonable speeds rather than once every two seconds.