### PR TITLE
removes limestone from golem colors

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -578,7 +578,6 @@
 #define GOLEM_JADE "517051"
 #define GOLEM_AMETHYST "3a0b3d"
 #define GOLEM_CORAL "ff96d6" //Pink
-#define GOLEM_LIMESTONE "e6e4d8" //Tan
 #define GOLEM_SILVER "94B9C0" //Ice grey, at least that's what microsoft paint says
 #define GOLEM_COPPER "b87333" //Orange
 #define GOLEM_GOLD "d4af37" //Gold
@@ -586,7 +585,6 @@
 #define GOLEM_OBSIDIAN "19132a" //Black
 #define GOLEM_LAPIS "26619C" //Deep blue
 #define GOLEM_BASALT "474a4c" //Dark grey
-#define GOLEM_MARBLE "E6E6E6" //White
 #define GOLEM_TOPER "fffb9e"
 
 //DOLL PAINT COLOR

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/golem/golem.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/golem/golem.dm
@@ -109,7 +109,6 @@
 		"Silver" = GOLEM_SILVER,
 		"Coral" = GOLEM_CORAL,
 		"Gold" = GOLEM_GOLD,
-		"Limestone" = GOLEM_LIMESTONE,
 		"Copper" = GOLEM_COPPER,
 		"Rust" = GOLEM_RUST,
 		"Obsidian" = GOLEM_OBSIDIAN,


### PR DESCRIPTION
## About The Pull Request

removes limestone golem skin color, added in #648 
way too close to marble which was removed in #624 because it encroached too heavily on dolls in terms of being human-adjacent

## Testing Evidence

<img width="688" height="207" alt="image" src="https://github.com/user-attachments/assets/a9485344-8ed7-40cf-8bc2-ddf055bd827d" />

all selectable golem colors
## Why It's Good For The Game

same reasoning as in #624, we have steel already and I don't think it fits well lorewise for the distinction between golems and dolls 
there are plenty more interesting character customization options you can have as a golem than just looking like a doll

I'd also debate on looking at copper as well because it's close to dolls' sienna color but I think it looks more orange than anything else