### PR TITLE
reverts stockpile bulksell change

### DIFF
--- a/code/modules/roguetown/roguemachine/stockpile/stockpile.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile.dm
@@ -23,7 +23,7 @@
 
 /obj/structure/roguemachine/stockpile/examine(mob/user)
 	. = ..()
-	. += span_info("Right click to sell everything on your turf into the stockpile.")
+	. += span_info("Right click to sell everything in front of the stockpile.")
 
 /obj/structure/roguemachine/stockpile/Topic(href, href_list)
 	. = ..()
@@ -161,9 +161,9 @@
 		if(istype(P, /obj/item/roguecoin/aalloy))
 			return
 
-		if(istype(P, /obj/item/roguecoin/inqcoin))	
+		if(istype(P, /obj/item/roguecoin/inqcoin))
 			return
-	
+
 		if(istype(P, /obj/item/roguecoin))
 			withdraw_tab.insert_coins(P)
 			return attack_hand(user)
@@ -172,7 +172,7 @@
 
 /obj/structure/roguemachine/stockpile/attack_right(mob/user)
 	if(ishuman(user))
-		for(var/obj/I in get_turf(user))
+		for(var/obj/I in get_turf(src))
 			attemptsell(I, user, FALSE, FALSE)
 		say("Bulk selling in progress...")
 		playsound(loc, 'sound/misc/hiss.ogg', 100, FALSE, -1)


### PR DESCRIPTION
change was added in #666 
## About The Pull Request

rclick now sells everything in front of it once more

## Testing Evidence

<img width="253" height="493" alt="image" src="https://github.com/user-attachments/assets/8c00c565-a9bd-4bcc-9caf-a58c6e9620ed" />


## Why It's Good For The Game

makes selling eggs massively less carcinogenic