### PR TITLE
makes smoke bombs one slot

### DIFF
--- a/code/game/objects/items/rogueitems/bombs.dm
+++ b/code/game/objects/items/rogueitems/bombs.dm
@@ -90,7 +90,7 @@
 	slot_flags = ITEM_SLOT_HIP
 	throw_speed = 0.5
 	grid_width = 32
-	grid_height = 64
+	grid_height = 32
 
 /obj/item/smokebomb/attack_self(mob/user)
     ..()


### PR DESCRIPTION
## About The Pull Request

makes smoke bombs small and portable
## Testing Evidence

Psydon strike me down if this one number change manages to break something

## Why It's Good For The Game

for what they are, they are too bulky. call it balancejakking, i suppose
