### PR TITLE
Eclipsum weapons are now silverbane

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -293,6 +293,7 @@
 	force = 25
 	max_integrity = 200
 	icon_state = "gsdagger"
+	is_silver = TRUE
 
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/pestrasickle

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -692,6 +692,7 @@
 	max_integrity = 300
 	force = 20
 	force_wielded = 35
+	is_silver = TRUE
 
 /obj/item/rogueweapon/halberd/bardiche
 	possible_item_intents = list(/datum/intent/spear/thrust/eaglebeak, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs


### PR DESCRIPTION
## About The Pull Request
Adds silverbane functionality to the eclipsum dagger and halberd, the latter of which is adminspawn only afaik.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="499" height="213" alt="image" src="https://github.com/user-attachments/assets/18a358d6-fffd-4382-b54b-8052559934c8" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The priest's dagger is their personal weapon, is cool and soulful. It's entire description waxes on about how its rarely made during an eclipse with two Gods sacred metals. Pretty lame it does absolutely fuckall unique for a knife. At least this makes it somewhat notable.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
