### PR TITLE
Prevent buffs from removing built-in traits. [Bugfix]

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -102,11 +102,11 @@
 /datum/status_effect/buff/ozium/on_apply()
 	. = ..()
 	owner.add_stress(/datum/stressevent/ozium)
-	ADD_TRAIT(owner, TRAIT_NOPAIN, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_NOPAIN, id)
 
 /datum/status_effect/buff/ozium/on_remove()
 	owner.remove_stress(/datum/stressevent/ozium)
-	REMOVE_TRAIT(owner, TRAIT_NOPAIN, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_NOPAIN, id)
 	. = ..()
 
 /datum/status_effect/buff/moondust
@@ -141,8 +141,6 @@
 	effectedstats = list("speed" = -5, "endurance" = 4, "intelligence" = -3, "constitution" = 3)
 	duration = 80 SECONDS
 	var/originalcmode = ""
-	var/hadcritres = FALSE
-	var/hadpainres = FALSE
 
 /datum/status_effect/buff/herozium/nextmove_modifier()
 	return 1.2
@@ -150,23 +148,15 @@
 /datum/status_effect/buff/herozium/on_apply()
 	. = ..()
 	owner.add_stress(/datum/stressevent/ozium)
-	if(!HAS_TRAIT(owner, TRAIT_NOPAIN))
-		ADD_TRAIT(owner, TRAIT_NOPAIN, TRAIT_GENERIC)
-	else
-		hadpainres = TRUE
-	if(!HAS_TRAIT(owner, TRAIT_CRITICAL_RESISTANCE))
-		ADD_TRAIT(owner, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)
-	else
-		hadcritres = TRUE
+	ADD_TRAIT(owner, TRAIT_NOPAIN, id)
+	ADD_TRAIT(owner, TRAIT_CRITICAL_RESISTANCE, id)
 	originalcmode = owner.cmode_music
 	owner.cmode_music = 'sound/music/combat_ozium.ogg'
 
 /datum/status_effect/buff/herozium/on_remove()
 	owner.remove_stress(/datum/stressevent/ozium)
-	if(!hadpainres)
-		REMOVE_TRAIT(owner, TRAIT_NOPAIN, TRAIT_GENERIC)
-	if(!hadcritres)
-		REMOVE_TRAIT(owner, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_NOPAIN, id)
+	REMOVE_TRAIT(owner, TRAIT_CRITICAL_RESISTANCE, id)
 	owner.cmode_music = originalcmode
 	. = ..()
 
@@ -185,14 +175,8 @@
 /datum/status_effect/buff/starsugar/on_apply()
 	. = ..()
 	owner.add_stress(/datum/stressevent/starsugar)
-	if(!HAS_TRAIT(owner, TRAIT_DODGEEXPERT))
-		ADD_TRAIT(owner, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-	else
-		haddodge = TRUE
-	if(!HAS_TRAIT(owner, TRAIT_DARKVISION))
-		ADD_TRAIT(owner, TRAIT_DARKVISION, TRAIT_GENERIC)
-	else
-		haddarkvision = TRUE
+	ADD_TRAIT(owner, TRAIT_DODGEEXPERT, id)
+	ADD_TRAIT(owner, TRAIT_DARKVISION, id)
 	if(owner.has_status_effect(/datum/status_effect/debuff/sleepytime))
 		owner.remove_status_effect(/datum/status_effect/debuff/sleepytime)
 	originalcmode = owner.cmode_music
@@ -200,10 +184,8 @@
 
 
 /datum/status_effect/buff/starsugar/on_remove()
-	if(!haddodge)
-		REMOVE_TRAIT(owner, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-	if(!haddarkvision)
-		REMOVE_TRAIT(owner, TRAIT_DARKVISION, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_DODGEEXPERT, id)
+	REMOVE_TRAIT(owner, TRAIT_DARKVISION, id)
 	owner.remove_stress(/datum/stressevent/starsugar)
 	owner.cmode_music = originalcmode
 	. = ..()
@@ -414,11 +396,11 @@
 
 /datum/status_effect/buff/wardenbuff/on_apply()
 	. = ..()
-	ADD_TRAIT(owner, TRAIT_LONGSTRIDER, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_LONGSTRIDER, id)
 
 /datum/status_effect/buff/wardenbuff/on_remove()
 	. = ..()
-	REMOVE_TRAIT(owner, TRAIT_LONGSTRIDER, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_LONGSTRIDER, id)
 
 /datum/status_effect/buff/dungeoneerbuff/process()
 
@@ -429,11 +411,11 @@
 
 /datum/status_effect/buff/dungeoneerbuff/on_apply()
 	. = ..()
-	ADD_TRAIT(owner, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_CIVILIZEDBARBARIAN, id)
 
 /datum/status_effect/buff/dungeoneerbuff/on_remove()
 	. = ..()
-	REMOVE_TRAIT(owner, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_CIVILIZEDBARBARIAN, id)
 
 /atom/movable/screen/alert/status_effect/buff/healing
 	name = "Healing Miracle"
@@ -795,13 +777,13 @@
 /datum/status_effect/buff/moonlightdance/on_apply()
 	. = ..()
 	to_chat(owner, span_warning("I see through the Moonlight. Silvery threads dance in my vision."))
-	ADD_TRAIT(owner, TRAIT_DARKVISION, MAGIC_TRAIT)
+	ADD_TRAIT(owner, TRAIT_DARKVISION, id)
 
 
 /datum/status_effect/buff/moonlightdance/on_remove()
 	. = ..()
 	to_chat(owner, span_warning("Noc's silver leaves my"))
-	REMOVE_TRAIT(owner, TRAIT_DARKVISION, MAGIC_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_DARKVISION, id)
 
 
 
@@ -864,11 +846,11 @@
 	. = ..()
 	to_chat(owner, span_danger("You feel as though some horrible deal has been prepared in your name. May you never see it fulfilled..."))
 	playsound(owner, 'sound/misc/bell.ogg', 100, FALSE, -1)
-	ADD_TRAIT(owner, TRAIT_DEATHBARGAIN, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_DEATHBARGAIN, id)
 
 /datum/status_effect/buff/undermaidenbargain/on_remove()
 	. = ..()
-	REMOVE_TRAIT(owner, TRAIT_DEATHBARGAIN, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_DEATHBARGAIN, id)
 
 
 /datum/status_effect/buff/undermaidenbargainheal/on_apply()
@@ -876,7 +858,7 @@
 	owner.remove_status_effect(/datum/status_effect/buff/undermaidenbargain)
 	to_chat(owner, span_warning("You feel the deal struck in your name is being fulfilled..."))
 	playsound(owner, 'sound/misc/deadbell.ogg', 100, FALSE, -1)
-	ADD_TRAIT(owner, TRAIT_NODEATH, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_NODEATH, id)
 	var/dirgeline = rand(1,6)
 	spawn(15)
 		switch(dirgeline)
@@ -897,7 +879,7 @@
 	. = ..()
 	to_chat(owner, span_warning("The Bargain struck in my name has been fulfilled... I am thrown from Necra's embrace, another in my place..."))
 	playsound(owner, 'sound/misc/deadbell.ogg', 100, FALSE, -1)
-	REMOVE_TRAIT(owner, TRAIT_NODEATH, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_NODEATH, id)
 
 /datum/status_effect/buff/undermaidenbargainheal
 	id = "undermaidenbargainheal"
@@ -939,14 +921,14 @@
 /datum/status_effect/buff/lesserwolf/on_apply()
 	. = ..()
 	to_chat(owner, span_warning("I feel my leg muscles grow taut, my teeth sharp, I am embued with the power of a predator. Branches and brush reach out for my soul..."))
-	ADD_TRAIT(owner, TRAIT_LONGSTRIDER, TRAIT_GENERIC)
-	ADD_TRAIT(owner, TRAIT_STRONGBITE, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_LONGSTRIDER, id)
+	ADD_TRAIT(owner, TRAIT_STRONGBITE, id)
 
 /datum/status_effect/buff/lesserwolf/on_remove()
 	. = ..()
 	to_chat(owner, span_warning("I feel Dendor's blessing leave my body..."))
-	REMOVE_TRAIT(owner, TRAIT_LONGSTRIDER, TRAIT_GENERIC)
-	REMOVE_TRAIT(owner, TRAIT_STRONGBITE, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_LONGSTRIDER, id)
+	REMOVE_TRAIT(owner, TRAIT_STRONGBITE, id)
 
 /atom/movable/screen/alert/status_effect/buff/pacify
 	name = "Blessing of Eora"
@@ -962,13 +944,13 @@
 	. = ..()
 	to_chat(owner, span_green("Everything feels great!"))
 	owner.add_stress(/datum/stressevent/pacified)
-	ADD_TRAIT(owner, TRAIT_PACIFISM, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_PACIFISM, id)
 	playsound(owner, 'sound/misc/peacefulwake.ogg', 100, FALSE, -1)
 
 /datum/status_effect/buff/pacify/on_remove()
 	. = ..()
 	to_chat(owner, span_warning("My mind is my own again, no longer awash with foggy peace!"))
-	REMOVE_TRAIT(owner, TRAIT_PACIFISM, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_PACIFISM, id)
 
 /datum/status_effect/buff/call_to_arms
 	id = "call_to_arms"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -356,10 +356,10 @@
 /datum/status_effect/buff/order/brotherhood/on_apply()
 	. = ..()
 	to_chat(owner, span_blue("My commander orders me to stand proud for the brotherhood!"))
-	ADD_TRAIT(owner, TRAIT_NOPAIN, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_NOPAIN, id)
 
 /datum/status_effect/buff/order/onfeet/on_remove()
-	REMOVE_TRAIT(owner, TRAIT_NOPAIN, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_NOPAIN, id)
 	. = ..()
 
 

--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -251,9 +251,9 @@
 /datum/component/martyrweapon/proc/adjust_traits(remove = FALSE)
 	for(var/trait in traits_applied)
 		if(!remove)
-			ADD_TRAIT(current_holder, trait, TRAIT_GENERIC)
+			ADD_TRAIT(current_holder, trait, "martyrweapon")
 		else
-			REMOVE_TRAIT(current_holder, trait, TRAIT_GENERIC)
+			REMOVE_TRAIT(current_holder, trait, "martyrweapon")
 
 /datum/component/martyrweapon/proc/adjust_stats(state)
 	if(current_holder)


### PR DESCRIPTION
## About The Pull Request
Buffs now use their own IDs instead of "generic" for adding and removing traits. Prevents them from unintentionally removing traits you spawned in with when their effects wear off.

It's possible that I might have missed some, but this was mainly just me looking over roguebuff.dm while also checking cases where these traits get removed.

For this PR's searchability, this affects:
- Ozium
- Herozium
- Starsugar
- Warden area buff (longstrider)
- Dungeoneer area buff (pugilist)
- Noc darksight ritual
- Necra death bargain ritual
- Dendor lesser wolf rite ritual
- Eora pacifism (pacify) ritual
- Wretch Deserter "brotherhood" or "stand proud" order buff
- Martyr Ultimate Weapon traits ("Vengeance") granted during ult

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compile-tested. There's too many effects for me to try and manually review them all, and there wouldn't be much of a point in doing so. HOWEVER, I did check these traits to make sure anything calling REMOVE_TRAIT on them wouldn't be heartbroken that they can't remove the buff.

Trait-code works by allowing a trait to have multiple "sources" that get added or removed for a given trait, and only when all of those sources are removed is the trait itself removed. See REMOVE_TRAIT and ADD_TRAIT macros.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fixes a bug with many of these buffs where they remove built-in traits for no good reason. Ozium removing TRAIT_NOPAIN after wearing off is what prompted this, and it's a great example.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
