### PR TITLE
Acrobats drain stamina from landing falls

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -46,6 +46,7 @@
 	if(HAS_TRAIT(src, TRAIT_NOFALLDAMAGE1))
 		if(levels <= 2)
 			Immobilize(10)
+			stamina_add(50)
 			if(m_intent == MOVE_INTENT_RUN)
 				toggle_rogmove_intent(MOVE_INTENT_WALK)
 			return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -46,7 +46,6 @@
 	if(HAS_TRAIT(src, TRAIT_NOFALLDAMAGE1))
 		if(levels <= 2)
 			Immobilize(10)
-			stamina_add(50)
 			if(m_intent == MOVE_INTENT_RUN)
 				toggle_rogmove_intent(MOVE_INTENT_WALK)
 			return

--- a/modular_azurepeak/virtues/movement.dm
+++ b/modular_azurepeak/virtues/movement.dm
@@ -1,4 +1,4 @@
 /datum/virtue/movement/acrobatic
 	name = "Acrobatic"
 	desc = "I have powerful legs, allowing me to land precisely where I want to, even with a running start."
-	added_traits = list(TRAIT_LEAPER, TRAIT_NOFALLDAMAGE1)
+	added_traits = list(TRAIT_LEAPER)

--- a/modular_azurepeak/virtues/movement.dm
+++ b/modular_azurepeak/virtues/movement.dm
@@ -1,4 +1,4 @@
 /datum/virtue/movement/acrobatic
 	name = "Acrobatic"
 	desc = "I have powerful legs, allowing me to land precisely where I want to, even with a running start."
-	added_traits = list(TRAIT_LEAPER)
+	added_traits = list(TRAIT_LEAPER, TRAIT_NOFALLDAMAGE1)


### PR DESCRIPTION
## About The Pull Request

Acrobats lose 50 stamina from landing from a zlevel fall.  This is HOPEFULLY enough to add a cost, but its little enough that an acrobat can drop 2 zlevels in quick succession without stamming out.

## Testing Evidence

<img width="1537" height="724" alt="image" src="https://github.com/user-attachments/assets/8ca792f8-0a82-4909-88fd-b3db05912f2c" />

## Why It's Good For The Game

It's not nearly as good as having the trait thats literally too good for anybody but werewolves to have removed, but alas.

Now instead of being "entirely" uncatchable, acrobats will only be "mostly" uncatchable upon using their ability to descend 1 zlevel instantly, or 2 zlevels safely.  They'll at least have to wait for their stamina to regen.
