### PR TITLE
Map Fixes

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -6532,7 +6532,9 @@
 /obj/structure/closet/crate/chest/crate,
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/curtain/magenta{
-	color = 54202a
+	color = 54202a;
+	pixel_y = 0;
+	icon_state = "curtain-closed"
 	},
 /obj/item/rogue/instrument/harp/handcarved,
 /obj/item/rogue/instrument/viola,
@@ -53039,7 +53041,9 @@
 /area/rogue/indoors/shelter/woods)
 "qdJ" = (
 /obj/structure/curtain/magenta{
-	color = 54202a
+	color = 54202a;
+	pixel_y = 0;
+	icon_state = "curtain-closed"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
@@ -55755,8 +55759,7 @@
 "qTW" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/curtain/magenta{
-	color = 54202a;
-	pixel_y = 0
+	color = 54202a
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
@@ -56759,8 +56762,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "rlj" = (
-/obj/structure/roguemachine/noticeboard,
-/turf/open/floor/rogue/cobble,
+/obj/structure/roguemachine/noticeboard{
+	pixel_y = 6;
+	pixel_x = -17
+	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "rlk" = (
 /obj/machinery/light/rogue/wallfire/candle/off/r,
@@ -57739,13 +57745,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
-"rBi" = (
-/obj/structure/curtain/magenta{
-	color = 54202a;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
 "rBl" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
@@ -145390,7 +145389,7 @@ wTJ
 hyA
 hMB
 haH
-gCR
+haH
 xqE
 iSu
 pkw
@@ -263357,7 +263356,7 @@ fLM
 rbu
 taS
 bYj
-rBi
+qdJ
 aar
 icb
 icb
@@ -274658,7 +274657,7 @@ kwU
 kwU
 phl
 cDX
-rlj
+sns
 sns
 sns
 feG
@@ -299001,7 +299000,7 @@ qyR
 aZo
 pWT
 fpx
-exD
+rlj
 exD
 exD
 xzx


### PR DESCRIPTION
- changes curtains to be closed at roundstart because it looks nicer. >:|
<img width="561" height="242" alt="image" src="https://github.com/user-attachments/assets/fc0531ad-d718-42a6-9e36-bd55cbb5092d" />

- adds a noticeboard that was missed by @ConstantineII (north-east gate)
<img width="842" height="520" alt="image" src="https://github.com/user-attachments/assets/d54d164c-cdcc-43a9-880e-933396f97681" />

- removed an additional noticeboard that is found near the new central one. (cleans up the alleyway like the beforetimes..)
<img width="788" height="474" alt="image" src="https://github.com/user-attachments/assets/1f308c84-49d1-4358-b7ce-0ff5994dd8ff" />


- fixes a tile issue with the bath-house that I missed in my sleepy mapping. u-u my biggest shame
<img width="568" height="279" alt="image" src="https://github.com/user-attachments/assets/9b6e14a3-dadb-471e-a06d-974a458d345f" />
<img width="699" height="299" alt="image" src="https://github.com/user-attachments/assets/84704568-c523-46da-977d-5f9e7b162559" />


