### PR TITLE
Thug Rework - Gang War Edition

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -129,19 +129,11 @@
 				if("Big Axe")
 					H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
 					r_hand = /obj/item/rogueweapon/greataxe // not steel
-
 			var/prev_real_name = H.real_name
 			var/prev_name = H.name
 			var/prefix = "Big" // if i see someone named "Boss" pick big man for this bit i will kill them
 			H.real_name = "[prefix] [prev_real_name]"
 			H.name = "[prefix] [prev_name]"
-
-	for(var/X in peopleknowme)
-		for(var/datum/mind/MF in get_minds(X))
-			if(MF.known_people)
-				if(prev_name)
-					MF.known_people -= prev_real_name
-					H.mind.person_knows_me(MF)
 
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/random


### PR DESCRIPTION
## About The Pull Request

This PR reworks the thug subclass of towner into a more distinct role to allow for further RP flavor and round participation without having them supersede actual combat roles

They now have three subclasses, including:
- Goon, an all-rounder with makeshift & random melee options
- Wise Guy, a stone/brick thrower that can also choose to be sneak/lockpicking oriented
- Big Man, a dumb big brute that can run into doors to damage them and is generally an unstoppable, if not incredibly slow and stupid, force

These changes also involve making thug limited to 8 total slots, for the sake of not allowing every towner in the game to be a funny gangster role.

## Testing Evidence

<img width="188" height="140" alt="image" src="https://github.com/user-attachments/assets/dfa9d25b-7686-4bd8-8ebf-5b38f3f77f23" />

<img width="343" height="245" alt="image" src="https://github.com/user-attachments/assets/ca3461a4-e520-4001-a650-6ff38b50d401" />

<img width="894" height="158" alt="image" src="https://github.com/user-attachments/assets/1b32e838-880e-4545-91f3-20cddeeb639e" />

## Why It's Good For The Game

More role flavor, more grounds for RP and player dynamics, and all without actually adding roles that have better skills than knights/wretches (or any armor, or any armor training)
