### PR TITLE
Add player based range culling for AI pathfinding

### DIFF
--- a/code/datums/ai/ai_movement/astar_movement.dm
+++ b/code/datums/ai/ai_movement/astar_movement.dm
@@ -5,6 +5,21 @@
 	max_pathing_attempts = 4
 	max_path_distance = 30
 
+///If a tree falls in a forest and no one is around to hear it, does it make a sound?
+///No, said the BYOND coder, for it will take up too many ticks
+/datum/ai_movement/proc/active_player_range(pawn_x, pawn_y, pawn_z)
+	for(var/i = GLOB.player_list.len; i > 0; i--)
+		var/mob/living/M = GLOB.player_list[i]
+		if(!istype(M))
+			continue
+		if(M.z != pawn_z) // not the same z sector
+			if(abs(M.y-pawn_y) > 6 || abs(M.x-pawn_x) > 6)
+				continue
+		else if(abs(M.y-pawn_y) > 14 || abs(M.x-pawn_x) > 14)
+			continue
+		return TRUE
+	return FALSE
+
 ///Put your movement behavior in here!
 /datum/ai_movement/astar/process(delta_time)
 	for(var/datum/ai_controller/controller as anything in moving_controllers)
@@ -28,6 +43,10 @@
 				minimum_distance = iter_behavior.required_distance
 
 		if(get_dist(movable_pawn, controller.current_movement_target) <= minimum_distance)
+			continue
+
+		// if there is no active player around, do not attempt to generate a path
+		if(!active_player_range(movable_pawn.x, movable_pawn.y, movable_pawn.z))
 			continue
 
 		var/generate_path = FALSE // set to TRUE when we either have no path, or we failed a step


### PR DESCRIPTION
## About The Pull Request

This PR adds a active player range check before launching into the expensive `get_path_to()` A-star search algorithm.

It places a scan for every single non-observer, living player within 14 tiles (or 6 tiles if across different Z sectors).

If this check succeeds, it continues processing other AI pathing, otherwise it fails and skips to the next AI to be processed.

Due to the involved effect that this change can have, it is highly recommended that ____this is tested before merged____.

## Testing Evidence
The test server was ran with a single player, and 3 spawned in ambush mobs. I ran around for 5 minutes, while avoiding their attacks in the bog.

**Take note of the `AStar()` execution count, and `astar/process()`.**

An artificial total count of 120 players was added as a worse case bruteforce test for `active_player_range()`.

### Before
<img width="1036" height="342" alt="before" src="https://github.com/user-attachments/assets/e3b8832f-1a9c-4eb2-89de-2716b22d49a6" />

### After
<img width="1036" height="204" alt="after" src="https://github.com/user-attachments/assets/b0ff9cc0-12db-4a68-9b56-72950bb2d66d" />

### `active_player_range()`
<img width="956" height="838" alt="active_player_range" src="https://github.com/user-attachments/assets/b251229c-6eff-46cd-bbd7-c509a2087cf6" />

## Why It's Good For The Game

In theory this should reduce the overall lag from running pathing for mobs outside of any player view.