### PR TITLE
separates polishing cream and polishing brushes in the goldface

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/luxury.dm
+++ b/code/modules/cargo/packsrogue/merchant/luxury.dm
@@ -63,11 +63,15 @@
 	cost = 250
 	contains = list(/obj/item/scomstone/listenstone)
 
-/datum/supply_pack/rogue/luxury/polishing_kit
-	name = "Polishing Kit"
-	no_name_quantity = TRUE
-	cost = 100
-	contains = list(/obj/item/polishing_cream, /obj/item/armor_brush)
+/datum/supply_pack/rogue/luxury/polishing_brush
+	name = "Polishing Brush"
+	cost = 40
+	contains = list(/obj/item/armor_brush)
+
+/datum/supply_pack/rogue/luxury/polishing_cream
+	name = "Polishing Cream"
+	cost = 60
+	contains = list(/obj/item/polishing_cream)
 
 /datum/supply_pack/rogue/luxury/talkstone
 	name = "Talkstone"


### PR DESCRIPTION
## About The Pull Request

there's an inexplicable bug i can't figure out that makes it so when you buy a polishing kit sometimes instead of cream and a brush it spits out two creams or two brushes

either way this just makes it so you can buy one or the other which is also useful for getting a refill on cream when you already have a brush

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

it's a webedit if this breaks the game i'll be shocked

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

pseudo bug fix and quality of life i don't need a brush when i'm only out of cream

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
