### PR TITLE
Allow Middle-aged people to be Apothecary

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
@@ -6,7 +6,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	allowed_races = RACES_ALL_KINDS
-	allowed_ages = list(AGE_ADULT)
+	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	tutorial = "Working under the tutelage of the court physician, you still remain a mere apprentice in the medical arts. Woe is the one who has to suffer your hand holding the scalpel when your master is out."
 	outfit = /datum/outfit/job/roguetown/apothecary
 	cmode_music = 'sound/music/combat_physician.ogg'


### PR DESCRIPTION


## About The Pull Request
This PR allows middle-aged people to work at the Apothecary.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
TBA (I'm busy)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The only role that allows middle-aged people to be surgeons is Court Phys and Barber Surgeon. Court Phys. is only playable by humans and like maybe 2 other races and Barber Surgeon is a shady back-alley surgeon.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
