### PR TITLE
Squire buff 3.0.

### DIFF
--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -235,9 +235,6 @@
 /obj/item/storage/keyring/guardknight
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/armory, /obj/item/roguekey/knight)
 
-/obj/item/storage/keyring/guardsquire
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/knight) //hehehe, leaving this in, :P
-
 /obj/item/storage/keyring/velder
 	keys = list(/obj/item/roguekey/velder, /obj/item/roguekey/farm, /obj/item/roguekey/butcher)
 


### PR DESCRIPTION
Legendary PR reposter. THE EASTER EGG IS REMOVED, THERE
## About The Pull Request

all squires get an iron dagger

all squires get a copper hammer

footman squire gets 3 shields

lancer squire gets a great weapon strap

## Testing Evidence

Lancer gets their stuff
<img width="1919" height="1079" alt="Screenshot 2025-08-23 191517" src="https://github.com/user-attachments/assets/b0966ce8-ca90-4b70-bf8e-071aef40b83d" />
Footman too
<img width="1919" height="1079" alt="Screenshot 2025-08-23 191657" src="https://github.com/user-attachments/assets/bb4e353d-348b-4ec7-a42b-d105a97b0a78" />
and the irregular
<img width="1919" height="1079" alt="Screenshot 2025-08-23 192111" src="https://github.com/user-attachments/assets/068be7c4-2d58-4fc7-9703-b37823857847" />

## Why It's Good For The Game

Squires are expected to repair equipment, yet there's only one hammer in the entire keep, so they all get crappy stone ones.
Squires get an iron dagger for standardization, so every squire starts with a primary(bow/sword/spear) and a backup(the dagger).
Footman Squires have access to shields, yet not the skill to use them.