### PR TITLE
Druid's furry form respects surrender button now

### DIFF
--- a/code/modules/spells/spell_types/wildshape.dm
+++ b/code/modules/spells/spell_types/wildshape.dm
@@ -29,9 +29,12 @@
 /obj/effect/proc_holder/spell/targeted/wildshape/cast(list/targets, mob/user = usr)
 	. = ..()
 	for(var/mob/living/carbon/human/M in targets)
+		if (M.has_status_effect(/datum/status_effect/debuff/submissive))
+			to_chat(user, span_warning("Your will is too broken to change form."))
+			return FALSE
 		if(!istype(M, /mob/living/carbon/human/species/wildshape)) //If we aren't a wildshaped species, we can use this
 			var/list/animal_list = list()
-			
+
 			for(var/path in possible_shapes) //First pass for the names
 				var/mob/living/carbon/human/species/wildshape/A = path
 				animal_list[initial(A.name)] = path


### PR DESCRIPTION
## About The Pull Request

From now as a druid you can press **yield** and then Beast Form
It drops all effects from you, aka 1 minute slowdown and 30 seconds stun so you can run away or start to attack
Instaclick button, no delay. Just press surrender and then beast form to stab your enemy in next second if you have changed your mind so cool so furry 

It also breaks grabs and removes all debuffs from them but I think its fine
Also they get aheal but there PR to remove it

Im fine with it let them have cool stuff but combat mode abuse is not cool
This pr prevents them to use furry form if they have **submissive** debuff (the one slowdown that lasts 60 seconds)


## Testing Evidence
<img width="1538" height="980" alt="image" src="https://github.com/user-attachments/assets/165423f5-82d4-4346-85c3-06ab212608ae" />
<img width="1547" height="968" alt="image" src="https://github.com/user-attachments/assets/9c2495da-ca8d-4289-a19a-dd3706cb8628" />




## Why It's Good For The Game

no surrender button abuse plz 