### PR TITLE
Dead nose prevents sewer water mood loss

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -153,7 +153,7 @@
 
 /mob/living/carbon/human/handle_inwater(turf/onturf, extinguish = TRUE, force_drown = FALSE)
 	. = ..()
-	if(istype(onturf, /turf/open/water/sewer))
+	if(istype(onturf, /turf/open/water/sewer) && !HAS_TRAIT(src, TRAIT_NOSTINK))
 		add_stress(/datum/stressevent/sewertouched)
 
 /mob/living/carbon/proc/get_complex_pain()


### PR DESCRIPTION
## About The Pull Request
Makes dead nose prevent the "Putrid stinking water!" mood debuff from sewer water.  Simple.

## Testing Evidence
Quick hack-jobbed image. Left is with dead nose, right is without.
<img width="978" height="354" alt="image" src="https://github.com/user-attachments/assets/1b580c25-b192-41bb-93c5-890986f643ab" />

## Why It's Good For The Game

Ugly people can now find solace in the sewers, for that is where they belong.

