### PR TITLE
fixes eye color updates

### DIFF
--- a/code/__HELPERS/customization.dm
+++ b/code/__HELPERS/customization.dm
@@ -13,7 +13,7 @@
 /mob/living/carbon/human/proc/get_eye_color()
 	var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
 	if(!eyes)
-		return "FFFFFF"
+		return "#FFFFFF"
 	return eyes.eye_color
 
 /mob/living/carbon/human/proc/get_chest_color()

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -387,6 +387,7 @@
 	using.screen_loc = rogueui_eye
 	using.hud = src
 	static_inventory += using
+	using.update_icon()
 
 	set_advclass()
 

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -803,7 +803,7 @@
 			iris.icon_state = "oeye_fixed"
 		else
 			iris.icon_state = "oeye"
-	iris.color = "#" + human.eye_color
+	iris.color = human.get_eye_color()
 	. += iris
 
 /atom/movable/screen/eye_intent/proc/toggle(mob/user)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -70,6 +70,9 @@
 		if(eye_color)
 			HMN.eye_color = eye_color
 			HMN.regenerate_icons()
+			if(HMN.hud_used)
+				for(var/atom/movable/screen/eye_intent/eyes_hud in HMN.hud_used.static_inventory)//updates our eye hud color
+					eyes_hud.update_icon()
 		else
 			eye_color = HMN.eye_color
 		if(HAS_TRAIT(HMN, TRAIT_NIGHT_VISION) && !lighting_alpha)


### PR DESCRIPTION
## About The Pull Request

partial port of https://github.com/Rotwood-Vale/Ratwood-Keep/pull/3076
eyes now properly update to their expected color on load-in and when you get a different pair of eyes

## Testing Evidence

<img width="731" height="284" alt="image" src="https://github.com/user-attachments/assets/1fbabcda-1960-4a75-a4c8-e08564b5e172" />

works as intended with no runtimes

## Why It's Good For The Game

idk bugfix I guess