### PR TITLE
Leather padded hoods list ingredients

### DIFF
--- a/modular_stonehedge/code/modules/clothing/rogueclothes/hats.dm
+++ b/modular_stonehedge/code/modules/clothing/rogueclothes/hats.dm
@@ -52,8 +52,8 @@
 					H.update_inv_neck()
 
 //RECIPES
-/datum/crafting_recipe/roguetown/sewing/studhood
-	name = "leather padded hood"
+/datum/crafting_recipe/roguetown/leather/studhood
+	name = "leather padded hood (2 leather)"
 	result = /obj/item/clothing/head/roguetown/helmet/leather/armorhood
 	reqs = list(/obj/item/natural/hide/cured = 2)
 	craftdiff = 2


### PR DESCRIPTION
## About The Pull Request

Another part of my crusade against crafting recipes that don't actually tell you what you need to craft them.  This PR also changes the leather padded hood to use skincraft instead of sewing, since it literally only uses leather. It's still a diff of 2 so this changes nothing for anybody except people that stitch shirts to apprentice sewing.

This PR does not touch the items characteristics. Someone else can do that when they lose to someone wearing it.

## Testing Evidence

<img width="341" height="395" alt="image" src="https://github.com/user-attachments/assets/9951a554-a2ef-4111-851b-250b36a31dc1" />

## Why It's Good For The Game

Tailoring/Skincrafting recipes tell you what they require. This one did not. I fixed the inconsistency.  It was also weird to have an item use sewing instead of skincrafting when leather was the only ingredient.
