### PR TITLE
moves elf and dwarf to appointed outcast races

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -197,10 +197,8 @@
 
 #define RACES_NOBILITY_ELIGIBLE \
     /datum/species/human/northern,\
-    /datum/species/elf/wood,\
     /datum/species/human/halfelf,\
     /datum/species/demihuman,\
-    /datum/species/dwarf/mountain,\
 
 #define RACES_CHURCH_FAVORED \
 	/datum/species/aasimar,\
@@ -208,6 +206,8 @@
 #define RACES_APPOINTED_OUTCASTS \
     /datum/species/tieberian,\
     /datum/species/elf/dark,\
+    /datum/species/elf/wood,\
+    /datum/species/dwarf/mountain,\
 
 #define RACES_MANMADE \
 	/datum/species/golem/metal,\


### PR DESCRIPTION

## About The Pull Request

elves are canonically racist against humens in the lore and it doesn't make much sense for dwarves to get preferred treatment over other guys but I'm open to critique since maybe dwarves are just chill like that
half-elves and halfkin are still allowed to be nobility

## Testing Evidence

<img width="1110" height="549" alt="image" src="https://github.com/user-attachments/assets/a80ed309-8234-4153-bab4-7770b5321b60" />
works

## Why It's Good For The Game

Points were made in the discord feedback threads that it doesn't really make sense that some races despite being racist against humens are allowed as full-on nobility positions like duke and knight