### PR TITLE
[HUGBOX] Restricts Kneestingers to Druids

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -56,7 +56,7 @@
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/targeted/wildshape			= CLERIC_T2,
 					/obj/effect/proc_holder/spell/targeted/beasttame			= CLERIC_T2,
-					/obj/effect/proc_holder/spell/targeted/conjure_glowshroom	= CLERIC_T3,
+					// /obj/effect/proc_holder/spell/targeted/conjure_glowshroom	= CLERIC_T3, - Moved to the druid job type, people were abusing it and blocking entire areas with it. This leaves Dendorites without a T3, but I don't care!
 					/obj/effect/proc_holder/spell/self/howl/call_of_the_moon	= CLERIC_T4,
 	)
 	confess_lines = list(

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -78,3 +78,5 @@
 	ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)	//Starts off maxed out.
+	if(H.mind)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/conjure_glowshroom) // Gives only druids the ability to summon glowshrooms, people were abusing it

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -65,7 +65,7 @@
 			to_chat(usr, "With Dendor's aide, you soothe [animal] of their anger.")
 	return tamed
 
-/obj/effect/proc_holder/spell/targeted/conjure_glowshroom
+/obj/effect/proc_holder/spell/targeted/conjure_glowshroom // This has been moved to the druid job type, but is still here for reference.
 	name = "Fungal Illumination"
 	range = 1
 	overlay_state = "blesscrop"


### PR DESCRIPTION
## About The Pull Request

This PR aims to restrict kneestingers to the druid job only, people have been abusing it and blocking off entire areas with it, making it impossible for others to walk by without getting shocked. It's gotten to the point wretches have been picking Dendor as their patron just so they don't get kneestingered because people keep putting those stupid shrooms all over the wretch waterfall.

<img width="688" height="239" alt="image" src="https://github.com/user-attachments/assets/e6a102f7-c7de-44d4-9134-76c740d60718" />

<img width="734" height="141" alt="image" src="https://github.com/user-attachments/assets/a26c367d-b606-4d0f-92fc-3ca6eb9f0264" />



## Testing Evidence

<details>
**Adventurer Cleric**
<img width="1919" height="1079" alt="Screenshot 2025-08-22 101759" src="https://github.com/user-attachments/assets/fa191146-8cb2-4943-9648-2f16cfc54fa4" />

**Lunacy Embracer**
<img width="1919" height="1079" alt="Screenshot 2025-08-22 101934" src="https://github.com/user-attachments/assets/e41b60a7-29ef-4003-99d9-c76d3ed7da36" />

**Druid**
<img width="1919" height="1079" alt="Screenshot 2025-08-22 101825" src="https://github.com/user-attachments/assets/e16429e9-fcec-48ad-bf8f-45b3f9f973e4" />


</details>

## Why It's Good For The Game

<img width="964" height="960" alt="image" src="https://github.com/user-attachments/assets/c1144324-a4ad-4037-96dd-6154b8f1e7fb" />

<img width="370" height="332" alt="image" src="https://github.com/user-attachments/assets/e2bf4ca6-d8eb-4ac1-8abc-375271e8ebe2" />


![dies-of-cringe-cringe](https://github.com/user-attachments/assets/986536aa-519f-4abf-9fd4-9c32f5dbe396)
