### PR TITLE
Declare Champion

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -59,6 +59,9 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 	var/brotherhoodtext = "Stand proud, for the Brotherhood!!"
 	var/chargetext = "Chaaaaaarge!!"
 
+	var/mob/living/carbon/champion = null
+	var/mob/living/carbon/ward = null
+
 	var/linglink
 	var/datum/martial_art/martial_art
 	var/static/default_martial_art = new/datum/martial_art

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -366,6 +366,16 @@
 	desc = span_red("My PATRON is NOT PROUD of ME!")
 	timer = 20 MINUTES
 
+/datum/stressevent/lostchampion
+	stressadd = 8
+	desc = span_red("I feel I have lost my champion! Oh, my stricken heart!")
+	timer = 25 MINUTES
+
+/datum/stressevent/lostward
+	stressadd = 8
+	desc = span_red("I have failed my ward! My ribbon fades in color!")
+	timer = 25 MINUTES
+
 /datum/stressevent/riddle_munch
 	stressadd = 10
 	desc = span_boldred("Perhaps I shouldn't have done that...")

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -252,6 +252,16 @@
 	desc = span_green("I feel inspired by the sermon.")
 	timer = 20 MINUTES
 
+/datum/stressevent/champion
+	stressadd = -3
+	desc = span_green("I am near my ward!")
+	timer = 1 MINUTES
+
+/datum/stressevent/ward
+	stressadd = -3
+	desc = span_green("I am near my Champion! Oh, oh, Champion!")
+	timer = 1 MINUTES
+
 /datum/stressevent/goodloving
 	timer = 5 MINUTES
 	stressadd = -3

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -38,6 +38,11 @@
 		Q.invisibility = INVISIBILITY_MAXIMUM
 		Q.become_blind("advsetup")
 
+
+/datum/outfit/job/roguetown/heir/pre_equip(mob/living/carbon/human/H)
+	..()
+	H.verbs |= /mob/living/carbon/human/proc/declarechampion
+
 /datum/advclass/heir/daring
 	name = "Daring Twit"
 	tutorial = "You're a somebody, someone important. It only makes sense you want to make a name for yourself, to gain your own glory so people see how great you really are beyond your bloodline. Plus, if you're beloved by the people for your exploits you'll be chosen! Probably. Shame you're as useful and talented as a squire, despite your delusions to the contrary."
@@ -249,3 +254,120 @@
 	H.adjust_skillrank(/datum/skill/combat/crossbows, pick(0,1), TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, pick(0,0,1), TRUE)
 	H.adjust_skillrank(/datum/skill/misc/athletics, pick(0,1), TRUE)
+
+/mob/living/carbon/human/proc/declarechampion()
+	set name = "Declare Champion"
+	set category = "Noble"
+
+
+	if(stat)
+		return
+	if(!mind)
+		return
+
+	if(!src.mind.champion)
+		var/list/folksnearby = list()
+		for(var/mob/living/carbon/human/newchampionpotential in (view(1)))
+			folksnearby += newchampionpotential
+		var/target = input(src, "Choose a champion") as null|anything in folksnearby
+		if(istype(target, /mob/living/carbon))
+			var/mob/living/carbon/guy = target
+			if(!guy)
+				return
+			if(guy == src)
+				return
+			if(!guy.mind)
+				return
+			src.say("Be my Champion, [guy]!")
+			var/prompt = alert(guy, "Do wish to be [src]'s Champion?", "Champion", "Yes", "No")
+			if(prompt == "No")
+				return
+
+			guy.say("I serve you, [src]!")
+			src.visible_message(span_warning("[src] begins tying the golden ribbon to [guy]'s wrist."))
+			if(do_after(src, 10 SECONDS))
+				src.visible_message(span_warning("[src] ties a golden ribbon to [guy]'s wrist."))
+				guy.mind.ward = src
+				src.mind.champion = guy
+				var/datum/status_effect/buff/champion/new_champion = guy.apply_status_effect(/datum/status_effect/buff/champion)
+				var/datum/status_effect/buff/ward/new_ward = src.apply_status_effect(/datum/status_effect/buff/ward)
+				new_champion.ward = src
+				new_ward.champion = guy
+
+	else
+		var/list/folksnearby = list()
+		for(var/mob/living/carbon/human/championremoval in (view(1)))
+			if(championremoval == src.mind.champion)
+				folksnearby += championremoval
+		var/mob/living/target = input(src, "Choose a champion") as null|anything in folksnearby
+		if(!target)
+			return
+
+		else
+			src.visible_message(span_warning("[src] begins untying the golden ribbon from [src.mind.champion]'s wrist."))
+			if(do_after(src, 10 SECONDS))
+				src.visible_message(span_warning("[src] unties a golden ribbon from [src.mind.champion]'s wrist."))
+				src.say("I revoke your championship, [target]!")
+				src.mind.champion = null
+				if(target.has_status_effect(/datum/status_effect/buff/champion))
+					target.remove_status_effect(/datum/status_effect/buff/champion)
+				if(src.has_status_effect(/datum/status_effect/buff/ward))
+					src.remove_status_effect(/datum/status_effect/buff/ward)
+
+
+/datum/status_effect/buff/champion
+	alert_type = /atom/movable/screen/alert/status_effect/buff/champion
+	var/mob/living/carbon/ward = null
+	effectedstats = list(STATKEY_CON = 1, STATKEY_END = 1)
+	duration = -1
+
+/atom/movable/screen/alert/status_effect/buff/champion
+	name = "Champion"
+	desc = "I am a Chosen by a Heir!"
+	icon_state = "buff"
+
+
+/datum/status_effect/buff/champion/on_creation()
+	spawn(5) // sob doesnt work without this??
+		examine_text = "<font color='yellow'>SUBJECTPRONOUN is the Champion Of [owner.mind.ward.real_name]!"
+	return ..()
+
+/datum/status_effect/buff/champion/tick()
+	for (var/mob/living/carbon/H in view(5, owner))
+		if(H == ward)
+			if (!owner.has_stress_event(/datum/stressevent/champion))
+				owner.add_stress(/datum/stressevent/champion)
+
+/datum/status_effect/buff/champion/on_remove()
+	ward.add_stress(/datum/stressevent/lostchampion)
+	owner.mind.ward = null
+	owner.remove_status_effect(/datum/status_effect/buff/champion)
+	if(ward && ward.mind)
+		ward.mind.champion = null
+		ward.remove_status_effect(/datum/status_effect/buff/ward)
+
+
+/datum/status_effect/buff/ward
+	alert_type = /atom/movable/screen/alert/status_effect/buff/ward
+	var/mob/living/carbon/champion = null
+	effectedstats = list(STATKEY_LCK = 1, STATKEY_WIL = 1)
+	duration = -1
+
+/atom/movable/screen/alert/status_effect/buff/ward
+	name = "Ward"
+	desc = "I have declared a champion."
+	icon_state = "buff"
+
+/datum/status_effect/buff/ward/tick()
+	for (var/mob/living/carbon/H in view(5, owner))
+		if(H == champion)
+			if(!owner.has_stress_event(/datum/stressevent/ward))
+				owner.add_stress(/datum/stressevent/ward)
+
+/datum/status_effect/buff/ward/on_remove()
+	champion.add_stress(/datum/stressevent/lostward)
+	owner.mind.champion = null
+	owner.remove_status_effect(/datum/status_effect/buff/ward)
+	if(champion && champion.mind)
+		champion.mind.ward = null
+		champion.remove_status_effect(/datum/status_effect/buff/champion)


### PR DESCRIPTION
## About The Pull Request
A port of https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3744

>Lets heir declare a champion
>Grants the Champion a +1 CON +1 END, and a mood buff while within range of the Ward
>Grants the Ward +1 FOR +1 END, and a mood buff while within range of the Champion
>The Champion gains a examine text of being the Ward's champion
>Both gain a mood nuke when the bond is broken(one dies, or the Heir revokes the declaration)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
You get a noble tab that gives you a "Declare champion" option,
<img width="220" height="88" alt="Screenshot 2025-09-13 144435" src="https://github.com/user-attachments/assets/022c7630-fa77-4bd5-8c90-e3ecd4ddec8b" />

You can use this to declare your friend your champion who will fight for you and it'll give you the  boost.
<img width="425" height="60" alt="Screenshot 2025-09-13 144607" src="https://github.com/user-attachments/assets/de863e1c-82f2-40c1-bff6-ff5c245f1e19" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I found this mechanic to be neat and a good addition to roleplaying something most people already do.