### PR TITLE
Clean up prepare_step() species check

### DIFF
--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -59,7 +59,13 @@
 	if(steps >= 6)
 		steps = 0
 
-	if(steps % 2 && LM.m_intent == MOVE_INTENT_WALK && islamia(LM) || steps % 3 && LM.m_intent == MOVE_INTENT_RUN && islamia(LM) || steps % 2 && !islamia(LM))
+	if(islamia(LM))
+		if(LM.m_intent == MOVE_INTENT_RUN)
+			if(steps != 0 && steps != 3)
+				return
+		else if(steps&1)
+			return
+	else if(steps&1)
 		return
 
 	if(steps != 0 && !LM.has_gravity(T)) // don't need to step as often when you hop around


### PR DESCRIPTION
## About The Pull Request

This PR optimizes a commonly executed proc `prepare_step()`. By using AND operators instead of MOD, it will perform faster as MOD is one of the most computationally expensive instructions to execute.

The logic is functionally the same as the old code, but should run faster.

## Testing Evidence

<img width="393" height="229" alt="Untitled" src="https://github.com/user-attachments/assets/5c407fca-63fc-4a65-b258-5f22e910ba95" />

## Why It's Good For The Game

Rewrites `prepare_step()` to use cheaper AND operators.