### PR TITLE
Don't allow beartraps to be armed over/next to travel tiles

### DIFF
--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -192,6 +192,15 @@
 		log_combat(user, src, "armed and dropped [src] near travel tiles")
 		break
 
+/obj/item/restraints/legcuffs/beartrap/after_throw(datum/callback/callback)
+	..()
+	if(!armed)
+		return
+	for(var/obj/structure/fluff/traveltile/TT in range(1, src)) // don't allow armed traps to be placed near travel tiles
+		close_trap()
+		log_combat(src, null, "[src] was kicked towards travel tiles")
+		break
+
 // When craftable beartraps get added, make these the ones crafted.
 /obj/item/restraints/legcuffs/beartrap/crafted
 	rusty = FALSE


### PR DESCRIPTION
## About The Pull Request

This PR prevents armed beartraps to be placed over/next to travel tiles.

## Testing Evidence

I have tested this locally and confirm it works.

## Why It's Good For The Game

This prevents players from using beartraps to spawn camp traveling players.