### PR TITLE
disables dungeoneer, adds lost slot to MAA

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -111,7 +111,7 @@
 
 #define GUARDSMAN	(1<<0)
 #define MANATARMS	(1<<1)
-#define DUNGEONEER	(1<<2)
+#define DUNGEONEER	(1<<2) //Unused
 #define SQUIRE		(1<<3)
 #define BOGGUARD	(1<<4)
 #define SERGEANT	(1<<5)
@@ -390,7 +390,6 @@
 #define GARRISON_ROLES \
 	/datum/job/roguetown/warden,\
 	/datum/job/roguetown/sergeant,\
-	/datum/job/roguetown/dungeoneer,\
 	/datum/job/roguetown/gatemaster,\
 	/datum/job/roguetown/manorguard,\
 	/datum/job/roguetown/sheriff,\

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -3,8 +3,8 @@
 	flag = DUNGEONEER
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	allowed_races = RACES_ALL_KINDS//Dungeoneer is a freak. His race selection should allow this.
 	allowed_sexes = list(MALE, FEMALE)
 

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -4,8 +4,8 @@
 	flag = MANATARMS
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 8
-	spawn_positions = 8
+	total_positions = 9
+	spawn_positions = 9
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_FEARED_UP
 	disallowed_races = list(


### PR DESCRIPTION
## About The Pull Request
Title.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
I cannot figure out how to give myself admin perms on my local server
## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->


<img width="515" height="525" alt="image" src="https://github.com/user-attachments/assets/dc66a85d-3db8-44d7-b3f7-01efa686c8df" />

less of this (cut a corpse's legs off without ever verifying it was a corpse, masked it, then pillory'd it, AFTER being told by the Castifico that it was dead.)


I don't personally believe the long-term behavior shown by people playing Dungeoneer justifies the existence of the class. It is loved by shitters, and so long as we continue not to punish shitters, it will continue to be an issue. 

The current population of people playing these classes makes antagonists fucking suck to play. They puppy guard the antagonists and make sure they get no more agency in the round with roughly the same candor as someone who would get job banned from warden on TG. 

Suiciding and playing a different character often is your literal only option with some people.

Either people who want to be wardens can volunteer at the beginning of the round as MAA, or they can suggest a better solution.

The reason people instantly try to escape from the dungeons is because you suck, guys. Be better.