### PR TITLE
Martyr sword shenannigans (adjustments/balancejakking)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -5,12 +5,12 @@
 /datum/component/martyrweapon
 	var/list/allowed_areas = list(/area/rogue/indoors/town/church, /area/rogue/indoors/town/church/chapel, /area/rogue/indoors/town/church/basement)
 	var/list/allowed_patrons = list()
-	var/cooldown = 30 MINUTES
+	var/cooldown = 15 MINUTES
 	var/last_activation = 0
 	var/next_activation = 0
 	var/end_activation = 0
 	var/ignite_chance = 2
-	var/traits_applied = list(TRAIT_NOPAIN, TRAIT_NOPAINSTUN, TRAIT_NOMOOD, TRAIT_NOHUNGER, TRAIT_NOBREATH, TRAIT_BLOODLOSS_IMMUNE, TRAIT_LONGSTRIDER, TRAIT_STRONGBITE, TRAIT_STRENGTH_UNCAPPED)
+	var/traits_applied = list(TRAIT_NOPAIN, TRAIT_NOPAINSTUN, TRAIT_NOMOOD, TRAIT_NOHUNGER, TRAIT_NOBREATH, TRAIT_BLOODLOSS_IMMUNE, TRAIT_LONGSTRIDER, TRAIT_STRONGBITE, TRAIT_STRENGTH_UNCAPPED, TRAIT_SHOCKIMMUNE)
 	var/stat_bonus_martyr = 3
 	var/mob/living/current_holder
 	var/is_active = FALSE
@@ -397,12 +397,14 @@
 					SEND_SOUND(H, sound(null))
 					H.cmode_music = 'sound/music/combat_martyr.ogg'
 					to_chat(H, span_warning("I can feel my muscles nearly burst from power! I can jump great heights!"))
+					ADD_TRAIT(H, TRAIT_GRABIMMUNE, TRAIT_GENERIC)
 					ADD_TRAIT(H, TRAIT_ZJUMP, TRAIT_GENERIC)
 					ADD_TRAIT(H, TRAIT_NOFALLDAMAGE2, TRAIT_GENERIC)
 				if(STATE_MARTYRULT)
 					SEND_SOUND(H, sound(null))
 					H.cmode_music = 'sound/music/combat_martyrult.ogg'
 					to_chat(H, span_warning("I can jump great heights!"))
+					ADD_TRAIT(H, TRAIT_GRABIMMUNE, TRAIT_GENERIC)
 					ADD_TRAIT(H, TRAIT_ZJUMP, TRAIT_GENERIC)
 					ADD_TRAIT(H, TRAIT_NOFALLDAMAGE2, TRAIT_GENERIC)
 			adjust_traits(remove = FALSE)
@@ -494,8 +496,8 @@
 /obj/item/rogueweapon/sword/long/martyr
 	force = 30
 	force_wielded = 36
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/chop)
+	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/peel)
+	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel, /datum/intent/sword/chop)
 	icon_state = "martyrsword"
 	icon = 'icons/roguetown/weapons/64.dmi'
 	item_state = "martyrsword"


### PR DESCRIPTION
## About The Pull Request

- Reduces Martyr Sword cooldown to 15 minutes (Only relevant for safe mode, as you're dead with those other modes.)
- Grants shock immunity on all activation modes. Grants grab immunity during the 6 minute and 2 minute ult-modes.
- Adds peel intent to one handed and two handed grips, replacing strike in the case of the latter.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="384" height="258" alt="image" src="https://github.com/user-attachments/assets/0c65f884-cf23-44cc-a480-73b7fce55f72" />
<img width="351" height="159" alt="image" src="https://github.com/user-attachments/assets/1b3d2a0b-7b6b-486a-a9d8-f73f8ad5be22" />
<img width="549" height="387" alt="image" src="https://github.com/user-attachments/assets/1b9796b6-6d53-4434-959d-72ff00e3be95" />
<img width="559" height="162" alt="image" src="https://github.com/user-attachments/assets/52a22694-66eb-4fa9-9dc6-16285817205b" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The martyr's role primarily is to defend the church, ideally we do not punish them with a cooldown that lasts 1/6th of the round for activating their lesser, weaker mode in the place they're meant to defend. This does also mean that after the martyr's death during the 6/2 minute ult, the priest can use the sword after 15 minutes but I think that's an acceptable cooldown considering how rare such an event might even be and how they're the only 2 people in the game that can use the funny fire stick anyway.

The shock immunity is to shore up on more niche cases, ideally the martyr isn't being shocked or easily stunned by mundane things or kneestingers during their active modes. Grab immunity is rather straightforward- hell, AP gives them this already.

The peel intent is something that most swords have and considering the martyr _sword_ is a sword, it feels fitting.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
