### PR TITLE
Refactors SSBMTreasury to be less performance intensive.

### DIFF
--- a/code/modules/roguetown/roguemachine/bathmaster.dm
+++ b/code/modules/roguetown/roguemachine/bathmaster.dm
@@ -186,7 +186,7 @@
 
 /obj/structure/roguemachine/bathvend/Destroy()
 	set_light(0)
-	QDEL_NULL(SSBMtreasury.brassface) // Clear our reference from the bath treasury subsystem.
+	SSBMtreasury.brassface = null // Clear our reference from the bath treasury subsystem.
 	return ..()
 
 /obj/structure/roguemachine/bathvend/Initialize()


### PR DESCRIPTION
## About The Pull Request

Some friends of mine were complaining about performance so I decided to run a tracy profile on a local version to see if I saw anything interesting, and I noticed a few things, this coming to the forefront of my attention.

Namely; BMtreasury/fire being a *very* hot proc-- so I checked it out, and I found that there were *THREE* instances in the fire() proc that searched the entire BYOND world, as well as the `wait` time for the subsystem being very, very low. (default is 20, it was set to 1.)

<img width="1439" height="300" alt="tracy-profiler_09QinTJDaK" src="https://github.com/user-attachments/assets/dbcf95a6-afcc-453c-8edf-839186eee4d3" />

So the main issues were; 
1. The wait time of 1
2. for(var/item in area) searches the whole world. `in area` == `in world` in effect.
3. the above was duplicated for closets.
4. for(var/obj/structure/roguemachine/bathvend/brassface) is searching the entire world for this machine. And not just like, once, it was happening every time.

To mitigate the performance losses I
1. added early returns to the beginning of the proc so that less processing is done if it's not time for the value to be checked.
2. changed the wait time up (it doesnt really matter what it is for this one so I made it a minute.)
3. instead of searching for items within  the area(which checks against the whole world), now it checks for the floortype used in the vault; in a range of 5 tiles around the brassface itself; then evaluating the contents of those tiles. This solution has some limitations, but for the purposes of alleviating a huge performance crunch it's *good enough* and I didn't have more time to spend refining it.

Here's another trace from testing after the changes; 

<img width="1531" height="826" alt="tracy-profiler_ZxHw01pt0Q" src="https://github.com/user-attachments/assets/afd91f6c-4e22-43fc-9852-ad0df22dd3c0" />

you can see (in the bottom right) that the time usage is drastically lower; the 1.2ms figure is from when I spawned 2000 individual coins to test the perf burden with lots of items, the other figures are with the default # of items the room spawns with.

The main limitation of my testing is I don't really have any context for how this machine functions normally-- I haven't played the actual game while interacting with it; so testing and feedback on that aspect would be appreciated. I was able to verify that the treasury value appreciated over time.

## Why It's Good For The Game
not having a relatively unimportant background subsystem dragging the whole game down for everyone is a plus.
