### PR TITLE
Gives recall a blank vocal component

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/recall.dm
+++ b/code/modules/spells/spell_types/wizard/utility/recall.dm
@@ -7,6 +7,8 @@
 	clothes_req = FALSE
 	cost = 4
 	spell_tier = 2
+	invocation = ""
+	invocation_type = "whisper"
 	cooldown_min = 3 MINUTES
 	associated_skill = /datum/skill/magic/arcane
 	xp_gain = TRUE


### PR DESCRIPTION
## About The Pull Request

Gives recall a blank vocal component for the purpose of balance

## Testing Evidence

2 lines, i tested and it works, trust me

## Why It's Good For The Game
Previously, you could call recall under ANY circumstances as a literal get out of jail free card, letting you get out of anything if left unattended for 15 seconds.
Now this can be countered by gagging the wizard / removing their tongue.
Balancejaking, one may say