### PR TITLE
Adds Cooldown to Throne & Priest Announcements

### DIFF
--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -30,10 +30,10 @@ SUBSYSTEM_DEF(communications)
 			if(SSticker.regentmob == user)
 				used_title = "[used_title]" + " Regent"
 			priority_announce(html_decode(user.treat_message(input)), "The [used_title] Speaks", 'sound/misc/bell.ogg', sender = user)
-			nonsilicon_message_cooldown = world.time + 5 SECONDS
+			nonsilicon_message_cooldown = world.time + 5 MINUTES
 		else
 			priority_announce(html_decode(user.treat_message(input)), "Someone Speaks", 'sound/misc/bell.ogg', sender = user)
-			nonsilicon_message_cooldown = world.time + 5 SECONDS
+			nonsilicon_message_cooldown = world.time + 5 MINUTES
 
 #undef COMMUNICATION_COOLDOWN
 #undef COMMUNICATION_COOLDOWN_AI

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -241,11 +241,15 @@ GLOBAL_LIST_EMPTY(heretical_players)
 	set category = "Priest"
 	if(stat)
 		return
+	if(!(devotion && devotion.devotion >= 750))
+		to_chat(src, span_warning("I need more devotion to channel Her voice! (750 required)"))
+		return FALSE
 	var/inputty = input("Make an announcement", "SCARLET REACH") as text|null
 	if(inputty)
 		if(!istype(get_area(src), /area/rogue/indoors/town/church/chapel))
 			to_chat(src, span_warning("I need to do this from the chapel."))
 			return FALSE
+		devotion.update_devotion(-750)
 		priority_announce("[inputty]", title = "The Priest Speaks", sound = 'sound/misc/bell.ogg', sender = src)
 
 /mob/living/carbon/human/proc/churcheapostasy()


### PR DESCRIPTION
## About The Pull Request

Throne announcements now have a 5 minute cooldown.
Priest announcements cost 750 devotion.

## Testing Evidence

<img width="447" height="241" alt="image" src="https://github.com/user-attachments/assets/205b6870-cddf-4bb6-9404-149a8aefa632" />
<img width="432" height="248" alt="image" src="https://github.com/user-attachments/assets/8cedd112-26b7-430a-b45d-fabf6eddd8f2" />


## Why It's Good For The Game

stop using announces for twitter beef ohhh my goddd
