### PR TITLE
fix cinnabar not appearing in bandit mage hoard

### DIFF
--- a/code/modules/cargo/packsrogue/Mage.dm
+++ b/code/modules/cargo/packsrogue/Mage.dm
@@ -174,7 +174,7 @@
 	cost = 20
 	contains = list(/obj/item/rogueweapon/woodstaff/quarterstaff/steel)
 
-/datum/supply_pack/rogue/bandit/Mage/cinnabar
+/datum/supply_pack/rogue/Mage/cinnabar
 	name = "Cinnabar Ore"
 	cost = 10
 	contains = list(/obj/item/rogueore/cinnabar = 1)


### PR DESCRIPTION
## About The Pull Request

fixes the fact that bandit rogue mage technically had cinnabar ore in their hoard, except that someone typed the path wrong so it didn't really exist. yay!

## Testing Evidence

<img width="305" height="995" alt="proof of testing" src="https://github.com/user-attachments/assets/37de0835-2ba4-43bd-b79e-f0e7a7d009a3" />

## Why It's Good For The Game

fixing bugs is awesome and sexy and is known to make your skin smoother
