### PR TITLE
Extremely minor Lunacy Embracer balancejak

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
@@ -36,7 +36,7 @@
 
 	H.change_stat("strength", 3)
 	H.change_stat("endurance", 2)
-	H.change_stat("constitution", 2)
+	H.change_stat("constitution", 3)
 	H.change_stat("speed", 2)
 	H.change_stat("fortune", 2) //nature smiles at me!
 	H.change_stat("intelligence", -2)


### PR DESCRIPTION
## About The Pull Request

I changed one number for Lunacy Embracers since I've heard they can be sometimes too fragile. 

HOWEVER.

This is more of a discussion PR. I want to know if the github side of the community is fine with this minor change or not. People have also discussed that the -2 perception they get is too harsh for a speed based class. So instead, it could change it to -1 perception, but no +3 con. Or +3 con but keep -2 Per.

What do you think?

## Testing Evidence

Single number change.

## Why It's Good For The Game

antag strong gud
