### PR TITLE
Psydonite nobles

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -9,7 +9,6 @@
 	disallowed_races = list(
 		/datum/species/lamia,
 	)
-	allowed_patrons = NON_PSYDON_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	display_order = JDO_COUNCILLOR
 	tutorial = "You may have inherited this position, bought your way into it, or were appointed to it by merit--perish the thought! Whatever the case though, you work as an assistant and agent of the crown in matters of state. Whether this be aiding the steward, the sheriff, or the crown itself, or simply enjoying the free food of the keep, your duties vary day by day. You may be the lowest rung of the ladder, but that rung still towers over everyone else in town."

--- a/code/modules/jobs/job_types/roguetown/courtier/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/jester.dm
@@ -9,7 +9,6 @@
 	disallowed_races = list(
 		/datum/species/lamia,
 	)
-	allowed_patrons = NON_PSYDON_PATRONS
 	allowed_ages = ALL_AGES_LIST
 	tutorial = "The Grenzelhofts were known for their Jesters, wisemen with a tongue just as sharp as their wit. \
 		You command a position of a fool, envious of the position your superiors have upon you. \

--- a/code/modules/jobs/job_types/roguetown/courtier/physician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/physician.dm
@@ -6,7 +6,6 @@
 	total_positions = 1
 	spawn_positions = 1
 	allowed_races = RACES_APPOINTED_OUTCASTS_UP
-	allowed_patrons = NON_PSYDON_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	display_order = JDO_PHYSICIAN
 	tutorial = "You were a child born into good wealth--but poor health. \

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -6,7 +6,6 @@
 	total_positions = 1
 	spawn_positions = 1
 	allowed_races = RACES_ALL_KINDS//Dungeoneer is a freak. His race selection should allow this.
-	allowed_patrons = NON_PSYDON_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	display_order = JDO_DUNGEONEER
 

--- a/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
@@ -10,7 +10,6 @@
 	disallowed_races = list(
 		/datum/species/lamia,
 	)
-	allowed_patrons = NON_PSYDON_PATRONS
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	tutorial = "You are the most experienced of the Crown's Soldiery, leading the men-at-arms in maintaining order and attending to threats and crimes below the court's attention. \
 				See to those under your command and fill in the gaps knights leave in their wake. Obey the orders of your Marshal and the Crown."

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -9,7 +9,6 @@
 	allowed_sexes = list(MALE, FEMALE) //same as town guard
 	allowed_races = RACES_ALL_KINDS//But. Actually not. Only Mercenary and Ex-Spy allow All Races.
 	tutorial = "You've known combat your entire life. There isn't a way to kill a man you havent practiced in the tapestries of war itself. You wouldn't call yourself a hero--those belong to the men left rotting in the fields where you honed your ancient trade. You don't sleep well at night anymore, you don't like remembering what you've had to do to survive. Trading adventure for stable pay was the only logical solution, and maybe someday you'll get to lay down the blade and rest your weary body..."
-	allowed_patrons = NON_PSYDON_PATRONS
 	allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD)
 	advclass_cat_rolls = list(CTAG_VETERAN = 20)
 	display_order = JDO_VET

--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -7,7 +7,6 @@
 	spawn_positions = 1
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NOBILITY_ELIGIBLE_UP
-	allowed_patrons = NON_PSYDON_PATRONS
 	allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD)
 	display_order = JDO_MARSHAL
 	tutorial = "You are an agent of the crown in matters of law and military, making sure that laws are pushed, verified and carried out by the retinue upon the citizenry of the realm. \

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -8,7 +8,6 @@
 	allowed_races = RACES_NOBILITY_ELIGIBLE_UP
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD)
-	allowed_patrons = NON_PSYDON_PATRONS
 	tutorial = "Your lineage is noble, and generations of strong, loyal knights have come before you. You served your time \
 	gracefully as knight of his royal majesty, and now you've grown into a role which many men can only dream of becoming. \
 	Veteran among knights, you lead the crown's knights to battle and organize the training squires. Obey the Marshal and the Crown. \

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -6,7 +6,6 @@
 	total_positions = 1
 	spawn_positions = 1
 	allowed_races = RACES_ALL_KINDS	//Duke selects his hand.
-	allowed_patrons = NON_PSYDON_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/hand
 	advclass_cat_rolls = list(CTAG_HAND = 20)

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -7,7 +7,6 @@
 	total_positions = 3
 	spawn_positions = 3
 	allowed_races = RACES_NOBILITY_ELIGIBLE_UP
-	allowed_patrons = NON_PSYDON_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	tutorial = "Having proven yourself both loyal and capable, you have been knighted to serve the realm as the royal family's sentry. \

--- a/code/modules/jobs/job_types/roguetown/nobility/lady.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lady.dm
@@ -8,7 +8,6 @@
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NOBILITY_ELIGIBLE_UP
-	allowed_patrons = NON_PSYDON_PATRONS
 	tutorial = "Picked out of your political value rather than likely any form of love, you have become the Grand Duke's most trusted confidant--and likely friend--throughout your marriage. Your loyalty and perhaps even your love will be tested this day... for the daggers that threaten your beloved are as equally pointed at your own throat."
 
 	spells = list(/obj/effect/proc_holder/spell/self/convertrole/servant,

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -11,7 +11,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	spawn_positions = 1
 	selection_color = JCOLOR_NOBLE
 	allowed_races = RACES_NOBILITY_ELIGIBLE_UP
-	allowed_patrons = NON_PSYDON_PATRONS
 	advclass_cat_rolls = list(CTAG_LORD = 20)
 	allowed_sexes = list(MALE, FEMALE)
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -6,7 +6,6 @@
 	total_positions = 4
 	spawn_positions = 4
 	allowed_races = RACES_ALL_KINDS
-	allowed_patrons = NON_PSYDON_PATRONS
 	spells = list(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 	advclass_cat_rolls = list(CTAG_WAPPRENTICE = 20)
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -8,7 +8,6 @@
 	spawn_positions = 2
 	f_title = "Princess"
 	allowed_races = RACES_NOBILITY_ELIGIBLE_UP //Maybe a system to force-pick lineage based on king and queen should be implemented. (No it shouldn't.)
-	allowed_patrons = NON_PSYDON_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT)
 	advclass_cat_rolls = list(CTAG_HEIR = 20)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -21,7 +21,6 @@
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_noble.ogg'
-	allowed_patrons = NON_PSYDON_PATRONS		//Same reason as lord. See Lord.
 
 
 


### PR DESCRIPTION
## About The Pull Request

Removes the allowed patron: NON_PSYDON_PATRONS from every role it is mentioned in. Keeps the define around in the code just in case.

## Testing Evidence

<img width="1516" height="822" alt="image_2025-08-28_140504611" src="https://github.com/user-attachments/assets/bfb4e1a7-6086-4f0c-ae1d-eae0eba739f8" />

## Why It's Good For The Game

If the inhumen are (mechanically)allowed to be all of these roles, so should the Psydonites. You can create a guy named "Richter Von Evilstein" have him worship Zizo and queue for duke, yet Psydonites are barred.