### PR TITLE
Improve mail feedback

### DIFF
--- a/code/modules/roguetown/roguemachine/mail.dm
+++ b/code/modules/roguetown/roguemachine/mail.dm
@@ -170,7 +170,7 @@
 					if(H.real_name == send2place)
 						mailrecipient = H
 						break
-				if(!mailrecipient && (alert("Could not find recipient [send2place]. Still send the letter?", "", "Yes", "No") == "No")) // ask player if they still want to send a letter to a non-found character
+				if(!mailrecipient && (alert("Could not find recipient [send2place]. Still send the letter?", "", "YES", "NO") == "NO")) // ask player if they still want to send a letter to a non-found character
 					return
 				var/findmaster
 				if(SSroguemachine.hermailermaster)


### PR DESCRIPTION
## About The Pull Request

This PR adds more additional feedback to the mailing logic.

* Ask the player if they still wish to send the letter if the recipient is not found
* Adds a mention of leaving the from name field blank to be able to send mail anonymously
* Adds a chat notice message hint if tried to collect their mail if their mail was stolen/burned/missing
* If the recipient tried to collect their mail and there was none to be found, silently readd the `ugotmail` status effect for the recipient if their mail is readded into the mastermail machine

## Testing Evidence

I have tested this logically and confirm it does exactly as above describes.
<img width="502" height="224" alt="tested" src="https://github.com/user-attachments/assets/98f8fa05-63df-42af-b520-aa70f16cbc89" />

## Why It's Good For The Game

More feedback helps players get less frustrated and cuts down on false bug reports.