### PR TITLE
wild eater now properly allows gross drinking

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -98,7 +98,7 @@
 
 /datum/reagent/water/gross/on_mob_life(mob/living/carbon/M)
 	..()
-	if(HAS_TRAIT(M, TRAIT_NASTY_EATER)) // lets orcs and goblins drink bogwater
+	if(HAS_TRAIT(M, TRAIT_NASTY_EATER) || HAS_TRAIT(M, TRAIT_WILD_EATER)) //freaks don't care about drinking slop water
 		return
 	M.adjustToxLoss(1)
 	M.add_nausea(12) //Over 8 units will cause puking


### PR DESCRIPTION
## About The Pull Request

bugfix for wild eater, not sure why it didn't have this since it says that it does in the trait desc

## Testing Evidence

<img width="420" height="222" alt="image" src="https://github.com/user-attachments/assets/de1980e8-9aa9-49d7-8605-a2094d750b60" />


## Why It's Good For The Game

allows lamia players to properly larp as disgusting freak monsters that drink bog water and eat raw mudcrab