### PR TITLE
zombie immune also stops rotting

### DIFF
--- a/code/datums/components/rotting.dm
+++ b/code/datums/components/rotting.dm
@@ -64,6 +64,9 @@
 	if (istype(A, /area/rogue/indoors/town))	//Stops rotting inside town buildings; will stop your zombification such as at church or appothocary.
 		return
 
+	if(HAS_TRAIT(C, TRAIT_ZOMBIE_IMMUNE) && !is_zombie)
+		return
+
 	if(!(C.mob_biotypes & (MOB_ORGANIC|MOB_UNDEAD)))
 		qdel(src)
 		return


### PR DESCRIPTION
## About The Pull Request

another attempt to stop golem zombification

## Testing Evidence

waited about 20 minutes with a golem corpse and a human corpse, no zombie or rotting on the golem while the human transformed and started making the fly buzzing noises

## Why It's Good For The Game

golem zombies are really bad because you can't rotcure them without the priest spell
TM first please in case this breaks something else