### PR TITLE
Lets Acolytes start with a wood staff and polearms 2

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -34,6 +34,7 @@
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 	beltl = /obj/item/storage/keyring/churchie
 	backl = /obj/item/storage/backpack/rogue/satchel
+	backr = /obj/item/rogueweapon/woodstaff
 	backpack_contents = list(/obj/item/ritechalk)
 	switch(H.patron?.type)
 		if(/datum/patron/divine/astrata)
@@ -111,6 +112,7 @@
 			armor = /obj/item/clothing/suit/roguetown/shirt/robe/astrata
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/medicine, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/alchemy, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)


### PR DESCRIPTION
## About The Pull Request

this takes 5 minutes to farm up roundstart. annoying.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="1613" height="403" alt="image" src="https://github.com/user-attachments/assets/3099a18c-ef7f-4377-9649-49f2630ff6f5" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

as an acolyte you are super duper valid to everyone. woodstaff tends to be one of your only lyfelines when someone walks in the front door during lowpop _yet again_ or when all the templars have left to walk into the north forest alone _yet again_

this lets me and other acolytes not waste time every single round for the item and easily trainable skill at the dummy

it's also thematic for monks to carry a dog beating staff

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
