### PR TITLE
Makes Lunacy Embracers Embrace the Thing They are Supposed to be Embracing, More

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
@@ -16,6 +16,8 @@
 		TRAIT_WOODWALKER,
 		TRAIT_NASTY_EATER,
 		TRAIT_CALTROPIMMUNE
+		TRAIT_ORGAN_EATER
+		TRAIT_DARKVISION
 	)
 	subclass_stats = list(
 		STATKEY_STR = 3,
@@ -31,17 +33,12 @@
 		/datum/skill/combat/wrestling = SKILL_LEVEL_MASTER,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/sewing = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/tanning = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/labor/farming = SKILL_LEVEL_MASTER,
-		/datum/skill/craft/carpentry = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/tracking = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/swimming = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/masonry = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/cooking = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/labor/butchering = SKILL_LEVEL_NOVICE
 		/datum/skill/labor/fishing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/magic/holy = SKILL_LEVEL_JOURNEYMAN,
 	)


### PR DESCRIPTION
## About The Pull Request

Removes many "civilized" skills from embracers that don't fit with their wild nature. Adds some skills that people who scrounge around in the wild naked all day should have. 
Removed:

Farming
Sewing
Tanning
Cooking
Carpentry
Alchemy
Masonry

(Fishing was left as it is to allow Abyssor embracers to fish.)

Adds or buffs:

Sneaking
Climbing
Swimming
Tracking
Butchering

Also gives the ORGAN_EATER and DARKVISION traits to embracers. 

## Testing Evidence

9/10 dentists agree that this works.

## Why It's Good For The Game

This skill overhaul removes a bunch of these weird skills that really make no sense for embracers to have, and helps them in areas where they clearly should be quite good. Organ eater will allow them to eat organs, consistent with their lifestyle of eating raw meat and drinking shit water. For a class which cannot wear clothes, they cannot carry around any source of light without using up a hand slot-and the idea of a lunacy embracer needing to carry around a lantern or torch all the time isn't really consistent with their intended place as creatures of the wild. Night-eyed is almost a mandatory virtue pick for them for this reason, so giving them its benefits from the start will allow embracer characters to play with other virtues and make more varied characters without forcing them to forego seeing.
