### PR TITLE
Allow subtle emotes to target sleeping mobs

### DIFF
--- a/modular/code/modules/living/emote.dm
+++ b/modular/code/modules/living/emote.dm
@@ -46,7 +46,7 @@
 	var/list/mobsinview = list()
 	var/list/mobspickable = list("1-Tile Range", "Same Tile")
 	for(var/mob/living/L in ghostless)
-		if(L.stat == CONSCIOUS && L != src) // To those conscious only. Slightly more expensive but subtle is not spammed
+		if(L.stat != DEAD && L != src) // to those living only - slightly more expensive but subtle is not spammed
 			mobsinview += L
 			if(!L.rogue_sneaking && L.name != "Unknown") // do not let hidden/unknown targets be added to list
 				mobspickable += L


### PR DESCRIPTION
## About The Pull Request

This PR improves #671 by allowing players to target sleeping mobs.

## Testing Evidence

I've tested this and confirm it works.

<img width="372" height="138" alt="testing" src="https://github.com/user-attachments/assets/2ee075c3-155d-4929-9c33-93d9512aba1c" />

## Why It's Good For The Game

Allows players to subtle emote even if their partner is sleeping.