### PR TITLE
skillbooks now contribute to noc influence

### DIFF
--- a/code/game/objects/items/rogueitems/skillbooks.dm
+++ b/code/game/objects/items/rogueitems/skillbooks.dm
@@ -33,7 +33,7 @@
 			else
 				icon_state = "book[iconval]_[open]"
 
-/obj/item/skillbook/fire_act()
+/obj/item/skillbook/burn()
 	GLOB.scarlet_round_stats[STATS_BOOKS_BURNED]++
 	..()
 

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -32,7 +32,7 @@
 	grid_height = 64
 
 //Destroyer of knowledge - for storytellers
-/obj/item/book/fire_act()
+/obj/item/book/burn()
 	GLOB.scarlet_round_stats[STATS_BOOKS_BURNED]++
 	..()
 


### PR DESCRIPTION
## About The Pull Request

yep
also fixes normal books to use burn() instead of fire_act() when calculating the stuff because it still contributes to the book burned tally despite being extinguished

## Testing Evidence

<img width="238" height="302" alt="image" src="https://github.com/user-attachments/assets/626e985d-7568-4df9-8342-c24f8963acf4" />

works as expected

## Why It's Good For The Game

flavor