### PR TITLE
Recall changes

### DIFF
--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -467,3 +467,36 @@
 	else
 		return INITIALIZE_HINT_QDEL
 
+/obj/effect/temp_visual/recall_smoke
+	name = "recall smoke"
+	icon = 'icons/effects/particles/smoke.dmi'
+	icon_state = "steam_cloud_1"
+	duration = 20
+	plane = GAME_PLANE_UPPER
+	layer = ABOVE_ALL_MOB_LAYER
+
+/atom/movable/screen/alert/status_effect/buff/recalling
+	name = "Recalling"
+	desc = "Im in the middle of casting recall."
+	icon_state = "buff"
+
+/datum/status_effect/buff/recalling
+	id = "recalling"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/recalling
+	var/effect_color
+	var/datum/stressevent/stress_to_apply
+	var/pulse = 0
+	var/ticks_to_apply = 5
+
+/datum/status_effect/buff/recalling/tick()
+	var/obj/effect/temp_visual/recall_smoke/M = new /obj/effect/temp_visual/recall_smoke(get_turf(owner))
+	M.color = effect_color
+	pulse += 1
+
+/obj/effect/temp_visual/recall_smoke/Initialize(mapload, set_color)
+	if(set_color)
+		add_atom_colour(set_color, FIXED_COLOUR_PRIORITY)
+	. = ..()
+	alpha = 180
+	pixel_x = rand(-15, 15)
+	pixel_y = rand(-15, 15)

--- a/code/modules/spells/spell_types/wizard/utility/recall.dm
+++ b/code/modules/spells/spell_types/wizard/utility/recall.dm
@@ -10,6 +10,8 @@
 	cooldown_min = 3 MINUTES
 	associated_skill = /datum/skill/magic/arcane
 	xp_gain = TRUE
+	invocation = ""
+	invocation_type = "whisper"
 	action_icon_state = "spell0"
 
 	var/turf/marked_location = null
@@ -32,6 +34,7 @@
 
 	// Subsequent casts - begin channeling
 	H.visible_message(span_warning("[H] closes [H.p_their()] eyes and begins to focus intently..."))
+	H.apply_status_effect(/datum/status_effect/buff/recalling)
 	if(do_after(H, recall_delay, target = H, progress = TRUE))
 		// Get any grabbed mobs
 		var/list/to_teleport = list(H)
@@ -51,6 +54,7 @@
 		smoke.start()
 		start_recharge()
 	else
+		H.remove_status_effect(/datum/status_effect/buff/recalling)
 		to_chat(H, span_warning("Your concentration was broken!"))
 		start_recharge()
 		revert_cast()


### PR DESCRIPTION
## About The Pull Request

Makes recall require an open mouth to cast (no actual spell, i couldnt get it to work proper)
While casting recall, you now emit smoke. Why?.. Because you disappear in a big cloud of smoke i guess, the real reason is making it more obvious youre casting it

## Testing Evidence


https://github.com/user-attachments/assets/1788aa10-07dc-4bff-bf30-dde4714ee30b



## Why It's Good For The Game
Balance, recall used to be a free get out of jail card with very little signs youre casting it besides a small message in chat and a progress bar, and also made it physically impossible to capture any mage that had it, as if you left them for literally 15 seconds they would be GONE.