### PR TITLE
Add muted volume check to loops and other amb sound logic

### DIFF
--- a/code/modules/droning/droning.dm
+++ b/code/modules/droning/droning.dm
@@ -82,6 +82,10 @@ SUBSYSTEM_DEF(droning)
 	if(!music || !dreamer)
 		return
 
+	if(!dreamer?.prefs.musicvol)
+		kill_droning(dreamer)
+		return
+
 	var/frenq = 1
 
 	if(HAS_TRAIT(dreamer.mob, TRAIT_DRUQK))
@@ -162,6 +166,9 @@ SUBSYSTEM_DEF(droning)
 	//kill the previous looping
 	kill_loop(dreamer)
 
+	if(!dreamer?.prefs.musicvol)
+		return
+
 	var/amb_sound_list = null
 	if(area_entered.we_looping_here)
 		if(GLOB.tod == "night")
@@ -193,6 +200,9 @@ SUBSYSTEM_DEF(droning)
 	if(!area_entered || !dreamer)
 		return
 	kill_rain(dreamer)
+
+	if(!dreamer?.prefs.musicvol)
+		return
 
 	var/amb_sound_list = null
 	if(area_entered.ambientrain)


### PR DESCRIPTION
## About The Pull Request

This PR adds muted music volume checks to the combat music and droning sound system.

## Testing Evidence

<img width="496" height="295" alt="proof" src="https://github.com/user-attachments/assets/68c5fa89-8e55-41cf-8009-9b95327e4fe8" />

## Why It's Good For The Game

This stop clients from having to stream the audio unless they have music enabled.