### PR TITLE
Pile appraisal skill for merchant and steward

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/steward.dm
@@ -53,6 +53,7 @@
 	H.change_stat("speed", -1)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular/pileappraisal)
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_SEEPRICES, type)
 	H.verbs |= /mob/living/carbon/human/proc/adjust_taxes

--- a/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
@@ -57,4 +57,4 @@
 	H.change_stat("strength", -1)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
-
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular/pileappraisal)

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -31,9 +31,21 @@
 	if(ishuman(targets[1]))
 		var/mob/living/carbon/human/target = targets[1]
 		var/mammonsonperson = get_mammons_in_atom(target)
-		var/mammonsinbank = SStreasury.bank_accounts[target]
+		var/mammonsinbank = SStreasury.bank_accounts[target] ? SStreasury.bank_accounts[target] : 0
 		var/totalvalue = mammonsinbank + mammonsonperson
 		to_chat(user, ("<font color='yellow'>[target] has [mammonsonperson] mammons on them, [mammonsinbank] in their meister, for a total of [totalvalue] mammons.</font>"))
+
+/obj/effect/proc_holder/spell/invoked/appraise/secular/pileappraisal
+	name = "Pile Appraise"
+	range = 1
+
+/obj/effect/proc_holder/spell/invoked/appraise/secular/pileappraisal/cast(list/targets, mob/living/user)
+	var/turf/T = get_turf(targets[1])
+	var/totalvalue = 0
+	for(var/obj/O in T.contents)
+		if(O.sellprice)
+			totalvalue += O.get_real_price()
+	to_chat(user, ("<font color='yellow'>That pile of items costs around [totalvalue] mammons.</font>"))
 
 // T1 - Take value of item in hand, apply that as healing. Destroys item.
 


### PR DESCRIPTION
## About The Pull Request
Adds new "spell" for merchant and steward that will calculate total price of a pile of items on a turf
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="376" height="434" alt="image" src="https://github.com/user-attachments/assets/4d05bc13-a8ac-4627-9fa4-4c4914480bbd" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
No need to manually calculate price of 5 bags of various items each adventurer dumps infront of you
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
