### PR TITLE
brings court jobs racelocks in line with eachother

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -7,7 +7,7 @@
 	total_positions = 1
 	spawn_positions = 1
 
-	allowed_races = RACES_APPOINTED_OUTCASTS_UP		//Nobility, no construct
+	allowed_races = RACES_SECOND_CLASS_NO_GOLEM		//Nobility, no construct
 	allowed_sexes = list(MALE, FEMALE)
 	spells = list(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 	display_order = JDO_MAGICIAN

--- a/code/modules/jobs/job_types/roguetown/courtier/physician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/physician.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
-	allowed_races = RACES_APPOINTED_OUTCASTS_UP
+	allowed_races = RACES_SECOND_CLASS_NO_GOLEM
 	allowed_patrons = NON_PSYDON_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	display_order = JDO_PHYSICIAN

--- a/code/modules/jobs/job_types/roguetown/nobility/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/steward.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
-	allowed_races = RACES_APPOINTED_OUTCASTS_UP
+	allowed_races = RACES_SECOND_CLASS_NO_GOLEM
 	allowed_sexes = list(MALE, FEMALE)
 	display_order = JDO_STEWARD
 	tutorial = "Coin, Coin, Coin! Oh beautiful coin: You're addicted to it, and you hold the position as the Grand Duke's personal treasurer of both coin and information. You know the power silver and gold has on a man's mortal soul, and you know just what lengths they'll go to in order to get even more. Keep your festering economy alive- for it is the only thing you can weigh any trust into anymore."

--- a/code/modules/jobs/job_types/roguetown/youngfolk/clerk.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/clerk.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
-	allowed_races = RACES_APPOINTED_OUTCASTS_UP
+	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT)
 


### PR DESCRIPTION
## About The Pull Request
Court magos, physician and steward are open for RACES_SECOND_CLASS_NO_GOLEM, same as councillor (they are basically specialized councillors)
Clerk gets RACES_ALL_KINDS same as shophand/servant
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
var edit
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
These roles are similar to each other in their purpose and making them to have different race locks makes no sence at all (especially opening court positions for outcasts but not for "second class")
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
