### PR TITLE
Half-kin can no longer be nobles

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -194,7 +194,6 @@
     /datum/species/human/northern,\
     /datum/species/elf/wood,\
     /datum/species/human/halfelf,\
-    /datum/species/demihuman,\
     /datum/species/dwarf/mountain,\
 
 #define RACES_CHURCH_FAVORED \
@@ -222,6 +221,7 @@
     /datum/species/dracon,\
     /datum/species/akula,\
 	/datum/species/lamia,\
+    /datum/species/demihuman,\
 
 #define RACES_FEARED \
 	/datum/species/halforc,\


### PR DESCRIPTION
## About The Pull Request

What it says on the title; half-kin can no longer be (most) nobility roles. They're the direct descendants of wild-kin after all, which means they were illegitimate children.

## Testing Evidence

<img width="1448" height="670" alt="Captura de pantalla 2025-09-15 154725" src="https://github.com/user-attachments/assets/1fa68fd2-48e5-4f9b-830f-f7c2318f8ff4" />

## Why It's Good For The Game

Wild-kin can't be nobles. It makes no sense from a lore standpoint that their offspring would be allowed to be, say, the grand duke of Scarlet Reach, or its inheritor. Bastards don't exactly look great with the clergy!
