### PR TITLE
The All Father Lives: Psydonites will always heal wounds, even when dead (although they will not revive without help)

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -49,9 +49,9 @@
 				W?.heal_wound(1)
 
 	/// ENDVRE AS HE DOES.
-	if(!stat && HAS_TRAIT(src, TRAIT_PSYDONITE) && !HAS_TRAIT(src, TRAIT_PARALYSIS))
+	if(HAS_TRAIT(src, TRAIT_PSYDONITE))
 		handle_wounds()
-		//passively heal wounds, but not if you're skullcracked OR DEAD.
+		//passively heal wounds, even if you're dead. THE ALL-FATHER LIVES!
 	if (blood_volume > BLOOD_VOLUME_SURVIVE)
 		var/list/wounds2 = get_wounds()
 		if (islist(wounds2))
@@ -165,7 +165,7 @@
 	location?.hotspot_expose(700, 50, 1)
 
 /mob/living/proc/handle_wounds()
-	if(stat >= DEAD)
+	if(!HAS_TRAIT(src, TRAIT_PSYDONITE) && stat >= DEAD)
 		for(var/datum/wound/wound as anything in get_wounds())
 			if(istype(wound, /datum/wound))
 				wound.on_death()


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

This pull request changes the way the PSYDONITE trait works; instead of not healing Psdyonite wounds if they're paralyzed or dead, it inverses that; it will always heal their wounds.

However, if they're already dead, or just really badly injured, it doesn't do anything otherwise to help them. So, your maimed corpse will slowly stop bleeding and its horrifically smashed bones will put themselves back together, but you will not rise without someone there to bring you back.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="1241" height="165" alt="psydonite" src="https://github.com/user-attachments/assets/1eef5498-b438-4cbf-ab0c-b4a8d4e58cdd" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

I found it very evocative of the budding lore for Psydonites to have this ability. In their heresy against the gospel of the Ten, Psydonites believe that the All-Father yet lives and is simply ENDURING in some kind of coma or deep slumber. It would be a grim channeling of Psydon's divinity if his more faithful clerics seemed to mimic him in that regard; though they seem dead, their bodies knit together as if still alive. But they do not wake from their repose of their own power. 

This doesn't affect Psydonites rotting into bones or anything like that. They will still eventually decompose into nothing.