### PR TITLE
runtime in mousecharge.dm fix

### DIFF
--- a/code/controllers/subsystem/processing/mousecharge.dm
+++ b/code/controllers/subsystem/processing/mousecharge.dm
@@ -45,5 +45,6 @@ PROCESSING_SUBSYSTEM_DEF(mousecharge)
 		if (MC_TICK_CHECK)
 			return
 
-/datum/controller/subsystem/processing/mousecharge/proc/access(var/percentage)///Only here bc I'm a lazy ass and want all my math on one screen.
+/datum/controller/subsystem/processing/mousecharge/proc/access(var/percentage)
+	percentage = clamp(percentage,0,100)///Only here bc I'm a lazy ass and want all my math on one screen.
 	return SSmousecharge.mouse_icons[floor(percentage / 5) + 1]


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
i forgot to clamp the charge value, causing it to behave oddly if you overcharged the spell.
## Testing Evidence
no runtime anymore (tested it because the server crashed and I had a second)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
bugfix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
