### PR TITLE
Fluted Cuirass option for knight errants

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -56,7 +56,7 @@
 
 /datum/advclass/noble/knighte
 	name = "Knight Errant"
-	tutorial = "You are a knight from a distant land, a scion of a noble house visiting Azuria for one reason or another."
+	tutorial = "You are a knight from a distant land, a scion of a noble house visiting Scarlet Reach for one reason or another."
 	outfit = /datum/outfit/job/roguetown/adventurer/knighte
 
 	traits_applied = list(TRAIT_NOBLE, TRAIT_HEAVYARMOR)
@@ -85,7 +85,7 @@
 
 /datum/outfit/job/roguetown/adventurer/knighte/pre_equip(mob/living/carbon/human/H)
 	..()
-	to_chat(H, span_warning("You are a knight from a distant land, a scion of a noble house visiting Azuria for one reason or another."))
+	to_chat(H, span_warning("You are a knight from a distant land, a scion of a noble house visiting Scarlet Reach for one reason or another."))
 	var/helmets = list(
 		"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
 		"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
@@ -107,7 +107,8 @@
 		"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
 		"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
 		"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
-		)
+		"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,		
+	)
 	var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
 	armor = armors[armorchoice]
 


### PR DESCRIPTION
## About The Pull Request

Gives knight errants the option of having a fluted cuirass

Also fixes mentions of Azuria in the descriptions

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="297" height="255" alt="test" src="https://github.com/user-attachments/assets/0558bd2b-004b-459c-bbeb-97027396b3cc" />

## Why It's Good For The Game
Gives knight errants a nice equal limb protection loadout option like the other knights
Also no more Azuria
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
