### PR TITLE
reverts AP port failed apprentice changes

### DIFF
--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/failed_apprentice.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/failed_apprentice.dm
@@ -1,17 +1,16 @@
 /datum/advclass/vagabond_mage
-	name = "Exiled Apprentice"
+	name = "Failed Apprentice"
 	tutorial = "Your master found you talentless, and cast you from their tower with nothing but your staff and dreams of what could've been."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/vagabond/mage
 	category_tags = list(CTAG_VAGABOND)
 
-	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T3)
+	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T2)
 	subclass_stats = list(
 		STATKEY_INT = 2,
-		STATKEY_CON = -2,
-		STATKEY_END = -2,
-		STATKEY_SPD = -1
+		STATKEY_CON = -1,
+		STATKEY_END = -1
 	)
 
 	subclass_spellpoints = 9
@@ -38,5 +37,5 @@
 	if(prob(33))
 		cloak = /obj/item/clothing/cloak/half/brown
 		gloves = /obj/item/clothing/gloves/roguetown/fingerless
-	
+
 	r_hand = /obj/item/rogueweapon/woodstaff


### PR DESCRIPTION
## About The Pull Request

un-nerfs their base stats, gives them t2 spells instead of t3, also renames the subrole to "failed apprentice" to better reflect both the dm file name and the context of the role

## Testing Evidence

<img width="457" height="243" alt="image" src="https://github.com/user-attachments/assets/610c18b5-7cda-420d-add5-6dafe0a16a61" />

## Why It's Good For The Game

failed apprentice is meant to be talentless and incapable of becoming a proper magos thrall, hence the name- it doesn't really make sense that you can cast all the same spells that proper magos apprentices can cast