### PR TITLE
Sack Mantrap Fix [HOTFIX]

### DIFF
--- a/code/datums/components/storage/storage_types.dm
+++ b/code/datums/components/storage/storage_types.dm
@@ -93,6 +93,10 @@
 	allow_quick_empty = TRUE
 	insert_preposition = "in"
 
+/datum/component/storage/concrete/roguetown/sack/New(datum/P, ...)
+	. = ..()
+	cant_hold = typecacheof(list(/obj/item/restraints/legcuffs/beartrap))
+
 /datum/component/storage/concrete/roguetown/sack/bag
 	dump_time = 10
 	not_while_equipped = TRUE


### PR DESCRIPTION
## About The Pull Request
Stops mantraps from going inside sacks.

## Testing Evidence
<img width="175" height="104" alt="image" src="https://github.com/user-attachments/assets/c8bfa9fa-dfba-4158-944d-cf058b0586d1" />


## Why It's Good For The Game
Stops a crime against Ravox from being committed.
