### PR TITLE
Fixes perma force stat debuff for weapon enchantment spell

### DIFF
--- a/code/modules/spells/components/enchanted_weapon.dm
+++ b/code/modules/spells/components/enchanted_weapon.dm
@@ -59,12 +59,10 @@
 	if(!istype(itemloc, /mob/living))
 		while(!istype(itemloc, /mob/living))
 			if(isnull(itemloc))
-				remove()
 				qdel(src)
 				return // If the item is not in a mob, remove the refresh
 			itemloc = itemloc.loc
 			if(istype(itemloc, /turf))
-				remove()
 				qdel(src)
 				return // If the item is on the ground, remove the refresh
 	var/mob/living/current_user = itemloc
@@ -77,7 +75,6 @@
 			endtime = world.time += DEFAULT_DURATION
 			addtimer(CALLBACK(src, PROC_REF(refresh_check)), DEFAULT_DURATION)
 	else
-		remove()
 		qdel(src)
 		return
 


### PR DESCRIPTION
## About The Pull Request

This PR fixes a bug in the enchantment cast spell. By letting the enchantment lapse, the code will call `remove()` to remove the buff, then upon `Destroy()`, it'll call `remove()` again and redo the force stat removal.

This reduces force stat removal TWICE, thus making the weapon weaker permanently.

## Testing Evidence

I have tested and confirm that the fix above works.

## Why It's Good For The Game

Fixes a bug.