### PR TITLE
removes marble skin color from golems

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -568,15 +568,15 @@
 #define GOLEM_IRON "525352"
 #define GOLEM_STEEL  "babbb9"
 #define GOLEM_BRONZE "e2a670"
-#define GOLEM_MARBLE "ffffff"
 #define GOLEM_COAL "1f1f1f"
 #define GOLEM_COBALT "323666"
 #define GOLEM_GRANITE "ff8f8f"
 #define GOLEM_JADE "517051"
 #define GOLEM_AMETHYST "3a0b3d"
+#define GOLEM_TOPER "fffb9e"
 
 //DOLL PAINT COLOR
-#define DOLL_LEAD "ffffff"
+#define DOLL_PORCELAIN "ffffff"
 #define DOLL_SIENNA "a0522d"
 
 // Pixel shifting

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/golem/doll.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/golem/doll.dm
@@ -88,8 +88,9 @@
 
 /datum/species/golem/porcelain/get_skin_list()
 	return list(
-		"LEAD" = "ffffff",
-		"SIENNA" = "a0522d",
+		"Porcelain" = DOLL_PORCELAIN,
+		"Sienna" = DOLL_SIENNA,
+
 	)
 
 /datum/species/golem/porcelain/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/golem/golem.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/golem/golem.dm
@@ -100,7 +100,7 @@
 		"Iron" = GOLEM_IRON,
 		"Steel" = GOLEM_STEEL,
 		"Bronze" = GOLEM_BRONZE,
-		"Marble" = GOLEM_MARBLE,
+		"Toper" = GOLEM_TOPER,
 		"Coal" = GOLEM_COAL,
 		"Cobalt" = GOLEM_COBALT,
 		"Granite" = GOLEM_GRANITE,


### PR DESCRIPTION
## About The Pull Request

replaces it with toper, a more yellow-ish material 
also renames lead on doll to porcelain since I think that fits the doll feel a bit more, if that bothers anyone I can change it back to lead

## Testing Evidence

<img width="268" height="324" alt="image" src="https://github.com/user-attachments/assets/b15852c6-690a-4c3a-8476-cc85560650a4" />

only new one is toper, I just posted the other ones in comparison so you can see that it doesn't look identical
## Why It's Good For The Game

Dolls already have a #FFFFFF option. Golems don't need to overlap on doll stuff, and golems already have steel as a color, thus golems don't need an #FFFFFF option.