### PR TITLE
Martyr skill tweak.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -462,12 +462,12 @@
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver = 1)
 
 	//No, they don't get any miracles. Their miracle is being able to use their weapon at all.
-	H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/tracking, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/medicine, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)


### PR DESCRIPTION
## About The Pull Request

5 swordsmanskill (chosen of the ten after all, no?) 
4 wrestling (what do you mean im struggling to peacefully remove whoever the priest told me to?)

## Testing Evidence

Two numbers changed, no need to test.

## Why It's Good For The Game

The chosen warrior of the Ten that swore an oath to be able to use their holy sword is at the same level of swordsmanship as a simple mercenary.
Compared to the iconoclast, who is the "cleric of matthios" getting 5 in three of their main skills, this results in Martyr having a whopping 50% parry chance, even when using their oath to become stronger, while the iconoclast remains at 90%. (this is hogwash)
With the recent grab nerfs, and every single role seemingly having high wrestling skill, the Martyr is struggling to remove interlopers from the church with their meager level 3 wrestling.