### PR TITLE
non inquis get a mood bonus from destroying soul churner

### DIFF
--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -276,3 +276,13 @@
 	stressadd = -4
 	desc = span_green("I've seen someone completely at peace! Their happiness is contagious!")
 	timer = 3 MINUTES
+
+/datum/stressevent/soulchurnerdestroyed
+	timer = 10 MINUTES
+	stressadd = -40
+	desc = span_green("That disgusting box was destroyed, and its captives freed.")
+
+/datum/stressevent/soulchurnerdestroyed_psydon
+	timer = 5 MINUTES
+	stressadd = -2
+	desc = span_green("The box of souls was destroyed. I feel relief.")

--- a/code/game/objects/items/rogueitems/inquisitionrelics.dm
+++ b/code/game/objects/items/rogueitems/inquisitionrelics.dm
@@ -96,6 +96,14 @@
 	if(soundloop)
 		QDEL_NULL(soundloop)
 	src.visible_message(span_cult("A great deluge of souls escapes the shattered box!"))
+	for (var/mob/living/carbon/human/H in hearers(7, src))
+		if (!H.client)
+			continue
+		if(!HAS_TRAIT(H, TRAIT_INQUISITION))
+			if(H?.patron?.type == /datum/patron/old_god)
+				H.add_stress(/datum/stressevent/soulchurnerdestroyed_psydon)
+			else
+				H.add_stress(/datum/stressevent/soulchurnerdestroyed)
 	return ..()
 
 /obj/item/psydonmusicbox/update_icon()

--- a/code/game/objects/items/rogueitems/inquisitionrelics.dm
+++ b/code/game/objects/items/rogueitems/inquisitionrelics.dm
@@ -67,9 +67,13 @@
 /obj/item/psydonmusicbox/examine(mob/user)
 	. = ..()
 	if(HAS_TRAIT(usr, TRAIT_INQUISITION))
-		desc = "A relic from the bowels of the Otavan cathedral's thaumaturgical workshops. Fourteen souls of heretics, all bound together, they will scream and protect us from magicks. It would be wise to not teach the heretics of its true nature, to only bring it to bear in dire circumstances."
+		. += "A relic from the bowels of the Otavan cathedral's thaumaturgical workshops. Fourteen souls of heretics, all bound together, they will scream and protect us from magicks. It would be wise to not teach the heretics of its true nature, to only bring it to bear in dire circumstances."
 	else
-		desc = "A cranked music box, it has the seal of the Otavan Inquisition on the side. It carries a somber feeling to it..."
+		. += "A cranked music box, it has the seal of the Otavan Inquisition on the side. It carries a somber feeling to it..."
+		if(isliving(user))
+			var/mob/living/L = user
+			if(L.has_status_effect(/datum/status_effect/buff/churnernegative))
+				. += span_userdanger("DESTROY IT!")
 
 /obj/item/psydonmusicbox/attack_self(mob/living/user)
 	. = ..()

--- a/code/game/objects/items/rogueitems/inquisitionrelics.dm
+++ b/code/game/objects/items/rogueitems/inquisitionrelics.dm
@@ -108,6 +108,7 @@
 				H.add_stress(/datum/stressevent/soulchurnerdestroyed_psydon)
 			else
 				H.add_stress(/datum/stressevent/soulchurnerdestroyed)
+				to_chat(H, (span_hypnophrase("\"Thank you.\"")))
 	return ..()
 
 /obj/item/psydonmusicbox/update_icon()


### PR DESCRIPTION
## About The Pull Request

title
+40 mood for non-psydons and +2 mood for psydons (they don't get the full bonus because they don't care as much when it activates)

## Testing Evidence

<img width="611" height="389" alt="image" src="https://github.com/user-attachments/assets/a496efab-8d70-4c00-930f-943e9f01ec40" />

## Why It's Good For The Game

flavor, you should feel good for freeing your buddies from eternal suffering