### PR TITLE
Shaman Nerf

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
@@ -79,8 +79,8 @@
 			H.adjust_skillrank(/datum/skill/magic/holy, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
 			H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
-			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/summonrogueweapon/evil/inhumenblade)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/message)
+			H?.mind.adjust_spellpoints(6) // Replace arcyne push dagger for 6 T1 spell points
 			H.change_stat("strength", 3) 
 			H.change_stat("endurance", 2)
 			H.change_stat("constitution", 2)


### PR DESCRIPTION
## About The Pull Request

Removes Arcyne Push Dagger from Shaman. Doesn't delete it from the code in case someone else makes a class for it, but at the moment Shaman's too busted, you get:

- Infinite Durability Katar that reappears at will, like it's a Hidden Blade from Assassin's Creed
- Dodge Expert (you start with light armor)
- Unarmed 5
- Wrestling 4
- Strong Bite
- Expert Pugilist (can hit any limb from the floor)
- Passive Cleric regen

It's just too good. This at least makes you so you have to sacrifice an inventory slot for a katar, and in turn gives them some T1 arcyne points, meaning you CANNOT buy offensive spells, but you can get some buffing stuff like Featherfall, Longstrider, Invisibility, etc. 
Shamans are supposed to be played alongside Varangian, they're meant to buff the fuck out of their Varangian and keep them fighting, they're not supposed to be solo fighters.

I will also port AP's Shaman rework once it's released. This is a quick nerf to them because fuck you.

## Testing Evidence

works on my machine trust me bro
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Shaman meta
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
