### PR TITLE
Kazegun Loadout Update

### DIFF
--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -1535,6 +1535,12 @@
 	allowed_race = NON_DWARVEN_RACE_TYPES
 	flags_inv = HIDEBOOB|HIDECROTCH
 
+/obj/item/clothing/suit/roguetown/armor/basiceast/light
+	name = "ronin dobo robe"
+	desc = "A dirty tattered dobo robe with white lapels, robes primarily worn by the nomadic or disgraced ronin traveling from their homeland."
+	armor = ARMOR_PADDED
+	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
+
 //less integrity than a leather cuirass, incredibly weak to blunt damage - great against slash - standard leather value against stab
 //the intent for these armors is to create specific weaknesses/strengths for people to play with
 
@@ -1545,6 +1551,12 @@
 	item_state = "eastsuit2"
 	armor = list("blunt" = 50, "slash" = 90, "stab" = 60, "piercing" = 30, "fire" = 0, "acid" = 0)
 	max_integrity = 200
+
+/obj/item/clothing/suit/roguetown/armor/basiceast/crafteast/light
+	name = "formal dobo robe"
+	desc = "A dobo robe with a red tassel, used primarily for general use by the populace for formal occasions."
+	armor = ARMOR_PADDED
+	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
 
 //craftable variation of eastsuit, essentially requiring the presence of a tailor with relevant materials
 //still weak against blunt
@@ -1558,6 +1570,12 @@
 	armor = list("blunt" = 50, "slash" = 90, "stab" = 60, "piercing" = 30, "fire" = 0, "acid" = 0)
 	max_integrity = 200
 
+/obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit/light
+	name = "worn dobo robe"
+	desc = "A tattered robe belonging to a warrior scarred from a battle long forgotten."
+	armor = ARMOR_PADDED
+	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
+
 /obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe
 	name = "foreign robes"
 	desc = "Flower-styled robes, said to have been infused with magical protection. The Merchant Guild says that this is from the southern Kazengite region."
@@ -1566,6 +1584,12 @@
 	armor = list("blunt" = 50, "slash" = 90, "stab" = 60, "piercing" = 30, "fire" = 0, "acid" = 0)
 	max_integrity = 300
 	sellprice = 25
+
+/obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe/
+	name = "floral robes"
+	desc = "Flower-styled robes, the Merchant Guild says that this is from the southern Kazengite region."
+	armor = ARMOR_PADDED
+	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
 
 // this robe spawns on a role that offers no leg protection nor further upgrades to the loadout, in exchange for better roundstart gear
 

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -1536,9 +1536,9 @@
 	flags_inv = HIDEBOOB|HIDECROTCH
 
 /obj/item/clothing/suit/roguetown/armor/basiceast/light
-	name = "ronin dobo robe"
+	name = "fragile dobo robe"
 	desc = "A dirty tattered dobo robe with white lapels, robes primarily worn by the nomadic or disgraced ronin traveling from their homeland."
-	armor = ARMOR_PADDED
+	armor = ARMOR_PADDED_BAD
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
 
 //less integrity than a leather cuirass, incredibly weak to blunt damage - great against slash - standard leather value against stab
@@ -1555,7 +1555,7 @@
 /obj/item/clothing/suit/roguetown/armor/basiceast/crafteast/light
 	name = "formal dobo robe"
 	desc = "A dobo robe with a red tassel, used primarily for general use by the populace for formal occasions."
-	armor = ARMOR_PADDED
+	armor = ARMOR_PADDED_BAD
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
 
 //craftable variation of eastsuit, essentially requiring the presence of a tailor with relevant materials
@@ -1573,7 +1573,7 @@
 /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit/light
 	name = "worn dobo robe"
 	desc = "A tattered robe belonging to a warrior scarred from a battle long forgotten."
-	armor = ARMOR_PADDED
+	armor = ARMOR_PADDED_BAD
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
 
 /obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe
@@ -1588,7 +1588,7 @@
 /obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe/
 	name = "floral robes"
 	desc = "Flower-styled robes, the Merchant Guild says that this is from the southern Kazengite region."
-	armor = ARMOR_PADDED
+	armor = ARMOR_PADDED_BAD
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
 
 // this robe spawns on a role that offers no leg protection nor further upgrades to the loadout, in exchange for better roundstart gear

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -466,6 +466,11 @@
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/stonekeep_merc.dmi'
 	armor = ARMOR_BOOTS
 
+/obj/item/clothing/shoes/roguetown/armor/rumaclan/light
+	name = "raised sandals"
+	desc = "A pair of wooden sandals worn by those from Kazengun region."
+	armor = ARMOR_BOOTS
+
 /obj/item/clothing/shoes/roguetown/boots/carapace
 	name = "carapace boots"
 	desc = "Boots made from carapace for added protection."

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -466,11 +466,6 @@
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/stonekeep_merc.dmi'
 	armor = ARMOR_BOOTS
 
-/obj/item/clothing/shoes/roguetown/armor/rumaclan/light
-	name = "raised sandals"
-	desc = "A pair of wooden sandals worn by those from Kazengun region."
-	armor = ARMOR_BOOTS
-
 /obj/item/clothing/shoes/roguetown/boots/carapace
 	name = "carapace boots"
 	desc = "Boots made from carapace for added protection."

--- a/code/modules/clothing/rogueclothes/pants.dm
+++ b/code/modules/clothing/rogueclothes/pants.dm
@@ -589,6 +589,11 @@
 	allowed_race = NON_DWARVEN_RACE_TYPES
 	flags_inv = HIDECROTCH
 
+/obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1/light
+	name = "cut-throat's pants"
+	desc = "Foreign pants worn by those from the Kazengun region."
+
+
 /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2
 	name = "strange ripped pants"
 	desc = "Weird pants typically worn by the destitute in Kazengun. Or, those looking to make a fashion statement."

--- a/code/modules/clothing/rogueclothes/pants.dm
+++ b/code/modules/clothing/rogueclothes/pants.dm
@@ -593,7 +593,6 @@
 	name = "cut-throat's pants"
 	desc = "Foreign pants worn by those from the Kazengun region."
 
-
 /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2
 	name = "strange ripped pants"
 	desc = "Weird pants typically worn by the destitute in Kazengun. Or, those looking to make a fashion statement."

--- a/code/modules/clothing/rogueclothes/pants.dm
+++ b/code/modules/clothing/rogueclothes/pants.dm
@@ -592,6 +592,7 @@
 /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1/light
 	name = "cut-throat's pants"
 	desc = "Foreign pants worn by those from the Kazengun region."
+	armor = ARMOR_PADDED_BAD
 
 /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2
 	name = "strange ripped pants"

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -387,6 +387,22 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Nun Habit"
 	path = /obj/item/clothing/suit/roguetown/shirt/robe/nun
 
+/datum/loadout_item/worn_dobo_robe
+	name = "Worn Dobo Robe"
+	path = /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit/light
+
+/datum/loadout_item/floral_robe
+	name = "Floral Robes"
+	path = /obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe/light
+
+/datum/loadout_item/formal_robe
+	name = "Formal Dobo Robe"
+	path = /obj/item/clothing/suit/roguetown/armor/basiceast/crafteast/light
+
+/datum/loadout_item/ronin_robe
+	name = "Ronin Dobo Robe"
+	path = /obj/item/clothing/suit/roguetown/armor/basiceast/light
+
 /datum/loadout_item/eastshirt1
 	name = "Black Foreign Shirt"
 	path = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt1
@@ -402,6 +418,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 /datum/loadout_item/leathertights
 	name = "Leather Tights"
 	path = /obj/item/clothing/under/roguetown/trou/leathertights
+
+/datum/loadout_item/rumaclanpants
+	name = "Cut-Throat Pants"
+	path = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1/light
 
 /datum/loadout_item/trou
 	name = "Work Trousers"


### PR DESCRIPTION
## About The Pull Request
Adds (hopefully) weak versions of the robes along with the cut-throat pants to the loadout system, the pants typo was fixed.

## Testing Evidence
<img width="262" height="159" alt="lodout update 2" src="https://github.com/user-attachments/assets/12893826-465a-4bae-b48a-6eb440108e90" />
<img width="318" height="218" alt="loadout update" src="https://github.com/user-attachments/assets/bfc7ef55-7581-49b5-b1ca-7630fa94f61c" />
Three out of the Five just to show for consistency they all have the same weakened state
<img width="538" height="400" alt="formal dobo" src="https://github.com/user-attachments/assets/ca4af139-4723-4bee-b782-e360c314fb55" />
<img width="542" height="419" alt="worn dobo" src="https://github.com/user-attachments/assets/f71c3472-e80c-41d4-8633-965f1ecfcdc2" />
<img width="519" height="416" alt="florals" src="https://github.com/user-attachments/assets/91d37547-503d-488c-be6f-ade395317ef8" />


## Why It's Good For The Game
Further rounds out the loadout for Kazengun items, the robes themselves are severely weakened compared to their actual worthwhile counterparts.