### PR TITLE
Noose and gallows

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -11,6 +11,34 @@
 	abstract_type = /datum/crafting_recipe/roguetown/survival/
 	skillcraft = /datum/skill/craft/crafting
 
+/datum/crafting_recipe/roguetown/structure/noose
+	name = "noose"
+	result = /obj/structure/noose
+	reqs = list(/obj/item/rope = 1)
+	craftdiff = 0
+	verbage = "tie"
+	craftsound = 'sound/foley/noose_idle.ogg'
+	ontile = TRUE
+/datum/crafting_recipe/roguetown/structure/noose/TurfCheck(mob/user, turf/T)
+	var/turf/checking = get_step_multiz(T, UP)
+	if(!checking)
+		return FALSE
+	if(!isopenturf(checking))
+		return FALSE
+	if(istype(checking,/turf/open/transparent/openspace))
+		return FALSE
+	return TRUE
+
+/datum/crafting_recipe/roguetown/structure/gallows
+	name = "gallows"
+	result = /obj/structure/noose/gallows
+	reqs = list(/obj/item/rope = 1, /obj/item/grown/log/tree/small = 2)
+	skillcraft = "/datum/skill/craft/carpentry"
+	craftdiff = 1
+	verbage = "constructs"
+	craftsound = 'sound/foley/Building-01.ogg'
+	ontile = TRUE
+
 /datum/crafting_recipe/roguetown/survival/tneedle
 	name = "sewing needle"
 	result = /obj/item/needle/thorn


### PR DESCRIPTION
Makes nooses and gallows craftable (again)

## About The Pull Request

Returns the ability to craft nooses and gallows!
1 rope no skill for noose,
1 rope 2 half logs and novice carpentry for gallows.

## Testing Evidence
<img width="140" height="138" alt="image" src="https://github.com/user-attachments/assets/5c196958-2951-4d08-8fba-123d1f9b8ca6" />

## Why It's Good For The Game

I want to fucking hang myself in-game sometimes, this lets me do it without going to one of the very few spots with mapped nooses.