### PR TITLE
Removes VL from the rotation

### DIFF
--- a/code/modules/events/antagonist/solo/vampires.dm
+++ b/code/modules/events/antagonist/solo/vampires.dm
@@ -9,7 +9,7 @@
 	antag_flag = ROLE_NBEAST
 	shared_occurence_type = SHARED_HIGH_THREAT
 
-	weight = 4 // frag out boy
+	weight = 0 // frag out boy
 	max_occurrences = 2
 	denominator = 50
 


### PR DESCRIPTION
## About The Pull Request

Vampires and Vampire Lord will no longer spawn. 

The People demand it and I deliver the 1 number change.

## Testing Evidence

It boots up.

![kuuga](https://github.com/user-attachments/assets/5d7261c8-226a-494b-8604-a78fc7448e53)

## Why It's Good For The Game

The amount of complaining over a genuinely broken antag is deafening but let me paraphrase something a user said.

"you can't grab it.

you can't stun it.

you can't bleed it out.

any damage you do to it can be healed instantly.

silver, its weakness, has no real effect on it in any meaningful way, requiring you to actually get through its armor, first.

due to our combat changes and the way damage is calculated and combat is handled, it will destroy your weapons in one to two hits, and you cannot do the same to it.

due to our combat changes and the way damage is calculated, it is able to delimb you through your armor- you cannot do the same to it. it is, likewise, functionally immune to maces, polearms, and other attacks.

it outstats you by an order of a magnitude and is much faster than you- a competent VL can simply run circles around you or anyone else fighting it, much like a werewolf, except unlike a werewolf, it cannot be pinned.

it has access to magic on top of being an armored spellcaster.

it can adminheal any damage it incidentally takes, including limb loss.

it is immune to counterspell.

it is immune to stamina loss, and thus cannot be baited, feinted, or parried- and, much like a lich and its skeletons, can swift-spam you to death, rapidly unleashing a stream of high damage attacks. even if it isn't peeling your armor to cut through your plate, it can, between its sword skill, its strength, etc, basically crunch through 500 points worth of plate armor in under 3-4 hits.

its thralls are even stronger than the VL itself is.

This just compounds and compounds and a Wide variety of unpatched bugs like infinite vitae and infinite death knights summon means it’s JUST as much of a swarm antag as lich is, except all the minions are also spellcasters and legendary sword fighters."

Until VL is fixed by a far more skillful coder than me, it would be for the best for him to be disabled.
