### PR TITLE
Priest robe and hood fire immunity (and acid proofing, I guess.)

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -305,6 +305,7 @@
 	color = null
 	icon_state = "priesthead"
 	item_state = "priesthead"
+	resistance_flags = FIRE_PROOF | ACID_PROOF
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	dynamic_hair_suffix = ""
 	sewrepair = TRUE

--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -108,6 +108,7 @@
 	name = "solar vestments"
 	desc = "Holy vestments sanctified by divine hands. Caution is advised if not a faithful."
 	icon_state = "priestrobe"
+	resistance_flags = FIRE_PROOF | ACID_PROOF
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
 	armor = ARMOR_PADDED	//Equal to gamby
 	color = null


### PR DESCRIPTION
## About The Pull Request
Adds the fire-proof and acid-proof resistance flags to the solar visage and solar vestments, the upper-robe and hood of the Priest.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1365" height="1018" alt="image" src="https://github.com/user-attachments/assets/a7c16b6a-fa4a-40dd-80cf-a0fbc23187f3" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The ordained voice of the Ten, the most devout follower of Astrata, a literal goddess of the Sun, should have clothes that aren't going to immediately fucking burn to a crisp. THEY'RE LITERALLY BLESSED GARMENTS!!! The acid proofing just helps cover more niche situations.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
