### PR TITLE
unarmed misscost adjustment

### DIFF
--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -409,8 +409,8 @@
 	noaa = FALSE
 	animname = "bite"
 	hitsound = list('sound/combat/hits/punch/punch (1).ogg', 'sound/combat/hits/punch/punch (2).ogg', 'sound/combat/hits/punch/punch (3).ogg')
-	misscost = 5
-	releasedrain = 2	//Lowered for intent stam usage.
+	misscost = 1
+	releasedrain = 1	//Lowered for intent stam usage.
 	swingdelay = 0
 	clickcd = 10
 	rmb_ranged = TRUE


### PR DESCRIPTION
## About The Pull Request

changes misscost and releasedrain to 1 for unarmed

## Testing Evidence

numbertweak.

## Why It's Good For The Game

<img width="199" height="234" alt="image" src="https://github.com/user-attachments/assets/79f323a7-eb0f-4357-9ca0-162084b9af39" />

why swinging big twohanded stick cost 1 but using hands cost 5 on miss and 2 on hit.

<img width="284" height="87" alt="image" src="https://github.com/user-attachments/assets/778e98e3-c12e-4c1d-8b62-3523a6b3260a" />

