### PR TITLE
wildshape (and zad form (and bat form) (and mist form)) no longer fully heals the user

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -84,14 +84,13 @@
 	var/tempatarget = null
 	var/pegleg = 0			//Handles check & slowdown for peglegs. Fuckin' bootleg, literally, but hey it at least works.
 	var/construct = 0
-	var/stasis = FALSE //I legitimately don't know where else to put this var. it handles wildshape stopping bleeding from happening basically
 
 /obj/item/proc/attack(mob/living/M, mob/living/user)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, M, user) & COMPONENT_ITEM_NO_ATTACK)
 		return FALSE
 	SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK, M, user)
 	if(item_flags & NOBLUDGEON)
-		return FALSE	
+		return FALSE
 
 	if(force && HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, span_warning("I don't want to harm other living beings!"))
@@ -150,7 +149,7 @@
 	if(M.has_status_effect(/datum/status_effect/buff/clash) && M.get_active_held_item() && ishuman(M) && !bad_guard)
 		var/mob/living/carbon/human/HM = M
 		var/obj/item/IM = M.get_active_held_item()
-		var/obj/item/IU 
+		var/obj/item/IU
 		if(user.used_intent.masteritem)
 			IU = user.used_intent.masteritem
 		HM.process_clash(user, IM, IU)
@@ -488,7 +487,7 @@
 
 	if(multiplier)
 		newforce = newforce * multiplier
-	
+
 	take_damage(newforce, I.damtype, I.d_type, 1)
 	if(newforce > 1)
 		I.take_damage(1, BRUTE, I.d_type)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -84,6 +84,7 @@
 	var/tempatarget = null
 	var/pegleg = 0			//Handles check & slowdown for peglegs. Fuckin' bootleg, literally, but hey it at least works.
 	var/construct = 0
+	var/stasis = FALSE //I legitimately don't know where else to put this var. it handles wildshape stopping bleeding from happening basically
 
 /obj/item/proc/attack(mob/living/M, mob/living/user)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, M, user) & COMPONENT_ITEM_NO_ATTACK)

--- a/code/game/objects/shapeshift_holder.dm
+++ b/code/game/objects/shapeshift_holder.dm
@@ -24,6 +24,7 @@
 
 		shape.apply_damage(damapply, source.convert_damage_type, forced = TRUE);
 
+	stored.stasis = TRUE
 	slink = soullink(/datum/soullink/shapeshift, stored , shape)
 	slink.source = src
 
@@ -78,6 +79,7 @@
 		var/damapply = stored.maxHealth * damage_percent
 
 		stored.apply_damage(damapply, source.convert_damage_type, forced = TRUE)
+	stored.stasis = FALSE
 	qdel(shape)
 	qdel(src)
 

--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -63,6 +63,8 @@
 			STOP_PROCESSING(SSobj, src)
 			return TRUE
 	for(var/mob/living/L in buckled_mobs)
+		if(L.stasis)//spit out our body if it's stored in a transform
+			unbuckle_mob(L)
 		if(world.time > last_eat + 50)
 			last_eat = world.time
 			L.flash_fullscreen("redflash3")
@@ -289,6 +291,8 @@
 			update_icon()
 			return TRUE
 	for(var/mob/living/L in buckled_mobs)
+		if(L.stasis)//spit out our body if it's stored in a transform
+			unbuckle_mob(L)
 		if(world.time > last_eat + 50)
 			last_eat = world.time
 			L.flash_fullscreen("redflash3")

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -130,7 +130,7 @@
 	W.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)
 	W.adjust_skillrank(/datum/skill/misc/climbing, 6, TRUE)
 	W.adjust_skillrank(/datum/skill/misc/swimming, 5, TRUE)
-	
+
 	W.STASTR = 20 // LOCK IN
 	W.STACON = 20
 	W.STAEND = 20

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -77,6 +77,7 @@
 //	stop_cmusic()
 
 	src.fully_heal(FALSE)
+	src.stasis = TRUE
 
 	var/ww_path
 	if(gender == MALE)
@@ -198,6 +199,7 @@
 	to_chat(W, span_userdanger("I return to my facade."))
 	playsound(W.loc, pick('sound/combat/gib (1).ogg','sound/combat/gib (2).ogg'), 200, FALSE, 3)
 	W.spawn_gibs(FALSE)
+	W.stasis = FALSE
 	W.Knockdown(30)
 	W.Stun(30)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1120,6 +1120,9 @@
 		if(reagents)
 			reagents.addiction_list = list()
 	cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
+	var/list/wCount = get_wounds()
+	if(wCount.len > 0)
+		heal_wounds(INFINITY)
 	..()
 	// heal ears after healing traits, since ears check TRAIT_DEAF trait
 	// when healing.

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
@@ -15,8 +15,8 @@
 	if(client)
 		SSdroning.play_area_sound(get_area(src), client)
 
-	fully_heal(FALSE) //If we don't do this, even a single cut will mean the player's real body will die in the void while they run around wildshaped
-	
+	stasis = TRUE //If we don't do this, even a single cut will mean the player's real body will die in the void while they run around wildshaped
+
 	var/mob/living/carbon/human/species/wildshape/W = new shapepath(loc) //We crate a new mob for the wildshaping player to inhabit
 
 	W.set_patron(src.patron)
@@ -87,5 +87,7 @@
 	W.regenerate_icons()
 
 	to_chat(W, span_userdanger("I return to my old form."))
+
+	W.stasis = FALSE
 
 	qdel(src)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -4,6 +4,9 @@
 	if(notransform)
 		return
 
+	if(stasis)//if we're in stasis via wildshape then we don't want to be messing with anything related to bleeding or whatever
+		return
+
 	if(damageoverlaytemp)
 		damageoverlaytemp = 0
 		update_damage_hud()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -5,9 +5,9 @@
 	sight = 0
 	see_in_dark = 8
 	hud_possible = list(ANTAG_HUD)
-	
+
 	typing_indicator_enabled = TRUE
-	
+
 	var/resize = 1 //Badminnery resize
 	var/lastattacker = null
 	var/lastattackerckey = null
@@ -98,6 +98,8 @@
 
 	var/list/status_effects //a list of all status effects the mob has
 	var/druggy = 0
+
+	var/stasis = FALSE //handles wildshape stopping bleeding from happening
 
 	//Speech
 	var/stuttering = 0

--- a/code/modules/spells/roguetown/vampire.dm
+++ b/code/modules/spells/roguetown/vampire.dm
@@ -7,6 +7,7 @@
 	cooldown_min = 50
 	die_with_shapeshifted_form =  FALSE
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat
+	convert_damage = FALSE
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/gaseousform
 	name = "Mist Form"
@@ -16,6 +17,7 @@
 	cooldown_min = 50
 	die_with_shapeshifted_form =  FALSE
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/gaseousform
+	convert_damage = FALSE
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/crow
 	name = "Zad Form"

--- a/code/modules/spells/roguetown/vampire.dm
+++ b/code/modules/spells/roguetown/vampire.dm
@@ -29,6 +29,7 @@
 	die_with_shapeshifted_form =  FALSE
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat/crow
 	sound = 'sound/vo/mobs/bird/birdfly.ogg'
+	convert_damage = FALSE
 
 //This is pretty much a proc override for the base shape shift to remove the gib
 /obj/effect/proc_holder/spell/targeted/shapeshift/crow/Shapeshift(mob/living/caster)


### PR DESCRIPTION
## About The Pull Request

it puts them in stasis mode where on_life() doesn't happen, therefore keeping wounds but nullifying oxyloss and bleeding and stuff that would otherwise kill them

## Testing Evidence

cut arm off -> wildshape -> come out of wildshape 10 minutes later -> health and blood is the same -> die from bloodloss 1 minute later because my arm is cut off

## Why It's Good For The Game

it was always a really weird way to handle the person not dying while in wildshape and I have no idea why it was done this way
this brings it slightly more in line with dnd type stuff where your wildshape is basically a shell and your original body retains the damage it took