### PR TITLE
Add targeted subtle emoting

### DIFF
--- a/modular/code/modules/living/emote.dm
+++ b/modular/code/modules/living/emote.dm
@@ -41,23 +41,20 @@
 	var/distance = 4
 	var/list/ghostless = get_hearers_in_view(distance, user)
 	var/list/mobsinview = list()
-	var/list/mobspickable = list()
+	var/list/mobspickable = list("1-Tile Range", "Same Tile")
 	for(var/mob/living/L in ghostless)
 		if(L.stat == CONSCIOUS && L != user) // To those conscious only. Slightly more expensive but subtle is not spammed
 			mobsinview += L
 			if(!L.rogue_sneaking && L.name != "Unknown") // do not let hidden/unknown targets be added to list
 				mobspickable += L
-
-	var/list/emotechoice = list("Same Tile", "1-Tile Range")
-	emotechoice += mobspickable
-	var/choice = input(user, "Pick a target?", "Subtle Emote") in emotechoice
+	var/choice = input(user, "Pick a target?", "Subtle Emote") in mobspickable
 	to_chat(user, "<i>[message]</i>")
 
 	var/user_loc
-	if(choice == "Same Tile")
-		distance = 0
-	else if(choice == "1-Tile Range")
+	if(choice == "1-Tile Range")
 		distance = 1
+	else if(choice == "Same Tile")
+		distance = 0
 	else // we picked a target
 		var/mob/living/target = choice
 		if(!isliving(target) || QDELETED(target)) // mob has since been deleted/destroyed, skip

--- a/modular/code/modules/living/emote.dm
+++ b/modular/code/modules/living/emote.dm
@@ -38,7 +38,8 @@
 		var/T = get_turf(user)
 		if(M.stat == DEAD && M.client && (M.client.prefs?.chat_toggles & CHAT_GHOSTSIGHT) && !(M in viewers(T, null)))
 			M.show_message(message)*/
-	var/list/ghostless = get_hearers_in_view(4, user)
+	var/distance = 4
+	var/list/ghostless = get_hearers_in_view(distance, user)
 	var/list/mobsinview = list()
 	var/list/mobspickable = list()
 	for(var/mob/living/L in ghostless)
@@ -52,14 +53,12 @@
 	var/choice = input(user, "Pick a target?", "Subtle Emote") in emotechoice
 	to_chat(user, "<i>[message]</i>")
 
-	var/distance
 	var/user_loc
 	if(choice == "Same Tile")
 		distance = 0
 	else if(choice == "1-Tile Range")
 		distance = 1
 	else // we picked a target
-		distance = 4
 		var/mob/living/target = choice
 		if(!isliving(target) || QDELETED(target)) // mob has since been deleted/destroyed, skip
 			to_chat(user, span_boldwarning("The subtle emote target no longer exists, try again."))

--- a/modular/code/modules/living/emote.dm
+++ b/modular/code/modules/living/emote.dm
@@ -40,11 +40,16 @@
 			M.show_message(message)*/
 	var/list/ghostless = get_hearers_in_view(4, user)
 	var/list/mobsinview = list()
+	var/list/mobspickable = list()
 	for(var/mob/living/L in ghostless)
-		if(L.stat == CONSCIOUS && !L.rogue_sneaking && L != user) // To those conscious only. Slightly more expensive but subtle is not spammed
+		if(L.stat == CONSCIOUS && L != user) // To those conscious only. Slightly more expensive but subtle is not spammed
 			mobsinview += L
+	for(var/mob/living/L in mobsinview)
+		if(!L.rogue_sneaking && L.name != "Unknown") // do not let hidden/unknown targets be added to list
+			mobspickable += L
+
 	var/list/emotechoice = list("Same Tile", "1-Tile Range")
-	emotechoice += mobsinview
+	emotechoice += mobspickable
 	var/choice = input(user, "Pick a target?", "Subtle Emote") in emotechoice
 	to_chat(user, "<i>[message]</i>")
 

--- a/modular/code/modules/living/emote.dm
+++ b/modular/code/modules/living/emote.dm
@@ -44,9 +44,8 @@
 	for(var/mob/living/L in ghostless)
 		if(L.stat == CONSCIOUS && L != user) // To those conscious only. Slightly more expensive but subtle is not spammed
 			mobsinview += L
-	for(var/mob/living/L in mobsinview)
-		if(!L.rogue_sneaking && L.name != "Unknown") // do not let hidden/unknown targets be added to list
-			mobspickable += L
+			if(!L.rogue_sneaking && L.name != "Unknown") // do not let hidden/unknown targets be added to list
+				mobspickable += L
 
 	var/list/emotechoice = list("Same Tile", "1-Tile Range")
 	emotechoice += mobspickable


### PR DESCRIPTION
## About The Pull Request

This PR adds subtle emote targeting.

Upon running a subtle emote string, all visible, conscious mobs within 4 tiles are added to a pickable list, along with choices for all mobs within 1 tile or on the same tile.

For mobs that are hidden/masked/sneaking, they will be ignored however for the 1 tile/same tile choice they will be included in the subtle emote range if close enough.

## Testing Evidence

<img width="621" height="407" alt="choice" src="https://github.com/user-attachments/assets/0d3fc741-8ae8-4139-a16e-81544fa3e8e5" />

<img width="569" height="353" alt="choice" src="https://github.com/user-attachments/assets/f8c26254-3805-47dd-8d6d-6e8f1c9870d2" />

## Why It's Good For The Game

This allows players to subtle emote within a public setting, and not involve others who would usually object to the emote's content.