### PR TITLE
Unarmed CD Hotfix

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -10,7 +10,7 @@
 	chargetime = 0
 	swingdelay = 0
 	damfactor = 1.3
-	clickcd = CLICK_CD_INTENTCAP
+	clickcd = 10
 	item_d_type = "slash"
 
 /datum/intent/katar/thrust
@@ -22,7 +22,7 @@
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
 	penfactor = 40
 	chargetime = 0
-	clickcd = CLICK_CD_INTENTCAP
+	clickcd = 8
 	item_d_type = "stab"
 
 /datum/intent/lordbash
@@ -54,7 +54,7 @@
 	hitsound = list('sound/combat/hits/punch/punch_hard (1).ogg', 'sound/combat/hits/punch/punch_hard (2).ogg', 'sound/combat/hits/punch/punch_hard (3).ogg')
 	chargetime = 0
 	penfactor = BLUNT_DEFAULT_PENFACTOR
-	clickcd = 8
+	clickcd = 10
 	damfactor = 1.1
 	swingdelay = 0
 	icon_state = "inpunch"


### PR DESCRIPTION
## About The Pull Request

To start out, unarmed weapons have been using a pretty much unique clickcd value instead of a number such as 8 or 10. "CLICK_CD_INTENTCAP" makes it functionally better in every way. (I'm not even joking) 

But drumroll please, for the actual value of what this means! 6, it's fucking 6. 6 is what you would get for using your bare fists. It's faster by 2 than the dagger's 8 which is truly telling with the amount of attacks you can pile up with that extra time while still having a solid 40 pen.

That was just for the Katar, Knuckles are in the same boat while being blunt damage and doing a solid amount of HURTIN', was as fast as a dammed steel dagger while doing a LOT more damage and being 2 slots compact, so they need a little tunin'.

## Testing Evidence

3 line changes it's fine, trust.

## Why It's Good For The Game

Giving unarmed (one of the most powerful melee setups at the moment) weapons that were more or less unique to it and completely blew away any comparable weapons like the steel dagger is utterly stupid and only compounds the issues at hand.
