### PR TITLE
Disables Peasant Rebellion

### DIFF
--- a/code/modules/events/antagonist/solo/rebels.dm
+++ b/code/modules/events/antagonist/solo/rebels.dm
@@ -11,7 +11,7 @@
 	base_antags = 1
 	maximum_antags = 3
 	denominator = 50 // adds 1 possible rebel for every 50 players
-	max_occurrences = 1
+	max_occurrences = 0 // disabled
 
 	earliest_start = 0 SECONDS
 


### PR DESCRIPTION
## About The Pull Request

disables peasant rebellion

## Testing Evidence

dude trust me

## Why It's Good For The Game

never amounts to anything. people who get it always ahelp to have it removed. people who keep it end up spamming the round end results with recruitment messages of "Join us!".

lame. it just wastes round antag points for no reason.
