### PR TITLE
Fixes Click Delay On Punch Misses

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -307,14 +307,14 @@
 						changeNext_move(CLICK_CD_RAPID)
 						if(get_dist(get_turf(src), T) <= used_intent.reach)
 							do_attack_animation(T, used_intent.animname, used_intent.masteritem, used_intent = src.used_intent)
+						var/adf = used_intent.clickcd
+						if(istype(rmb_intent, /datum/rmb_intent/aimed))
+							adf = round(adf * CLICK_CD_MOD_AIMED)
+						if(istype(rmb_intent, /datum/rmb_intent/swift))
+							adf = max(round(adf * CLICK_CD_MOD_SWIFT), CLICK_CD_INTENTCAP)
+						changeNext_move(adf)
 						if(W)
 							playsound(get_turf(src), pick(W.swingsound), 100, FALSE)
-							var/adf = used_intent.clickcd
-							if(istype(rmb_intent, /datum/rmb_intent/aimed))
-								adf = round(adf * CLICK_CD_MOD_AIMED)
-							if(istype(rmb_intent, /datum/rmb_intent/swift))
-								adf = max(round(adf * CLICK_CD_MOD_SWIFT), CLICK_CD_INTENTCAP)
-							changeNext_move(adf)
 						else
 							playsound(get_turf(src), used_intent.miss_sound, 100, FALSE)
 							if(used_intent.miss_text)


### PR DESCRIPTION
## About The Pull Request

punch misses had practically 0 swing delay so you could just stam yourself out by clicking too much

this uh. makes it missed punches have the same swing delay as successful punches

## Testing Evidence

i punched. i missed.
i punched. i hit.

i picked up a weapon.
i swung. i missed.
i swung. i hit.

it works.

trust.

## Why It's Good For The Game

I am a code tyrant.
