### PR TITLE
properly paths stamina poison / makes it lower stam

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -17,7 +17,7 @@
 	name = "ozium"
 	category = "Table"
 	result = list(/obj/item/reagent_containers/powder/ozium)
-	reqs = list(/obj/item/ash = 2, /datum/reagent/stampoison = 2, /obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry = 1)
+	reqs = list(/obj/item/ash = 2, /datum/reagent/toxin/stampoison = 2, /obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry = 1)
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/alchemy/ozium_3x
@@ -26,7 +26,7 @@
 	result = list(/obj/item/reagent_containers/powder/ozium,
 					/obj/item/reagent_containers/powder/ozium,
 					/obj/item/reagent_containers/powder/ozium)
-	reqs = list(/obj/item/ash = 3, /datum/reagent/stampoison = 3, /obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry = 2)
+	reqs = list(/obj/item/ash = 3, /datum/reagent/toxin/stampoison = 3, /obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry = 2)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/moon

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -357,9 +357,9 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	toxpwr = 0
 
 
-/datum/reagent/stampoison/on_mob_life(mob/living/carbon/M)
+/datum/reagent/toxin/stampoison/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_INFINITE_STAMINA))
-		M.energy_add(-45) //Slowly leech energy
+		M.stamina_add(15) //Slowly leech energy
 	return ..()
 
 /datum/reagent/toxin/strongstampoison
@@ -372,9 +372,9 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	toxpwr = 0
 
 
-/datum/reagent/strongstampoison/on_mob_life(mob/living/carbon/M)
+/datum/reagent/toxin/strongstampoison/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_INFINITE_STAMINA))
-		M.energy_add(-180) //Rapidly leech energy
+		M.stamina_add(45) //Rapidly leech energy
 	return ..()
 
 /datum/reagent/toxin/killersice

--- a/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
@@ -163,7 +163,7 @@
         )
     reqs = list(
         /obj/item/ammo_casing/caseless/rogue/arrow/iron = 5,
-        /datum/reagent/stampoison = 25,
+        /datum/reagent/toxin/stampoison = 25,
         )
 
     req_table = TRUE
@@ -180,7 +180,7 @@
         )
     reqs = list(
         /obj/item/ammo_casing/caseless/rogue/arrow/stone = 5,
-        /datum/reagent/stampoison = 25,
+        /datum/reagent/toxin/stampoison = 25,
         )
 
     req_table = TRUE


### PR DESCRIPTION
## About The Pull Request

it used to lower energy, I changed it to lower stam to be consistent with the name
I will say that this absolutely obliterates your stamina bar at lower END levels (at END 9, 2u of stam poison will take half of your bar, and 2u of strong stam poison will exhaust you) so I'd prefer it get TMed to test numbers and make sure it's not just "I poison u to death and u die"

## Testing Evidence

<img width="278" height="110" alt="image" src="https://github.com/user-attachments/assets/4877733b-af40-43e9-befe-4ad5d929b5c9" />

## Why It's Good For The Game

it's a bugfix because the poison is otherwise completely nonfunctional, and also I think it makes it consistent with its name since it's called stamina poison and not energy/mana poison