### PR TITLE
Inquisition Racelockening

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 1 // THE ONE.
 	spawn_positions = 1
-	allowed_races = RACES_SECOND_CLASS_NO_GOLEM
+	allowed_races = RACES_CHURCH_FAVORED_UP		//An incredibly bigoted organization. They would only allow races PSYDON Himself created into such an esteemed role. Aasimar are given a pass, as they consider the Ten to be saints, and Aasimar have far more direct connections to them then the other races.
 	disallowed_races = list(
 		/datum/species/lamia,
 	)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthodoxist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthodoxist.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 3 // THREE GOONS!!
 	spawn_positions = 3
-	allowed_races = RACES_SECOND_CLASS_NO_GOLEM
+	allowed_races = RACES_SECOND_CLASS_NO_GOLEM // As opposed to the Inquisitor or Absolver, Orthodoxists could be "redeemed" "lesser" races and heretics.
 	disallowed_races = list(
 		/datum/species/lamia,
 	)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -6,7 +6,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_races = RACES_SECOND_CLASS_NO_GOLEM		//Not been around long enough to be inquisitor, brand new race to the world.
+	allowed_races = RACES_CHURCH_FAVORED_UP		//An incredibly bigoted organization. They would only allow races PSYDON Himself created into such an esteemed role. Aasimar are given a pass, as they consider the Ten to be saints, and Aasimar have far more direct connections to them then the other races.
 	disallowed_races = list(
 		/datum/species/lamia,
 	)


### PR DESCRIPTION
## About The Pull Request
Race locks Inquisitor and Absolver to the Noble races + Aasimar. Keeps Orthodoxist the same.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1427" height="500" alt="image" src="https://github.com/user-attachments/assets/7daa4fee-08e3-4ddf-bd96-26b46dce7356" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The Inquisition is meant to be an incredibly bigoted organization, against just about all flavors of anyone different to themselves. As Psydonites, they should only be allowing those races that were directly created by PSYDON to rise to the apexes of power within the organization. Aasimar are given a pass, as Psydonites do view the Ten as saints (as seen in the flavour text of various Inquisition items and what not) and the Aasimar are far closer to the Ten then any of the other races they created.

Orthodoxists are allowed to stay the same, as they can be imagined to be indoctrinated heretics and the like.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
