### PR TITLE
Add new Pickpocket virtue Swift Fingers

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -265,7 +265,7 @@
 /datum/virtue/utility/swiftfingers
 	name = "Swift Fingers"
 	desc = "You have a natural talent for weaving your hands into the pockets of others unnoticed, or weightlessly untying a belt. You know how to take away goods from their owners far easier than most travelers."
-	added_skills = list(list(/datum/skill/misc/stealing, 2, 3))
+	added_skills = list(list(/datum/skill/misc/stealing, 3, 4))
 
 /datum/virtue/utility/granary
 	name = "Cunning Provisioner"

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -262,6 +262,11 @@
 	added_stashed_items = list("Lockpick Ring" = /obj/item/lockpickring/mundane)
 	added_skills = list(list(/datum/skill/misc/lockpicking, 3, 6))
 
+/datum/virtue/utility/swiftfingers
+	name = "Swift Fingers"
+	desc = "You have a natural talent for weaving your hands into the pockets of others unnoticed, or weightlessly untying a belt. You know how to take away goods from their owners far easier than most travelers."
+	added_skills = list(list(/datum/skill/misc/stealing, 2, 3))
+
 /datum/virtue/utility/granary
 	name = "Cunning Provisioner"
 	desc = "You've worked in or around the docks enough to steal away a sack of supplies that no one would surely miss, just in case. You've picked up on some cooking and fishing tips in your spare time, as well."


### PR DESCRIPTION
## About The Pull Request

This PR adds a pick pocket virtue called Swift Fingers - it adds the `Pickpocketing` skill to your character.

## Virtue Description

**Swift Fingers**
_You have a natural talent for weaving your hands into the pockets of others unnoticed, or weightlessly untying a belt. You know how to take away goods from their owners far easier than most travelers._

This Virtue adds the following skills:
**III levels of Pickpocketing, up to Expert**

## Testing Evidence

<img width="385" height="213" alt="proof" src="https://github.com/user-attachments/assets/858a278c-c760-423d-895e-056a0c3ad7a3" />

## Why It's Good For The Game

Makes it easier for players to steal, instead of having to grind up this skill.