### PR TITLE
Player-placed kneestingers delete on timer & revert miracle removal from everyone but druids.

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -56,7 +56,7 @@
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/targeted/wildshape			= CLERIC_T2,
 					/obj/effect/proc_holder/spell/targeted/beasttame			= CLERIC_T2,
-					// /obj/effect/proc_holder/spell/targeted/conjure_glowshroom	= CLERIC_T3, - Moved to the druid job type, people were abusing it and blocking entire areas with it. This leaves Dendorites without a T3, but I don't care!
+					/obj/effect/proc_holder/spell/targeted/conjure_glowshroom	= CLERIC_T3,
 					/obj/effect/proc_holder/spell/self/howl/call_of_the_moon	= CLERIC_T4,
 	)
 	confess_lines = list(

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -129,3 +129,15 @@
 	var/obj/effect/decal/cleanable/molten_object/I = new (get_turf(src))
 	I.desc = ""
 	qdel(src)
+
+/obj/structure/glowshroom/dendorite
+	var/timeleft = 60 SECONDS
+
+/obj/structure/glowshroom/dendorite/Initialize()
+	. = ..()
+	if(timeleft)
+		QDEL_IN(src, timeleft)
+
+/obj/structure/glowshroom/dendorite/attackby(obj/item/W, mob/user, params)
+	// Dendorite glowshrooms don't electrocute when hit
+	. = ..()

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -78,5 +78,3 @@
 	ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)	//Starts off maxed out.
-	if(H.mind)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/conjure_glowshroom) // Gives only druids the ability to summon glowshrooms, people were abusing it

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/fae/sylph.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/fae/sylph.dm
@@ -81,7 +81,7 @@
 		return
 	for(var/turf/turf as anything in RANGE_TURFS(3,src.loc))
 		if(prob(30))
-			new /obj/structure/glowshroom(turf)
+			new /obj/structure/glowshroom/dendorite(turf)
 
 
 /mob/living/simple_animal/hostile/retaliate/rogue/fae/sylph/death(gibbed)

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -85,8 +85,8 @@
 	var/turf/T = user.loc
 	for(var/X in GLOB.cardinals)
 		var/turf/TT = get_step(T, X)
-		if(!isclosedturf(TT) && !locate(/obj/structure/glowshroom) in TT)
-			new /obj/structure/glowshroom(TT)
+		if(!isclosedturf(TT) && !locate(/obj/structure/glowshroom) in TT && !locate(/obj/structure/glowshroom/dendorite) in TT)
+			new /obj/structure/glowshroom/dendorite(TT)
 	return TRUE
 
 /obj/effect/proc_holder/spell/self/howl/call_of_the_moon

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -65,7 +65,7 @@
 			to_chat(usr, "With Dendor's aide, you soothe [animal] of their anger.")
 	return tamed
 
-/obj/effect/proc_holder/spell/targeted/conjure_glowshroom // This has been moved to the druid job type, but is still here for reference.
+/obj/effect/proc_holder/spell/targeted/conjure_glowshroom
 	name = "Fungal Illumination"
 	range = 1
 	overlay_state = "blesscrop"


### PR DESCRIPTION
## About The Pull Request

Reverts https://github.com/Scarlet-Reach/Scarlet-Reach/pull/627
Creates a player-made variant of knee-stingers that are the exact same as regular map stingers except they don't shock you when attacked & auto-delete after 1 minute.
Also gave this knee-stinger variant to Sylphs since they spawn like 5 gazillion at a time.

## Testing Evidence


https://github.com/user-attachments/assets/b0492312-8446-4a81-843a-10c8f5e608db


https://github.com/user-attachments/assets/ec74664b-b39f-4808-b8be-e15a17cbcccc


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

lol
<img width="1020" height="1036" alt="image" src="https://github.com/user-attachments/assets/965e0b0a-eaa5-4c20-b0b6-120efde65608" />

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
