### PR TITLE
adds a proper cooldown to fire patting

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -375,6 +375,7 @@
 		visible_message("<span class='warning'>[src] rolls on the ground, trying to put [p_them()]self out!</span>")
 	else
 		visible_message("<span class='notice'>[src] pats the flames to extinguish them.</span>")
+		last_special = world.time + CLICK_CD_RESIST
 	sleep(30)
 	if(fire_stacks <= 0)
 		ExtinguishMob(TRUE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1054,7 +1054,7 @@
 		C.container_resist(src)
 
 	else if(mobility_flags & MOBILITY_MOVE)
-		if(on_fire)
+		if(on_fire && last_special <= world.time)
 			resist_fire() //stop, drop, and roll
 			changeNext_move(CLICK_CD_RESIST)
 		else if(has_status_effect(/datum/status_effect/leash_pet))


### PR DESCRIPTION
## About The Pull Request

the CD to pat fire on yourself is now properly 2s, on live you can currently just instantly extinguish yourself when on fire

## Testing Evidence

tested and works as expected

## Why It's Good For The Game

hopefully makes burning more lethal since it's quite easy to just immediately extinguish yourself at the moment
Probably worth TMing since I don't know the balance ramifications of this