### PR TITLE
only transfer 1 firestack when touching someone who's on fire

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1567,18 +1567,21 @@
 
 	if(on_fire)
 		if(L.on_fire) // If they were also on fire
-			var/firesplit = (fire_stacks + L.fire_stacks)/2
-			fire_stacks = firesplit
-			L.fire_stacks = firesplit
+			if(fire_stacks >= L.fire_stacks)
+				fire_stacks--
+				L.fire_stacks++
+			else
+				fire_stacks++
+				L.fire_stacks--
 		else // If they were not
-			fire_stacks /= 2
-			L.fire_stacks += fire_stacks
+			fire_stacks--
+			L.fire_stacks++
 			if(L.IgniteMob()) // Ignite them
 				log_game("[key_name(src)] bumped into [key_name(L)] and set them on fire")
 
 	else if(L.on_fire) // If they were on fire and we were not
-		L.fire_stacks /= 2
-		fire_stacks += L.fire_stacks
+		L.fire_stacks--
+		fire_stacks++
 		IgniteMob() // Ignite us
 
 //Mobs on Fire end


### PR DESCRIPTION
## About The Pull Request

title

## Testing Evidence

tested and it works, trust me bro!

## Why It's Good For The Game

another optimistic and hopeful buff toward making setting someone on fire a useful combat strategy
skeletons who have been set alight by astrata blast now can't as easily extinguish themselves by charging directly at the person who set them on fire
this obviously still allows you to set people on fire by running into them, but the key point is that you can't just delete 5+ stacks of fire from yourself by running into someone else