### PR TITLE
Kneestingers will not shock inactive people, & damage halved for recently-shocked

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -33,7 +33,12 @@
 		if(world.time > L.last_client_interact + 0.2 SECONDS)
 			return FALSE
 
-		if(L.electrocute_act(30, src))
+		var/electrodam = 30
+		if(world.time < (L.mob_timers["kneestinger"] + 30 SECONDS))
+			electrodam = 15
+
+		if(L.electrocute_act(electrodam, src))
+			L.mob_timers["kneestinger"] = world.time
 			src.take_damage(15)
 			L.consider_ambush(always = TRUE)
 			if(L.throwing)
@@ -61,7 +66,11 @@
 	if(!isliving(movable_victim))
 		return FALSE
 	var/mob/living/victim = movable_victim
-	if(victim.electrocute_act(30, src))
+	var/electrodam = 30
+	if(world.time < (victim.mob_timers["kneestinger"] + 30 SECONDS))
+		electrodam = 15
+	if(victim.electrocute_act(electrodam, src))
+		victim.mob_timers["kneestinger"] = world.time
 		victim.emote("painscream")
 		victim.update_sneak_invis(TRUE)
 		victim.consider_ambush(always = TRUE)


### PR DESCRIPTION
## About The Pull Request
If you have not acted (clicked or moved) in the last 2 or so ticks (`0.2 SECONDS`) then Kneestingers will not shock you at all.
Despite the jiggle from being bumped, the kneestingers still only take damage when electrocuting people.

Also implements a suggestion, inspired by IRL stinging nettles, to reduce the damage kneestingers give you for consecutive shocks. Even with these changes to prevent others pushing you in, it just might not be your dae and you misinput anyways. So, I cut the damage in half if you've been shocked within the last 30 seconds. (In the code this is 30 -> 15 but real damage is a little different.)

Foreseen side effects:
  - Standing still and dodging in combat will remove the kneestingers from the list of tiles you can dodge to.
    - Also applies to standing still and having the mouse held down for longer than the 0.2s delay.

tags: dendor. druid.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/eea207de-452d-4b1d-b2a0-82648af8c4e0


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Significantly reduces the potential for these to be used as anything other than area denial. Kneestingers have been a pretty broken and abusable feature for quite some time, and recently there was a case where a group was throwing people into their kneestinger minefield during combat, causing the shock to proc *multiple times a throw*. At least one from that group admitted they wanted to see the stingers nerfed. [*This is what you want, this is what you get.*](https://www.youtube.com/watch?v=O0bk6Hbz0ZU)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
