### PR TITLE
Adds Xylix items to loadout

### DIFF
--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -153,6 +153,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Necra Tabard"
 	path = /obj/item/clothing/cloak/templar/necran
 
+/datum/loadout_item/tabard/xylix
+	name = "Xylix Tabard"
+	path = /obj/item/clothing/cloak/templar/xylixian
+
 /datum/loadout_item/tabard/psydon
 	name = "Psydon Tabard"
 	path = /obj/item/clothing/cloak/templar/psydon
@@ -516,6 +520,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 /datum/loadout_item/psicross/eora
 	name = "Amulet of Eora"
 	path = /obj/item/clothing/neck/roguetown/psicross/eora
+
+/datum/loadout_item/psicross/xylix
+	name = "Amulet of Xylix"
+	path = /obj/item/clothing/neck/roguetown/psicross/xylix
 
 /datum/loadout_item/psicross/naledi
 	name = "Naledian Psy-Bracelet"


### PR DESCRIPTION
## About The Pull Request

Adds Xylix's amulet and tabard to the loadout, just as every other Divine + PSYDON has.

## Testing Evidence

<img width="273" height="231" alt="image" src="https://github.com/user-attachments/assets/1b0cda1a-80e6-4c0c-aaeb-8d20e7cf20dc" />

## Why It's Good For The Game

Consistency. They were the only "good" team god to not have their stuff.
