### PR TITLE
[HUGBOX] Anti-killbox areas for mappers / Prevents digging into Inquisition basement

### DIFF
--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -105,7 +105,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_dusk = 'sound/music/area/banditcamp.ogg'
 	droning_sound_night = 'sound/music/area/banditcamp.ogg'
 
-/area/rogue/outdoors/banditcamp/exterior
+/area/rogue/outdoors/banditcamp/exterior // Only use these around traveltiles - Constantine
 	name = "bandit camp outdoors"
 
 /area/rogue/outdoors/banditcamp/exterior/can_craft_here() //Made to prevent killboxes - Constantine
@@ -685,7 +685,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_night = 'sound/music/unholy.ogg'
 	converted_type = /area/rogue/outdoors/dungeon1
 
-/area/rogue/under/cave/inhumen/entrance
+/area/rogue/under/cave/inhumen/entrance // Only use these around traveltiles - Constantine
 	name = "inhumen"
 
 /area/rogue/under/cave/inhumen/entrance/can_craft_here() //Made to prevent killboxes - Constantine


### PR DESCRIPTION
## About The Pull Request
This prevents people from making cancerous BOS killboxes F13 style. 
<img width="157" height="106" alt="Screenshot 2025-08-28 174844" src="https://github.com/user-attachments/assets/dd3dd8c9-5aba-4e52-8fb9-d99856c1444e" />
**Note:** I didn't add anything to the map itself, just the areas needed for mappers to do so.
## Testing Evidence

<details><summary>Testing evidence</summary>

https://github.com/user-attachments/assets/a7831e8a-ffe5-4f31-8bec-4c0809cc7e41

</details>


## Why It's Good For The Game
Prevents shit like this from happening in the future. 
<img width="500" height="802" alt="Screenshot_65" src="https://github.com/user-attachments/assets/cfc2a66d-8c18-4f28-b1b0-74aed44fe4a2" />
<img width="500" height="570" alt="image (3)" src="https://github.com/user-attachments/assets/3add1f78-b9d4-4655-97ff-eadd84bbe457" />

