### PR TITLE
makes shortsword and *small* messer swift

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -222,6 +222,7 @@
 	gripped_intents = null
 	minstr = 4
 	wdefense = 4.5
+	wbalance = WBALANCE_SWIFT
 	wlength = WLENGTH_SHORT
 	w_class = WEIGHT_CLASS_NORMAL
 	grid_width = 32
@@ -653,6 +654,7 @@
 	gripped_intents = null
 	minstr = 4
 	wdefense = 3.5
+	wbalance = WBALANCE_SWIFT
 	wlength = WLENGTH_SHORT
 	w_class = WEIGHT_CLASS_NORMAL
 	grid_width = 32


### PR DESCRIPTION
## About The Pull Request

+ makes iron and steel shortswords swift. Same for the messer (not the kriegmesser) and gladius.

## Testing Evidence
it doth compile
<img width="528" height="424" alt="image" src="https://github.com/user-attachments/assets/ac59f966-ccd4-4531-a3fd-b1601804311f" />

## Why It's Good For The Game

STRchuds never ever use it. The weapon is basically a worse rapier/sabre. Some have even said it deals less dmg than a steel dagger. Having more options for when you lose your rapier/sabre is makes SPD build less miserable.
