### PR TITLE
properly removes the recall buff and its vfx on successful cast

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1270,3 +1270,21 @@
 /datum/status_effect/buff/adrenaline_rush/on_remove()
 	. = ..()
 	REMOVE_TRAIT(owner, TRAIT_ADRENALINE_RUSH, INNATE_TRAIT)
+
+/atom/movable/screen/alert/status_effect/buff/recalling
+	name = "Recalling"
+	desc = "I'm in the middle of casting Recall. I need to stand still!"
+	icon_state = "buff"
+
+/datum/status_effect/buff/recalling
+	id = "recalling"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/recalling
+	var/effect_color
+	var/datum/stressevent/stress_to_apply
+	var/pulse = 0
+	var/ticks_to_apply = 5
+
+/datum/status_effect/buff/recalling/tick()
+	var/obj/effect/temp_visual/recall_smoke/M = new /obj/effect/temp_visual/recall_smoke(get_turf(owner))
+	M.color = effect_color
+	pulse += 1

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -467,31 +467,13 @@
 	else
 		return INITIALIZE_HINT_QDEL
 
-/obj/effect/temp_visual/recall_smoke
+/obj/effect/temp_visual/recall_smoke //effects from casting the Recall spell, meant to make it more obvious that you're doing it
 	name = "recall smoke"
 	icon = 'icons/effects/particles/smoke.dmi'
 	icon_state = "steam_cloud_1"
 	duration = 20
 	plane = GAME_PLANE_UPPER
 	layer = ABOVE_ALL_MOB_LAYER
-
-/atom/movable/screen/alert/status_effect/buff/recalling
-	name = "Recalling"
-	desc = "Im in the middle of casting recall."
-	icon_state = "buff"
-
-/datum/status_effect/buff/recalling
-	id = "recalling"
-	alert_type = /atom/movable/screen/alert/status_effect/buff/recalling
-	var/effect_color
-	var/datum/stressevent/stress_to_apply
-	var/pulse = 0
-	var/ticks_to_apply = 5
-
-/datum/status_effect/buff/recalling/tick()
-	var/obj/effect/temp_visual/recall_smoke/M = new /obj/effect/temp_visual/recall_smoke(get_turf(owner))
-	M.color = effect_color
-	pulse += 1
 
 /obj/effect/temp_visual/recall_smoke/Initialize(mapload, set_color)
 	if(set_color)

--- a/code/modules/spells/spell_types/wizard/utility/recall.dm
+++ b/code/modules/spells/spell_types/wizard/utility/recall.dm
@@ -52,6 +52,7 @@
 		var/datum/effect_system/smoke_spread/smoke = new
 		smoke.set_up(3, marked_location)
 		smoke.start()
+		H.remove_status_effect(/datum/status_effect/buff/recalling)
 		start_recharge()
 	else
 		H.remove_status_effect(/datum/status_effect/buff/recalling)


### PR DESCRIPTION
## About The Pull Request

also moves the buff itself to roguebuff.dm for code consistency

## Testing Evidence

<img width="831" height="762" alt="image" src="https://github.com/user-attachments/assets/1703f457-6974-4102-85c2-d2f150fcfccc" />

notice no lingering buff effect 
## Why It's Good For The Game

bugfix so every mage that successfully uses recall doesn't turn into Incredible Gassy for the rest of the round