### PR TITLE
Idle AI if there is no player in range

### DIFF
--- a/code/datums/ai/ai_movement/astar_movement.dm
+++ b/code/datums/ai/ai_movement/astar_movement.dm
@@ -5,21 +5,6 @@
 	max_pathing_attempts = 4
 	max_path_distance = 30
 
-///If a tree falls in a forest and no one is around to hear it, does it make a sound?
-///No, said the BYOND coder, for it will take up too many ticks
-/datum/ai_movement/proc/active_player_range(pawn_x, pawn_y, pawn_z)
-	for(var/i = GLOB.player_list.len; i > 0; i--)
-		var/mob/living/M = GLOB.player_list[i]
-		if(!istype(M))
-			continue
-		if(M.z != pawn_z) // not the same z sector
-			if(abs(M.y-pawn_y) > 6 || abs(M.x-pawn_x) > 6)
-				continue
-		else if(abs(M.y-pawn_y) > 14 || abs(M.x-pawn_x) > 14)
-			continue
-		return TRUE
-	return FALSE
-
 ///Put your movement behavior in here!
 /datum/ai_movement/astar/process(delta_time)
 	for(var/datum/ai_controller/controller as anything in moving_controllers)
@@ -43,10 +28,6 @@
 				minimum_distance = iter_behavior.required_distance
 
 		if(get_dist(movable_pawn, controller.current_movement_target) <= minimum_distance)
-			continue
-
-		// if there is no active player around, do not attempt to generate a path
-		if(!active_player_range(movable_pawn.x, movable_pawn.y, movable_pawn.z))
 			continue
 
 		var/generate_path = FALSE // set to TRUE when we either have no path, or we failed a step

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -77,7 +77,25 @@
 		return TRUE
 	return FALSE
 
+// Check if a player is in range of the AI
+// TODO: Note, we can nuke this once we put complex on spatial grid sleeping
+/mob/living/carbon/human/proc/scan_for_player_in_range()
+	for(var/i = GLOB.player_list.len; i > 0; i--)
+		var/mob/living/M = GLOB.player_list[i]
+		if(!istype(M))
+			continue
+		if(M.z != z) // not the same z sector
+			if(abs(M.y-y) > 6 || abs(M.x-x) > 6)
+				continue
+		else if(abs(M.y-y) > 14 || abs(M.x-x) > 14)
+			continue
+		return TRUE
+	return FALSE
+
 /mob/living/carbon/human/proc/process_ai()
+	// Prevent expensive pathing if it is in idle mode and there's no players
+	if((mode == NPC_AI_IDLE || mode == NPC_AI_OFF) && !scan_for_player_in_range())
+		return FALSE
 	if(IsDeadOrIncap())
 		walk_to(src,0)
 		return stat == DEAD // only stop processing if we're dead-dead
@@ -417,8 +435,8 @@
 			pathing_frustration = 0
 			myPath -= myPath[1]
 			NPC_THINK("MOVEMENT TURN [movement_turn]: Movement on cooldown for [movespeed/10] seconds!")
-			sleep(movespeed) // wait until next move	
-		
+			sleep(movespeed) // wait until next move
+
 // blocks, but only while path is being calculated
 /mob/living/carbon/human/proc/start_pathing_to(new_target)
 	if(!new_target)


### PR DESCRIPTION
## About The Pull Request

This PR ports over an improved/smarter change made by https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3879, which is a port of #973

By moving the player culling check to `/mob/living/carbon/human/process_ai()`, it will prevent any AI processing - instead of just on A-Star pathing.

It also doesn't change AI that are busy, so they will not infinitely pause until a player gets within range.

## Testing Evidence

<img width="289" height="219" alt="evidence" src="https://github.com/user-attachments/assets/8202df88-31e8-4f20-a33b-0084a7307313" />

### Before

<img width="814" height="233" alt="before" src="https://github.com/user-attachments/assets/6ade32ee-8310-4bdb-b7f0-75f5e411b833" />

### After

<img width="819" height="226" alt="after" src="https://github.com/user-attachments/assets/56fe2ef5-6854-494c-a842-16b401d46521" />

## Why It's Good For The Game

This is an overall improvement made towards making the server run smoother.