### PR TITLE
hides smith quality

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/_anvil_recipe.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/_anvil_recipe.dm
@@ -121,27 +121,20 @@
 	var/modifier // Multiplier which will determine quality of final product depending on final skill_quality calculation
 	switch(skill_quality)
 		if(BLACKSMITH_LEVEL_MIN to BLACKSMITH_LEVEL_SPOIL)
-			I.name = "ruined [I.name]"
 			modifier = 0.3
 		if(BLACKSMITH_LEVEL_AWFUL)
-			I.name = "awful [I.name]"
 			modifier = 0.5
 		if(BLACKSMITH_LEVEL_CRUDE)
-			I.name = "crude [I.name]"
 			modifier = 0.8
 		if(BLACKSMITH_LEVEL_ROUGH)
-			I.name = "rough [I.name]"
 			modifier = 0.9
 		if(BLACKSMITH_LEVEL_COMPETENT)
 			modifier = 1
 		if(BLACKSMITH_LEVEL_FINE)
-			I.name = "fine [I.name]"
 			modifier = 1.1
 		if(BLACKSMITH_LEVEL_FLAWLESS)
-			I.name = "flawless [I.name]"
 			modifier = 1.2
 		if(BLACKSMITH_LEVEL_LEGENDARY to BLACKSMITH_LEVEL_MAX)
-			I.name = "masterwork [I.name]"
 			modifier = 1.3
 			I.polished = 4
 			I.AddComponent(/datum/component/metal_glint)


### PR DESCRIPTION
## About The Pull Request

Smithing quality no longer changes the name of an item. It still buffs item value.

## Testing Evidence

TBA

## Why It's Good For The Game

The smithing quality is a nuisance when you inspect somebody and you see a massive list of masterwork masterwork masterwork. Plus, it gives people a false idea that maybe it nerfs durability or damage or protection of weapons and armor, tricking players.