### PR TITLE
Fixes Aspirant & Peasant Rebellion

### DIFF
--- a/code/modules/antagonists/roguetown/villain/aspirant.dm
+++ b/code/modules/antagonists/roguetown/villain/aspirant.dm
@@ -37,10 +37,10 @@
 
 /datum/antagonist/aspirant/ruler/greet() // No alert for the ruler to always keep them guessing.
 
-/datum/antagonist/prebel/can_be_owned(datum/mind/new_owner)
+/datum/antagonist/aspirant/can_be_owned(datum/mind/new_owner)
 	. = ..()
 	if(.)
-		if(!(new_owner.assigned_role in GLOB.noble_positions) || !(new_owner.assigned_role in GLOB.garrison_positions))
+		if(!((new_owner.assigned_role in GLOB.noble_positions) || (new_owner.assigned_role in GLOB.garrison_positions) || (new_owner.assigned_role in GLOB.courtier_positions)))
 			return FALSE
 
 /datum/antagonist/aspirant/on_gain()

--- a/code/modules/antagonists/roguetown/villain/peasantrebel.dm
+++ b/code/modules/antagonists/roguetown/villain/peasantrebel.dm
@@ -51,7 +51,6 @@
 			return FALSE
 		if(new_owner.current && HAS_TRAIT(new_owner.current, TRAIT_MINDSHIELD))
 			return FALSE
-		return TRUE
 
 /datum/antagonist/prebel/on_gain()
 	. = ..()

--- a/code/modules/events/antagonist/solo/minor/aspirant.dm
+++ b/code/modules/events/antagonist/solo/minor/aspirant.dm
@@ -37,7 +37,7 @@
 	for(var/datum/mind/antag_mind as anything in setup_minds)
 		add_datum_to_mind(antag_mind, antag_mind.current)
 
-	var/list/helping = list("Consort" ,"Hand" ,"Prince" ,"Captain" ,"Steward" ,"Court Magician ","Loudmouth", "Royal Knight", "Town Elder","Veteran")
+	var/list/helping = list("Consort", "Hand", "Suitor", "Prince", "Knight Captain", "Marshal", "Steward", "Court Magician", "Knight", "Councillor", "Town Elder", "Veteran")
 	var/list/possible_helpers = list()
 	for(var/mob/living/living in GLOB.human_list)
 		if(!living.client)


### PR DESCRIPTION
## About The Pull Request

someone did an oopsie woopsie a long time ago so peasant rebellion just never worked, and aspirant didn't trigger for half the roles it should.

## Testing Evidence
As tailor:
<img width="519" height="107" alt="image" src="https://github.com/user-attachments/assets/1e4628d3-37b5-4be4-8bb2-3aa05d99b9a0" />

As knight:
<img width="500" height="105" alt="image" src="https://github.com/user-attachments/assets/ea69a48e-5e1b-4ac0-9137-1e3b41c015aa" />

As court magician:
<img width="506" height="107" alt="image" src="https://github.com/user-attachments/assets/ef9e0f00-6351-40a4-bafd-beb0a41e8cf3" />


## Why It's Good For The Game

things working correctly is good
