### PR TITLE
Gives martyr sword peel intent

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -494,8 +494,8 @@
 /obj/item/rogueweapon/sword/long/martyr
 	force = 30
 	force_wielded = 36
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/chop)
+	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/peel)
+	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel, /datum/intent/sword/chop)
 	icon_state = "martyrsword"
 	icon = 'icons/roguetown/weapons/64.dmi'
 	item_state = "martyrsword"


### PR DESCRIPTION
## About The Pull Request
Gives peel intent to one-handed martyr sword (they've an intent slot free there), and replaces their strike with peel on the two-handed stance. This brings them in line with the longsword and greatsword(iirc)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="224" height="158" alt="image" src="https://github.com/user-attachments/assets/6c2683fe-32b0-4545-b1e9-3a6f2eee0808" />
<img width="324" height="219" alt="image" src="https://github.com/user-attachments/assets/623560ac-159a-4935-a240-6fcb9e4f7d9d" />
<img width="1365" height="1022" alt="image" src="https://github.com/user-attachments/assets/9c0004d0-b0fd-4006-8fbd-9574cf8b9303" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
One of the biggest advantages of swords is them having a peel intent. The martyr sword is, for most intents and purposes, a sword. It's lack of peel intent makes it slightly subpar in its default state, despite its high force.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
