### PR TITLE
Limit hunger loss if naked and on bath turf

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -922,8 +922,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	if(HAS_TRAIT(H, TRAIT_NOHUNGER))
 		return //hunger is for BABIES
 
-	if(!H.wear_armor && !H.wear_shirt && !H.wear_pants)
-		if(istype(get_turf(H), /turf/open/water/bath)) // if we're naked in bath, don't process hunger
+	if(H.stat != DEAD && !H.wear_armor && !H.wear_shirt && !H.wear_pants && H.nutrition < NUTRITION_LEVEL_HUNGRY) // Only pause nutrition consuming if nutrition is below NUTRITION_LEVEL_HUNGRY
+		if(istype(get_turf(H), /turf/open/water/bath)) // if we're naked in bath
 			return
 
 	//The fucking TRAIT_FAT mutation is the dumbest shit ever. It makes the code so difficult to work with


### PR DESCRIPTION
## About The Pull Request

This PR prevents hunger dropping down to starving levels if standing on a `/turf/open/water/bath` turf and naked.

This is so characters do not drain to starving status while submerged in a bath tile, or cause that _dreadful_ stomach growling sound effect until your character eats something.

## Testing Evidence

<img width="611" height="286" alt="Untitled" src="https://github.com/user-attachments/assets/27eda9d8-c34a-46ae-b139-3a49ce82b28c" />

## Why It's Good For The Game

It'll decrease interruptions while roleplaying.