### PR TITLE
gives wretches an alternative exit back in the waterfall so they aren't permacamped in the south forest

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -21163,6 +21163,13 @@
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"gwm" = (
+/obj/structure/fluff/traveltile/wretch{
+	aportalgoesto = "wretchin1";
+	aportalid = "wretchout1"
+	},
+/turf/closed/mineral/random/rogue,
+/area/rogue/outdoors/mountains)
 "gwq" = (
 /obj/structure/roguerock,
 /turf/open/water/cleanshallow,
@@ -33714,10 +33721,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "klW" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
+/obj/structure/fluff/traveltile/wretch{
+	aportalgoesto = "wretchin3";
+	aportalid = "wretchout3"
 	},
-/turf/closed/mineral/rogue/bedrock,
+/turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
 "kmc" = (
 /obj/structure/closet/crate/chest/crate,
@@ -41272,7 +41280,6 @@
 /obj/item/quiver/bolts,
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/rope/chain,
-/obj/item/gwstrap,
 /obj/item/rogueweapon/mace/cudgel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
@@ -72206,7 +72213,6 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/rope/chain,
-/obj/item/gwstrap,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "vTN" = (
@@ -322676,7 +322682,7 @@ vvB
 vvB
 vvB
 vvB
-vvB
+gwm
 aBB
 aBB
 aBB
@@ -511371,7 +511377,7 @@ qPv
 ujm
 ujm
 ujm
-klW
+ujm
 ujm
 ujm
 ujm
@@ -511821,11 +511827,11 @@ ujm
 ujm
 ujm
 ujm
-ujm
-ujm
 klW
-ujm
-ujm
+klW
+klW
+klW
+klW
 ujm
 qPv
 tIH
@@ -512272,13 +512278,13 @@ ujm
 ujm
 ujm
 ujm
-ujm
-ujm
-ujm
-ujm
-ujm
-ujm
-ujm
+bhn
+fnC
+fnC
+fnC
+fnC
+fnC
+bhn
 ujm
 qPv
 qPv
@@ -512724,13 +512730,13 @@ ujm
 ujm
 ujm
 ujm
-ujm
-ujm
-vuw
-vuw
-vuw
-ujm
-ujm
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
+fnC
 ujm
 qPv
 qPv
@@ -513177,10 +513183,10 @@ ujm
 ujm
 ujm
 fnC
-vuw
-vuw
-vuw
-vuw
+fnC
+fnC
+fnC
+fnC
 fnC
 fnC
 ujm
@@ -513629,11 +513635,11 @@ vMR
 ujm
 ujm
 fnC
-vuw
-vuw
-vuw
-vuw
-vuw
+ujm
+ujm
+ujm
+ujm
+ujm
 fnC
 ujm
 ujm

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3156,6 +3156,13 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/inhumen)
+"FH" = (
+/obj/structure/fluff/traveltile/wretch{
+	aportalgoesto = "wretchout3";
+	aportalid = "wretchin3"
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave/inhumen)
 "FO" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -3913,6 +3920,10 @@
 "RX" = (
 /turf/closed/indestructible/riveted,
 /area/start)
+"Sc" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/inhumen)
 "Sd" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
@@ -3988,6 +3999,10 @@
 "TD" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
+/area/rogue/under/cave/inhumen)
+"TG" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/inhumen)
 "TK" = (
 /obj/structure/flora/roguegrass/water/reeds,
@@ -19958,11 +19973,11 @@ rQ
 rQ
 wN
 wN
+wN
 xm
 xm
 xm
-xm
-xm
+Sc
 xm
 wN
 wN
@@ -20087,16 +20102,16 @@ rQ
 rQ
 rQ
 wN
-uJ
+wN
+Ld
 xm
 hO
-xm
+TG
 xm
 xm
 Jc
+wN
 Jc
-wN
-wN
 Jc
 tX
 KZ
@@ -20217,12 +20232,12 @@ rQ
 rQ
 rQ
 wN
-uJ
-uJ
-xm
-xm
-xm
+FH
 Jc
+Jc
+xm
+Sc
+xm
 Jc
 Jc
 Jc
@@ -20347,10 +20362,10 @@ rQ
 rQ
 rQ
 wN
-uJ
-uJ
-uJ
-xm
+FH
+Jc
+Jc
+Jc
 Jc
 Jc
 Jc
@@ -20477,12 +20492,12 @@ rQ
 rQ
 rQ
 wN
-uJ
-uJ
-xm
-xm
+FH
 Jc
-wN
+Jc
+Jc
+Jc
+Jc
 Jc
 Jc
 Jc
@@ -20608,10 +20623,10 @@ rQ
 rQ
 wN
 wN
-uJ
-xm
 Ld
-wN
+Jc
+Jc
+Jc
 wN
 wN
 Qg


### PR DESCRIPTION
## About The Pull Request

adds a secondary exit to the wretch camp on the north east end of their camp that leads to behind the hamlet waterfall, back to where it used to be before it was inexplicably moved to the south forest i think from maybe an upstream change
i don't need to tell you that right now the south forest has literally fuckall player traffic other than new adventurers spawning in and guards and wardens stacking up to repel the constant wretch gate storms because there's fuckall else to do int he south forest
yes wretches have the underdark exit but unless you know the routes like the back of your hand it's very unintuitive to escape the underdark
as it is if you want to play wretch and interact with the half of the map with actual player density then you have to either take several detours through the bog, sprint through the town with a mask on, or go around the coast for a like five minute adventure through the water

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

i had a screenshot of the travel tiles behind  the waterfall on my clipboard but i accidentally erased it pushing to origin
i tested it and it works

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

okay so this is going to be controversial whether or not it's actually good to enable both of the minor antagonist roles to be able to inhabit one half of the map, but bandits as is have a secondary exit quite literally like five screens away from the current main wretch exit
realistically this'll enable more frontal gate assaults as bandits and wretches invariably team up and likely still making the south forest a bumfuck nothing ever happens place because every wretch in their sane mind is going to go up north where there's Actually People To Interact With Because Nobody Besides Guards Who Wanna Frag And Fresh Spawning Adventurers are in the south forest
it's a bandaid solution to the fact that the map is super duper northsided in terms of content to do and it's naturally where players gather but it can't be fixed without the town literally being moved in its entirety
i'm sorry but the south forest sucks

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
