### PR TITLE
wild goblin eyes now hurt you while implanted

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -178,9 +178,13 @@
 
 /obj/item/organ/eyes/night_vision/wild_goblin/on_life()
 	. = ..()
-	if (!istype(owner, /mob/living/carbon/human/species/goblin))
+	if (!isgoblinp(owner))
 		if (prob(10))
-			owner.adjustToxLoss(0.2)
+			owner.adjustToxLoss(5)
+			applyOrganDamage(5)
+			owner.blur_eyes(3)
+			if(prob(50))
+				to_chat(owner, span_red("My eyes burn and my body aches."))
 
 /obj/item/organ/eyes/night_vision/mushroom
 	name = "fung-eye"


### PR DESCRIPTION

## About The Pull Request

non-goblins will take tox damage and extremely high eye damage, going blind in a few minutes
also fixes the check that was in there because **YOU CAN'T CHECK A SPECIES LIKE THAT!!!!!!!**

## Testing Evidence

<img width="1871" height="958" alt="image" src="https://github.com/user-attachments/assets/6688d3c1-817f-47dc-a7b3-0931fec04079" />

also tested with a goblin and it worked fine 
## Why It's Good For The Game

easily-accessible super darkvision for literally anyone who cared to get the eyes implanted massively undermines the value of other sources of darkvision
also pseudo goblin buff maybe since they can use these and still be fine