### PR TITLE
adds racism

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -739,6 +739,14 @@
 				if (stuck_thing.w_class >= WEIGHT_CLASS_SMALL)
 					. += span_bloody("<b>[m3] \a [stuck_thing] stuck in [m2] [part.name]!</b>")
 
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/stress = H.get_stress_amount()//stress check for racism
+		if(H.has_flaw(/datum/charflaw/paranoid) || (!HAS_TRAIT(H, TRAIT_EMPATH) && stress >= 4))//if you have paranoid flaw or you're stressed while not being an empath
+			if(H.dna.species.name != dna.species.name)
+				if(dna.species.stress_examine)//some species don't have a stress desc
+					. += dna.species.stress_desc
+
 	if((user != src) && isliving(user))
 		var/mob/living/L = user
 		var/final_str = STASTR
@@ -842,7 +850,7 @@
 	var/trait_exam = common_trait_examine()
 	if(!isnull(trait_exam))
 		. += trait_exam
-	
+
 
 
 /mob/living/proc/status_effect_examines(pronoun_replacement) //You can include this in any mob's examine() to show the examine texts of status effects!


### PR DESCRIPTION
## About The Pull Request

species with stress_desc now have that desc visible near the end of your examine if you're paranoid or stressed

## Testing Evidence

<img width="233" height="267" alt="image" src="https://github.com/user-attachments/assets/09222784-bff6-40f2-916e-32c814fd0b0d" />

Works properly with: 
Paranoid trait (always displays as non-same species)
Stress while not being an empath (does display)
Stress while being an empath (doesn't display)

## Why It's Good For The Game

stress_desc has always existed despite never being used and I want to make it used since it adds flavor