### PR TITLE
heretic wretch stat balancejak

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -9,10 +9,11 @@
 
 	traits_applied = list(TRAIT_RITUALIST, TRAIT_HEAVYARMOR, TRAIT_HERETIC_DEVOUT)
 	// Heretic is by far the best class with access to rituals (as long as they play a god with ritual), holy and heavy armor. So they keep 7 points.
+	// ... except templars get the same but aren't supposed to 1vX
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_CON = 2,
-		STATKEY_END = 1
+		STATKEY_END = 3
 	)
 
 	subclass_skills = list(


### PR DESCRIPTION
## About The Pull Request

gives heretic wretches 3 endurance instead of 1, bringing them in line with the templars which they are mirroring 1:1

## Testing Evidence


## Why It's Good For The Game
templar (ritualist and steelhearted are applied on the main class, so they have those traits too)
<img width="402" height="141" alt="image" src="https://github.com/user-attachments/assets/b94c6ca1-6459-46cc-b48f-b211a7395b3a" />

... and this is a current heretic wretch
<img width="553" height="162" alt="Screenshot 2025-09-11 203704" src="https://github.com/user-attachments/assets/5028933b-c0d4-4c79-a751-b7d95ce95f30" />

