### PR TITLE
removes royal puzzlebox from the loot spawner

### DIFF
--- a/_maps/templates/smalldungeons.dm
+++ b/_maps/templates/smalldungeons.dm
@@ -66,7 +66,6 @@
 		/obj/item/storage/bag/tray = 3,
 		/obj/item/mundane/puzzlebox/medium = 3,
 		/obj/item/mundane/puzzlebox/easy = 1,
-		/obj/item/mundane/puzzlebox/impossible = 2,
 
 		//medical
 		/obj/item/needle = 4,
@@ -231,7 +230,6 @@
 		/obj/item/storage/bag/tray = 3,
 		/obj/item/mundane/puzzlebox/medium = 2,
 		/obj/item/mundane/puzzlebox/easy = 2,
-		/obj/item/mundane/puzzlebox/impossible = 1
 	)
 	lootcount = 1
 

--- a/code/game/objects/effects/spawners/loot_spawners.dm
+++ b/code/game/objects/effects/spawners/loot_spawners.dm
@@ -324,7 +324,6 @@
 		/obj/item/reagent_containers/glass/cup/golden/small = 1,
 		/obj/item/reagent_containers/glass/cup/skull = 1,
 		/obj/item/mundane/puzzlebox/medium = 1,
-		/obj/item/mundane/puzzlebox/impossible = 1,
 		//medical
 		/obj/item/needle = 4,
 		/obj/item/natural/bundle/cloth = 3,


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

this pr removes the royal puzzlebox from loot spawners. it can still be spawned in by admins for an event or some shit.

## Testing Evidence

it is a three line change. it compiles.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
<img width="196" height="198" alt="image" src="https://github.com/user-attachments/assets/1575cd81-f0a1-4d02-8018-f0767bbfc1eb" />

this shouldnt be fucking possible

<img width="211" height="147" alt="image" src="https://github.com/user-attachments/assets/825a565b-17c7-4310-a9a8-be541c8aa6fc" />

what is this. removing this from the game is healthier because it prevents insane amounts of powergaming
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
