### PR TITLE
HOTFIX - Fix crafting gallows, fix crafting nooses on z-level 1

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -11,34 +11,6 @@
 	abstract_type = /datum/crafting_recipe/roguetown/survival/
 	skillcraft = /datum/skill/craft/crafting
 
-/datum/crafting_recipe/roguetown/structure/noose
-	name = "noose"
-	result = /obj/structure/noose
-	reqs = list(/obj/item/rope = 1)
-	craftdiff = 0
-	verbage = "tie"
-	craftsound = 'sound/foley/noose_idle.ogg'
-	ontile = TRUE
-/datum/crafting_recipe/roguetown/structure/noose/TurfCheck(mob/user, turf/T)
-	var/turf/checking = get_step_multiz(T, UP)
-	if(!checking)
-		return FALSE
-	if(!isopenturf(checking))
-		return FALSE
-	if(istype(checking,/turf/open/transparent/openspace))
-		return FALSE
-	return TRUE
-
-/datum/crafting_recipe/roguetown/structure/gallows
-	name = "gallows"
-	result = /obj/structure/noose/gallows
-	reqs = list(/obj/item/rope = 1, /obj/item/grown/log/tree/small = 2)
-	skillcraft = "/datum/skill/craft/carpentry"
-	craftdiff = 1
-	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
-	ontile = TRUE
-
 /datum/crafting_recipe/roguetown/survival/tneedle
 	name = "sewing needle"
 	result = /obj/item/needle/thorn

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -871,3 +871,31 @@
 	verbage_simple = "weave"
 	verbage = "weaves"
 	craftdiff = 0
+
+/datum/crafting_recipe/roguetown/structure/noose
+	name = "noose"
+	result = /obj/structure/noose
+	reqs = list(/obj/item/rope = 1)
+	craftdiff = 1	
+	verbage = "tie"
+	craftsound = 'sound/foley/noose_idle.ogg'
+	ontile = TRUE
+
+/datum/crafting_recipe/roguetown/structure/noose/TurfCheck(mob/user, turf/T)
+	var/turf/checking = get_step_multiz(T, UP)
+	if(!checking)
+		return TRUE // Letting you craft in centcomm Z-level (bandit/vampire/wretch camps)
+	if(!isopenturf(checking))
+		return FALSE
+	if(istype(checking, /turf/open/transparent/openspace))
+		return FALSE
+	return TRUE
+
+/datum/crafting_recipe/roguetown/structure/gallows
+	name = "gallows"
+	result = /obj/structure/noose/gallows
+	reqs = list(/obj/item/rope = 1, /obj/item/grown/log/tree/small = 2)
+	craftdiff = 2
+	verbage = "constructs"
+	craftsound = 'sound/foley/Building-01.ogg'
+	ontile = TRUE


### PR DESCRIPTION
## About The Pull Request
Craftable noose/gallows PR didn't actually work for the gallows, due to passing the typepath as a string.
Also took the liberty of making nooses craftable if there is no turf above you, which should only happen if you are at the highest point in the overworld or, more importantly, if you're on the Centcomm Z-level.
**This means you can now craft nooses in the Bandit Camp, the Heretic/Wretch Cathedral, and the Vampire Manor.**

Also moves the recipes to their appropriate file where they originally were. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="265" height="144" alt="Screenshot from 2025-08-22 01-26-52" src="https://github.com/user-attachments/assets/b9e9fda1-ca86-496f-9280-acc58c25690e" />

<img width="559" height="393" alt="Screenshot from 2025-08-22 01-31-35" src="https://github.com/user-attachments/assets/dee9cf71-0f68-4717-b598-85e5d3fbd062" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Things work correctly and good. I don't think people technically being able to craft nooses in the sky will be any real issue.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
