### PR TITLE
Fixes thief attributes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -129,11 +129,6 @@
 					shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt1
 					cloak = /obj/item/clothing/cloak/thief_cloak
 					head = /obj/item/clothing/head/roguetown/mentorhat //other armor pieces are nerfed to justify this
-			H.change_stat("strength", -1)
-			H.change_stat("intelligence", 1)
-			H.change_stat("perception", 1)
-			H.change_stat("endurance", 1)
-			H.change_stat("speed", 3)
 
 		if("Bard")
 			to_chat(H, span_warning("You make your fortune in brothels, flop houses, and taverns – gaining fame for your songs and legends. If there is any truth to them, that is."))


### PR DESCRIPTION
## About The Pull Request

When the "Eastern Agent" thief equipment loadout was added, it also added the statblock a second time. This PR removes it.

## Testing Evidence

I didn't test it yet, I'll do that later, but it's a pretty safe bet.

## Why It's Good For The Game

As funny as it is for a thief to have 19 speed roundstart, that's probably something we should patch out.
