### PR TITLE
Remove duplicated call to knot_try()

### DIFF
--- a/code/datums/sexcon/sexcon.dm
+++ b/code/datums/sexcon/sexcon.dm
@@ -191,8 +191,6 @@
 			splashed_user.apply_status_effect(/datum/status_effect/facial/internal)
 		else
 			splashed_user.apply_status_effect(/datum/status_effect/facial)
-	if(user != target)
-		knot_try()
 	after_ejaculation()
 	if(!oral)
 		after_intimate_climax()


### PR DESCRIPTION
## About The Pull Request

This PR fixes a duplicated call to `knot_try()` that was introduced erroneously in 23fbdba18291c938ab4159bb1ed1875453f699f7

## Testing Evidence

I've tested and confirmed this fix works.

## Why It's Good For The Game

Fixes a bug.
