### PR TITLE
Tweak thicc sneaking spotted text

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -896,7 +896,10 @@
 	if (prob(probby))
 		// whoops it saw us
 		target.mob_timers[MT_FOUNDSNEAK] = world.time
-		to_chat(target, span_danger("[src] sees me! I'm found!"))
+		if(!target.thicc_sneaking)
+			to_chat(target, span_danger("[src] sees me! I'm found!"))
+		else
+			to_chat(target, span_danger("[src] sees me! The clap of my asscheeks gave me away!"))
 		target.update_sneak_invis(TRUE)
 		return TRUE
 	else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1914,7 +1914,10 @@
 				marked = TRUE
 				if(M.m_intent == MOVE_INTENT_SNEAK || M.mob_timers[MT_INVISIBILITY] > world.time)
 					emote("huh")
-					to_chat(M, span_danger("[src] sees me! I'm found!"))
+					if(!M.thicc_sneaking)
+						to_chat(M, span_danger("[src] sees me! I'm found!"))
+					else
+						to_chat(M, span_danger("[src] sees me! The clap of my asscheeks gave me away!"))
 					M.mob_timers[MT_INVISIBILITY] = world.time
 					M.mob_timers[MT_FOUNDSNEAK] = world.time
 					M.update_sneak_invis(reset = TRUE)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -704,7 +704,7 @@
 				m_intent = MOVE_INTENT_SNEAK
 				if(isliving(src))
 					var/mob/living/L = src
-					if(!islamia(L) && (/datum/mob_descriptor/prominent/prominent_bottom in L.mob_descriptors))
+					if(!islamia(L) && !isdoll(L) && (/datum/mob_descriptor/prominent/prominent_bottom in L.mob_descriptors))
 						L.thicc_sneaking = TRUE
 					else
 						L.thicc_sneaking = FALSE


### PR DESCRIPTION
## About The Pull Request

This PR adjusts the spotted while sneaking flavor text for prominent posterior characters.

It also filters out doll species from having their asscheeks clapping while sneaking.

## Testing Evidence

<img width="345" height="243" alt="proof" src="https://github.com/user-attachments/assets/9d8a992d-dc5a-4668-851d-a2353a23beea" />

## Why It's Good For The Game

<img width="419" height="22" alt="flavor" src="https://github.com/user-attachments/assets/02ec1d46-ac3e-4325-ba70-05327e015600" />