### PR TITLE
Deadite tags!

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -182,6 +182,7 @@
 #define TRAIT_DYES "Dyemaster"
 #define TRAIT_GOODWRITER "Great Writer"
 #define TRAIT_ADRENALINE_RUSH "Adrenaline Rush"
+#define TRAIT_DEADITE "Deadite"
 // ARMOR / CLOTHING GIVEN TRAITS (GIVEN BY WEARING CLOTHES/ARMOR PIECES)
 #define TRAIT_MONK_ROBE	"Holy Vestatures"
 
@@ -328,6 +329,8 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_GOODWRITER = span_notice("I'm proficient at writing. Any skillbooks made by me will allow the reader to learn the subject more quickly."),
 	TRAIT_BLOODLOSS_IMMUNE = span_notice("While I may bleed, I will feel nothing from it."),
 	TRAIT_ADRENALINE_RUSH = span_notice("I'm invigorated in the midst of battle! I don't feel my wounds!")
+	TRAIT_DEADITE = span_danger("The Rot has overtaken me.")
+
 ))
 
 // trait accessor defines

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -328,7 +328,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_HERESIARCH = span_warning("I know of sacred sites of worship where followers of the Ascendants convene, and the path to the nearest conclave is etched into my memory."),
 	TRAIT_GOODWRITER = span_notice("I'm proficient at writing. Any skillbooks made by me will allow the reader to learn the subject more quickly."),
 	TRAIT_BLOODLOSS_IMMUNE = span_notice("While I may bleed, I will feel nothing from it."),
-	TRAIT_ADRENALINE_RUSH = span_notice("I'm invigorated in the midst of battle! I don't feel my wounds!")
+	TRAIT_ADRENALINE_RUSH = span_notice("I'm invigorated in the midst of battle! I don't feel my wounds!"),
 	TRAIT_DEADITE = span_danger("The Rot has overtaken me.")
 
 ))

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -54,7 +54,8 @@
 		TRAIT_ZOMBIE_SPEECH,
 		TRAIT_ZOMBIE_IMMUNE,
 		TRAIT_ROTMAN,
-		TRAIT_NORUN
+		TRAIT_NORUN,
+		TRAIT_DEADITE
 	)
 	/// Traits applied to the owner when we are cured and turn into just "rotmen"
 	var/static/list/traits_rotman = list(

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -146,6 +146,8 @@
 				. += span_phobia("A disgraced member of the nobility...")
 			else
 				. += span_notice("A disgraced noble.")
+		if(HAS_TRAIT(src, TRAIT_DEADITE))
+			. += span_userdanger("DEADITE!")
 
 		//For tennite schism god-event
 		if(length(GLOB.tennite_schisms))

--- a/code/modules/mob/living/carbon/human/npc/deadite.dm
+++ b/code/modules/mob/living/carbon/human/npc/deadite.dm
@@ -34,6 +34,7 @@
 	mob_biotypes |= MOB_UNDEAD
 	var/datum/zombie_antag = src.mind.add_antag_datum(/datum/antagonist/zombie, team = FALSE, admin_panel = TRUE)
 	equipOutfit(new /datum/outfit/job/roguetown/deadite)
+	ADD_TRAIT(src, TRAIT_DEADITE, TRAIT_GENERIC)
 	//Make sure deadite NPCs don't show up in the antag listings
 	GLOB.antagonists -= zombie_antag
 	update_body()

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -521,10 +521,6 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Amulet of Eora"
 	path = /obj/item/clothing/neck/roguetown/psicross/eora
 
-/datum/loadout_item/psicross/xylix
-	name = "Amulet of Xylix"
-	path = /obj/item/clothing/neck/roguetown/psicross/xylix
-
 /datum/loadout_item/psicross/naledi
 	name = "Naledian Psy-Bracelet"
 	path = /obj/item/clothing/neck/roguetown/psicross/naledi


### PR DESCRIPTION
## About The Pull Request

Deadites are now marked with a tag similar to vampires, or outlaws, or what have you. Shamelessly brought back from #201, but without the jump removal from deadites.
Also removes a duplicated item in the loadout because someone clearly didn't look through and double check before PRing stuff. What an idiot, right?

## Testing Evidence
Using that rat that we hate:
<img width="794" height="229" alt="image" src="https://github.com/user-attachments/assets/c07ff7b4-6af7-4ed8-900a-f5d323166cfd" />

Yes, I also tested to ensure the tag and trait are removed just as the others are, but thats less fun to put together into an image
## Why It's Good For The Game

It's really hard to tell whos a deadite and who is just a creacher with some of these races, man. Doubly so when they are facing north.
