### PR TITLE
Fix exploit of looking outside of buildings

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -870,9 +870,11 @@
 			look_up()
 		else
 			if(istransparentturf(T))
-				look_down(T)
-			else
-				look_further(T)
+				var/turf/MT = get_turf(src)
+				if((T in view(MT))) // if we got line of sight, allow player to look down
+					look_down(T)
+					return
+			look_further(T)
 	else
 		look_further(T)
 


### PR DESCRIPTION
## About The Pull Request

This PR fixes a exploit of being able to look outside of buildings.

1) Stand by any wall with an exterior that has open space tiles
2) Right click shift the obscured black area which leads to open space outside, and you'll get a view from below

<img width="402" height="363" alt="1" src="https://github.com/user-attachments/assets/7d8b4f31-4778-4e11-b7b2-284d36a6f36e" />
<img width="522" height="526" alt="2" src="https://github.com/user-attachments/assets/1005343f-76f1-40a3-862b-7ec1b22e09e7" />

## Testing Evidence

I have tested this locally and confirm it has fixed the exploit.

## Why It's Good For The Game

Fixes an exploit.