### PR TITLE
Blackedsmithy  Disallows Blacksmith Apprentice from Steward and Merchant

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/steward.dm
@@ -19,6 +19,8 @@
 
 	advclass_cat_rolls = list(CTAG_STEWARD = 2)
 
+	virtue_restrictions = list(/datum/virtue/utility/blacksmith)
+
 	job_traits = list(TRAIT_NOBLE, TRAIT_SEEPRICES)
 	job_subclasses = list(
 		/datum/advclass/steward

--- a/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
@@ -20,6 +20,9 @@
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_noble.ogg'
 
+
+	virtue_restrictions = list(/datum/virtue/utility/blacksmith)
+
 	job_traits = list(TRAIT_SEEPRICES, TRAIT_CICERONE)
 
 	advclass_cat_rolls = list(CTAG_MERCH = 2)


### PR DESCRIPTION
## About The Pull Request

Pulling code from Priestcode and adding to merchant and steward. As of current too many players are grabbing this Virtue and combining it with this trait to circumvent the blacksmith and do things themself. Its powergamey as hell and been requested many times and pulled into question why a noble would get their hands dirty. Also lessens blacksmiths true job.

