### PR TITLE
Mantles and coifs now say they need an extra bar, and an iron mantle fix.

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -666,7 +666,7 @@
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/chainmantle
-	name = "Mantle"
+	name = "Mantle (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/neck/roguetown/chaincoif/chainmantle
@@ -674,22 +674,22 @@
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/chainmantle/iron
-	name = "Mantle"
+	name = "Mantle (+1 Iron)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/ingot/iron)
-	created_item = /obj/item/clothing/neck/roguetown/chaincoif/chainmantle
+	created_item = /obj/item/clothing/neck/roguetown/chaincoif/chainmantle/iron
 	createditem_num = 1
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/fullchaincoif
-	name = "Full Chain Coif"
+	name = "Full Chain Coif (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/neck/roguetown/chaincoif/full
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/fullchaincoif/iron
-	name = "Full Chain Coif"
+	name = "Full Chain Coif (+1 Iron)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/ingot/iron)
 	created_item = /obj/item/clothing/neck/roguetown/chaincoif/full/iron


### PR DESCRIPTION
## About The Pull Request
Mantles and coifs now say they need that extra bar to make.
Smithing an iron mantle actually results in an iron mantle, not a steel one
## Testing Evidence
<img width="132" height="27" alt="image" src="https://github.com/user-attachments/assets/6bb5b522-95a1-4b4c-a1b6-4ef0dad00f9a" />
<img width="148" height="29" alt="image" src="https://github.com/user-attachments/assets/1d250f9f-f9fe-4b80-8463-516c7ab21d8a" />
<img width="143" height="18" alt="image" src="https://github.com/user-attachments/assets/32f8d3cc-386d-4888-981b-be7c6402fae5" />
<img width="114" height="22" alt="image" src="https://github.com/user-attachments/assets/d925b286-c8ca-494e-9f04-41810c2d6004" />
<img width="166" height="105" alt="image" src="https://github.com/user-attachments/assets/b0d16117-3684-4eb1-ad56-5bdb5b536e0b" />


## Why It's Good For The Game

No more misleading for newer smiths, + a one word bugfix