### PR TITLE
simple mobs show desc / simple mob lamia changes

### DIFF
--- a/code/modules/mob/living/simple_animal/examine.dm
+++ b/code/modules/mob/living/simple_animal/examine.dm
@@ -4,6 +4,8 @@
 	var/t_is = p_are()
 
 	. = list("<span class='info'>✠ ------------ ✠\nThis is \a <EM>[src]</EM>.")
+	if(desc)
+		. += desc
 
 	var/m1 = "[t_He] [t_is]"
 	var/m2 = "[t_his]"

--- a/code/modules/mob/living/simple_animal/rogue/creacher/lamia.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/lamia.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia
 	icon = 'icons/roguetown/mob/monster/lamia.dmi'
-	name = "lamia"
-	desc = "This slithering monstrosity has a human torso, a large snake tail, and four bladed arms."
+	name = "greater lamia"
+	desc = "This slithering monstrosity has a human torso, a large snake tail, and four bladed arms. Some say they're cousins of the more Humen-like Lamia, but even further touched by Abyssor."
 	icon_state = "lamia_f"
 	icon_living = "lamia_f"
 	icon_dead = "lamia_dead"
@@ -11,7 +11,7 @@
 	speak_chance = 1
 	see_in_dark = 9
 	move_to_delay = 2
-	base_intents = list(/datum/intent/simple/bite, /datum/intent/simple/claw)
+	base_intents = list(/datum/intent/simple/elementalt3_unarmed)//dryad's chopping intent, I think it fits better for a scary monster with multiple sword arms
 	botched_butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 1)
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 1,
 						/obj/item/reagent_containers/food/snacks/fat = 1,

--- a/code/modules/mob/living/simple_animal/rogue/farm/chicken.dm
+++ b/code/modules/mob/living/simple_animal/rogue/farm/chicken.dm
@@ -2,7 +2,7 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken
 	icon = 'icons/roguetown/mob/monster/chicken.dmi'
 	name = "\improper chicken"
-	desc = ""
+	desc = "A small, domestic, flightless bird. It's known for both its egg-laying and rapid breeding, making it a boon for carnivorous societies."
 	icon_state = "chicken_brown"
 	icon_living = "chicken_brown"
 	icon_dead = "chicken_brown_dead"


### PR DESCRIPTION
## About The Pull Request

simplemobs now show descriptions if they have one
lamia simplemobs are now called greater lamia and their desc reflects their relation to normal lamias
lamias now use chop intent because they have 4 bladed arms and they were biting people before

## Testing Evidence

<img width="673" height="426" alt="image" src="https://github.com/user-attachments/assets/d5257014-3c55-4e74-8e70-c3ffeb5504f6" />

## Why It's Good For The Game

flavor