### PR TITLE
Pestran templar bugfix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -268,9 +268,9 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 	belt = /obj/item/storage/belt/rogue/leather/black
 	beltr = /obj/item/storage/keyring/churchie
+	beltl = /obj/item/rogueweapon/scabbard/sword
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
 	armor = /obj/item/clothing/suit/roguetown/armor/plate	///Half-Plate not fullplate
-	r_hand = /obj/item/rogueweapon/scabbard/sword
 	backpack_contents = list(
 		/obj/item/ritechalk,
 		/obj/item/storage/belt/rogue/pouch/coins/mid,


### PR DESCRIPTION
## About The Pull Request

Moves the templar scabbard to their left belt slot, so when you pick pestran sickles as a pestran templar you actually get both sickles.

## Testing Evidence

one line change

## Why It's Good For The Game

bugfix
