### PR TITLE
Fixes Hover Maptext on Big Objects

### DIFF
--- a/code/_onclick/hud/mouseover.dm
+++ b/code/_onclick/hud/mouseover.dm
@@ -50,6 +50,7 @@
 			PM = params2list(params)
 			p.client.mouseovertext.movethis(PM, TRUE)
 		else
+			PM = list("screen-loc" = "[offset_x]:0,[max(offset_y, 1)]:0")
 			p.client.mouseovertext.movethis(PM)
 		p.client.mouseovertext.maptext = {"<span style='font-size:8pt;font-family:"Pterra";color:#ddd7df;text-shadow:0 0 10px #fff, 0 0 20px #fff, 0 0 30px #e60073, 0 0 40px #e60073, 0 0 50px #e60073, 0 0 60px #e60073, 0 0 70px #e60073;' class='center maptext '>[name]"}
 		p.client.screen |= p.client.mouseovertext


### PR DESCRIPTION
## About The Pull Request

makes it so that objects bigger than a tile don't mess up your screen trying to render mouseover text in space it doesn't fit in

## Testing Evidence

<img width="381" height="541" alt="image" src="https://github.com/user-attachments/assets/f35a1f39-1d3e-4e7e-bdfd-25ab9c711464" />


## Why It's Good For The Game

I am a code tyrant.
