### PR TITLE
Ruma Tattoos Fullbody Coverage + Fixes

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -73,6 +73,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/body_parts_covered = 0 //see setup.dm for appropriate bit flags
 	var/body_parts_covered_dynamic = 0
 	var/body_parts_inherent	= 0 //bodypart coverage areas you cannot peel off because it wouldn't make any sense (peeling chest off of torso armor, hands off of gloves, head off of helmets, etc)
+	var/surgery_cover = TRUE // binary, whether this item is considered covering its bodyparts in respect to surgery. Tattoos, etc. are false. 
 	var/gas_transfer_coefficient = 1 // for leaking gas from turf to mask and vice-versa (for masks right now, but at some point, i'd like to include space helmets)
 	var/permeability_coefficient = 1 // for chemicals/diseases
 	var/siemens_coefficient = 1 // for electrical admittance/conductance (electrocution checks and shit)

--- a/code/modules/clothing/rogueclothes/scabbard.dm
+++ b/code/modules/clothing/rogueclothes/scabbard.dm
@@ -110,7 +110,7 @@
 	..()
 
 /obj/item/scabbard/examine(mob/user)
-	..()
+	. = ..()
 	if(sheathed)
 		. += span_notice("The sheath is occupied by [sheathed].")
 

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -664,13 +664,16 @@
 	armor = list("blunt" = 30, "slash" = 50, "stab" = 50, "piercing" = 20, "fire" = 0, "acid" = 0)
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
 	slot_flags = ITEM_SLOT_SHIRT|ITEM_SLOT_ARMOR
-	body_parts_covered = ARMS 
+	body_parts_covered = COVERAGE_FULL
+	body_parts_inherent = COVERAGE_FULL
 	icon = 'icons/roguetown/clothing/shirts.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts.dmi'
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_shirts.dmi'
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
 	allowed_race = NON_DWARVEN_RACE_TYPES
+	flags_inv = null //free the breast
+	surgery_cover = FALSE // cauterize and surgery through it.
 	max_integrity = 600 //Bad armor protection and very basic crit protection, but incredibly hard to break completely
 	var/repair_amount = 6 //The amount of integrity the tattoos will repair themselves
 	var/repair_time = 20 SECONDS //The amount of time between each repair

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -674,7 +674,7 @@
 	allowed_race = NON_DWARVEN_RACE_TYPES
 	flags_inv = null //free the breast
 	surgery_cover = FALSE // cauterize and surgery through it.
-	max_integrity = 600 //Bad armor protection and very basic crit protection, but incredibly hard to break completely
+	max_integrity = 400 //Bad armor protection and very basic crit protection, but hard to break completely
 	var/repair_amount = 6 //The amount of integrity the tattoos will repair themselves
 	var/repair_time = 20 SECONDS //The amount of time between each repair
 	var/last_repair //last time the tattoos got repaired

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/kashira.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/kashira.dm
@@ -11,11 +11,17 @@
 
 /datum/outfit/job/roguetown/mercenary/kashira/pre_equip(mob/living/carbon/human/H)
 	..()
+	armor = /obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe
+	shirt = /obj/item/clothing/suit/roguetown/armor/skin_armor/easttats
+	cloak = /obj/item/clothing/cloak/eastcloak1
+	shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
+	gloves = /obj/item/clothing/gloves/roguetown/eastgloves2
+	pants = /obj/item/clothing/under/roguetown/trou/eastpants1
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/rogueweapon/sword/sabre/mulyeog/rumacaptain
 	beltl = /obj/item/scabbard/rumacaptain
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/flashlight/flare/torch, /obj/item/flashlight/flare/torch/lantern)
+	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/flashlight/flare/torch/lantern)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
@@ -32,22 +38,6 @@
 	H.change_stat("perception", 1)
 	H.change_stat("speed", -1)
 	H.adjust_blindness(-3)
-
-	if(should_wear_masc_clothes(H))
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt1
-		cloak = /obj/item/clothing/cloak/eastcloak1
-		pants = /obj/item/clothing/under/roguetown/trou/eastpants1
-		gloves = /obj/item/clothing/gloves/roguetown/eastgloves2
-		armor = /obj/item/clothing/suit/roguetown/armor/skin_armor/easttats
-		shoes = /obj/item/clothing/shoes/roguetown/boots
-		H.change_stat("endurance", 1)
-		H.change_stat("constitution", 1) //to compensate for the permanent lack of armor
-		H.dna.species.soundpack_m = new /datum/voicepack/male/evil()
-	else if(should_wear_femme_clothes(H))
-		armor = /obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe
-		shirt = /obj/item/clothing/suit/roguetown/armor/skin_armor/easttats
-		shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
-
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)	
 	ADD_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC) //i swear this isn't as good as it sounds

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/rumaclan.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/rumaclan.dm
@@ -25,9 +25,9 @@
 			neck = /obj/item/clothing/neck/roguetown/leather //minimal defense
 			beltr = /obj/item/scabbard/rumahench
 			beltl = /obj/item/rogueweapon/sword/sabre/mulyeog/rumahench
-			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt2
+			armor = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt2
 			cloak = /obj/item/clothing/cloak/eastcloak1
-			armor = /obj/item/clothing/suit/roguetown/armor/skin_armor/easttats
+			shirt = /obj/item/clothing/suit/roguetown/armor/skin_armor/easttats
 			pants = /obj/item/clothing/under/roguetown/trou/eastpants2
 			shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
 			gloves = /obj/item/clothing/gloves/roguetown/eastgloves2
@@ -57,8 +57,8 @@
 			head = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/kazengunese
 			neck = /obj/item/clothing/neck/roguetown/leather //minimal defense
 			beltl = /obj/item/flashlight/flare/torch/lantern
-			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt1
-			armor = /obj/item/clothing/suit/roguetown/armor/skin_armor/easttats
+			armor = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt1
+			shirt = /obj/item/clothing/suit/roguetown/armor/skin_armor/easttats
 			pants = /obj/item/clothing/under/roguetown/trou/eastpants2
 			shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 			gloves = /obj/item/clothing/gloves/roguetown/eastgloves2

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -116,7 +116,7 @@
 				if(grab.sublimb_grabbed == location)
 					return TRUE
 		for(var/obj/item/equipped_item in carbon_victim.get_equipped_items(include_pockets = FALSE, include_beltslots = FALSE))
-			if(zone2covered(location, equipped_item.body_parts_covered))
+			if(zone2covered(location, equipped_item.body_parts_covered) && equipped_item.surgery_cover)
 				return FALSE
 		if(ishuman(carbon_victim))
 			var/mob/living/carbon/human/human_victim = carbon_victim


### PR DESCRIPTION
## About The Pull Request

makes the lenticular tattoos fullbody coverage and will not block surgery
they are applied to shirt slots on relevant roles and can be worn with armour
decreased integrity from 600 to 400.
removed differences between male and female kashira

## Testing Evidence

<img width="414" height="249" alt="image" src="https://github.com/user-attachments/assets/077a8dba-d004-49fc-9db6-5c8f3bbe93ea" />


## Why It's Good For The Game

the tats took up your armour slot and. only covered the arms. not good.
