### PR TITLE
Dragon Ring Hotfix

### DIFF
--- a/code/modules/clothing/rogueclothes/rings.dm
+++ b/code/modules/clothing/rogueclothes/rings.dm
@@ -190,9 +190,9 @@
 	..()
 	if(active_item)
 		to_chat(user, span_notice("Gone is thy hoard."))
-		user.change_stat("strength", -5)
-		user.change_stat("constitution", -5)
-		user.change_stat("endurance", -5)
+		user.change_stat("strength", -2)
+		user.change_stat("constitution", -2)
+		user.change_stat("endurance", -2)
 		active_item = FALSE
 	return
 


### PR DESCRIPTION
## About The Pull Request
The last dragon ring PR, https://github.com/Scarlet-Reach/Scarlet-Reach/pull/657/ made it so you lose -5 instead of -2 each time you remove the ring, thusly lowering the user's ACTUAL stat by 3 every take it was taken off and if repeated, you can end up with 1 in CON, END and STR. It's bleak milord.


## Why It's Good For The Game

Person who coded the nerf didn't do it right, this fixes it.
