### PR TITLE
Knuckle Deep

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -54,7 +54,7 @@
 	hitsound = list('sound/combat/hits/punch/punch_hard (1).ogg', 'sound/combat/hits/punch/punch_hard (2).ogg', 'sound/combat/hits/punch/punch_hard (3).ogg')
 	chargetime = 0
 	penfactor = BLUNT_DEFAULT_PENFACTOR
-	clickcd = 10
+	clickcd = 12
 	damfactor = 1.1
 	swingdelay = 0
 	icon_state = "inpunch"
@@ -352,7 +352,7 @@
 	slot_flags = ITEM_SLOT_HIP
 	parrysound = list('sound/combat/parry/pugilism/unarmparry (1).ogg','sound/combat/parry/pugilism/unarmparry (2).ogg','sound/combat/parry/pugilism/unarmparry (3).ogg')
 	sharpness = IS_BLUNT
-	max_integrity = 300
+	max_integrity = 150
 	swingsound = list('sound/combat/wooshes/punch/punchwoosh (1).ogg','sound/combat/wooshes/punch/punchwoosh (2).ogg','sound/combat/wooshes/punch/punchwoosh (3).ogg')
 	associated_skill = /datum/skill/combat/unarmed
 	throwforce = 12


### PR DESCRIPTION
## About The Pull Request

In my previous PR, https://github.com/Scarlet-Reach/Scarlet-Reach/pull/665 I had touched the more or less attack rate of the katar and knuckles, without realizing that I left the knuckles in a far better place than I should have. As of current, they attack faster than any other blunt weapon in the game and are 2 slots, so you can carry around a LOT of them easily, while I don't know where the size code is, I do know where clickCD and integrity are so I thought I'd put this together after consulting @kiwedespars our resident unarmed abuser.

## Testing Evidence

2 line change, trust bro trust.

## Why It's Good For The Game

Knuckles are still used constantly as just a fucking pocket mace and with how many classes get 5 in unarmed, have become the brunt of armor smashing in antag fights, so. Believe me when I say with the duration of a single feint you can absolutely destroy someone through a steel helm with these things.
