### PR TITLE
Nukes Dragon Ring buff.

### DIFF
--- a/code/modules/clothing/rogueclothes/rings.dm
+++ b/code/modules/clothing/rogueclothes/rings.dm
@@ -181,9 +181,9 @@
 	else if(slot == SLOT_RING)
 		active_item = TRUE
 		to_chat(user, span_notice("Here be dragons."))
-		user.change_stat("strength", 5)
-		user.change_stat("constitution", 5)
-		user.change_stat("endurance", 5)
+		user.change_stat("strength", 3)
+		user.change_stat("constitution", 3)
+		user.change_stat("endurance", 3)
 	return
 
 /obj/item/clothing/ring/dragon_ring/dropped(mob/living/user)


### PR DESCRIPTION
## About The Pull Request
Reduces the dragon rings buffing from a ridiculous 5 in str, con and end to a still insane but likely more reasonable 3 in each.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I literally changed 3 numbers.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The Dragon Ring was - from what I've been told, for some ungodly reason, buffed on blackmoor (lol) to being a godlike item. The dragon ring is meant to be notably powerful, but shouldn't elevate you into being stronger than literally anything else in the game. Hell, if you're one of the few classes in the game with 14-15 in str/end or con you'll straightup be elevated into being as strong as the VL or werewolves in some respects.

It is a hard to make item that gives notable benefits, but shouldn't be so absurd as to make any combatant wearing it godlike. Seriously, who thought making an item give you a total of 15 stat points was a good idea? This is without factoring in the fact that with a dedicated player you can straightup mass produce these.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
