### PR TITLE
Tentatively fixes Graggar Cullings [HOTFIX, UNDER INVESTIGATION, PLEASE TESTMERGE FIRST]

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -165,6 +165,7 @@
 /obj/item/reagent_containers/food/snacks/organ/On_Consume(mob/living/eater)		//Graggarites looove eating organs, they loooove eating organs!
 	if(HAS_TRAIT(eater, TRAIT_ORGAN_EATER))
 		eat_effect = /datum/status_effect/buff/foodbuff
+		check_culling(eater)
 		foodtype = RAW | MEAT
 	else
 		eat_effect = initial(eat_effect)
@@ -172,7 +173,6 @@
 	if(bitecount >= bitesize)
 		record_featured_stat(FEATURED_STATS_CRIMINALS, eater)
 		GLOB.scarlet_round_stats[STATS_ORGANS_EATEN]++
-		check_culling(eater)
 		SEND_SIGNAL(eater, COMSIG_ORGAN_CONSUMED, src.type)
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request
Graggar Cullings are currently broken and do not resolve when the heart is eaten. This PR tries to fix it.

Currently shifts the check_culling proc up a little to check if it isn't an issue with organ_inside being null at the time it is checked.

## Testing Evidence
<img width="446" height="68" alt="image" src="https://github.com/user-attachments/assets/969000fe-5a1e-4373-8352-035594d4bca2" />


## Why It's Good For The Game
Bugfix good.
