### PR TITLE
Sun and Moon - Astrata and Noc

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -4,8 +4,8 @@
 
 /datum/patron/divine/astrata
 	name = "Astrata"
-	domain = "Twinned Goddess of the Sun, Day, and Order"
-	desc = "The she-form of the Twinned Gods, the combined amalgam of single-bodied Astrata and Noc that opens her eyes at glorious Dae. Men bask under the gift of the Sun. A single form begets two Gods that shift at Dusk and Dawn but always endures, even at night."
+	domain = "Goddess of the Sun, Day, and Order"
+	desc = "The Sun-Tyrant of the Ten, sister and rival to Noc - and the eldest of them all. Her radiance keeps the evils at bay during the dae. Night, however, is a different tale."
 	worshippers = "The Noble Hearted, Zealots and Farmers"
 	mob_traits = list(TRAIT_APRICITY)
 	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
@@ -27,9 +27,9 @@
 
 /datum/patron/divine/noc
 	name = "Noc"
-	domain = "Twinned God of the Moon, Night, and Knowledge"
-	desc = "The he-form of the Twinned Gods, the combined amalgam of single-bodied Noc and Astrata that opens his eyes during pondorous Night. He gifted man knowledge of divinity and magicks. A single form begets two Gods that shift at Dusk and Dawn but always endures, even at dae."
-	worshippers = "Wizards and Scholars"
+	domain = "God of the Moon, Night, Knowledge and Arcyne"
+	desc = "The Veiled One of the Ten, brother and rival to Astrata. His wisdom paves the way in the moonlight. Tales of esoteric magic at the destination are sung - in the words of decaying scripts."
+	worshippers = "The Curious, Wizards and Scholars"
 	mob_traits = list(TRAIT_NIGHT_OWL, TRAIT_DARKVISION)
 	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
 					/obj/effect/proc_holder/spell/invoked/noc_sight				= CLERIC_T0,
@@ -183,7 +183,7 @@
 	name = "Pestra"
 	domain = "Goddess of Decay, Disease and Medicine"
 	desc = "Goddess that blessed many a saint with healing hands, Pestra taught man the arts of medicine and its benefits."
-	worshippers = "The Sick, Phyicians, Apothecaries"
+	worshippers = "The Sick, Physicians, Apothecaries"
 	mob_traits = list(TRAIT_EMPATH, TRAIT_ROT_EATER)
 	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
 					/obj/effect/proc_holder/spell/invoked/diagnose				= CLERIC_ORI,

--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -35,15 +35,15 @@
 	switch(riteselection) // rite selection goes in this section, try to do something fluffy. Presentation is most important here, truthfully.
 		if("Guiding Light") // User selects Guiding Light, begins the stuff for it
 			if(do_after(user, 50)) // just flavor stuff before activation
-				user.say("I beseech the she-form of the Twinned God!!")
+				user.say("I beseech the guidance of the Sun!!")
 				if(do_after(user, 50))
 					user.say("To bring Order to a world of naught!!")
 					if(do_after(user, 50))
 						user.say("Place your gaze upon me, oh Radiant one!!")
-						to_chat(user,span_danger("You feel the eye of Astrata turned upon you. Her warmth dances upon your cheek. You feel yourself warming up...")) // A bunch of flavor stuff, slow incanting.
+						to_chat(user,span_danger("You feel Astrata's strict gaze turned upon you. Her warmth dances upon your cheek. You feel yourself heating up...")) // A bunch of flavor stuff, slow incanting.
 						icon_state = "astrata_active"
 						if(!HAS_TRAIT(user, TRAIT_CHOSEN)) //Priests don't burst into flames.
-							loc.visible_message(span_warning("[user]'s bursts to flames! Embraced by Her Warmth wholly!"))
+							loc.visible_message(span_warning("[user]'s bursts to flames! Embraced by Her warmth wholly!"))
 							playsound(loc, 'sound/combat/hits/burn (1).ogg', 100, FALSE, -1)
 							user.adjust_fire_stacks(10)
 							user.IgniteMob()
@@ -83,12 +83,12 @@
 	switch(riteselection) // put ur rite selection here
 		if("Moonlight Dance")
 			if(do_after(user, 50))
-				user.say("I beseech the he-form of the Twinned God!!")
+				user.say("I beseech the guidance of the Moon!!")
 				if(do_after(user, 50))
 					user.say("To bring Wisdom to a world of naught!!")
 					if(do_after(user, 50))
-						user.say("Place your gaze upon me, oh wise one!!")
-						to_chat(user,span_cultsmall("The waning half of the Twin-God carries but one eye. With some effort, it can be drawn upon supplicants."))
+						user.say("Place your gaze upon me, oh Wise one!!")
+						to_chat(user,span_cultsmall("You feel Noc's comforting gaze fall upon you. You feel surrounded by a soothing chill."))
 						playsound(loc, 'sound/magic/holyshield.ogg', 80, FALSE, -1)
 						moonlightdance(src)
 						user.apply_status_effect(/datum/status_effect/debuff/ritesexpended)

--- a/strings/rt/timechangetips.txt
+++ b/strings/rt/timechangetips.txt
@@ -1,6 +1,6 @@
 The Holy Ecclesial is a splinter of the Holy See, formed during the great schism. They worship the Four Ascendants as true divinity.
 PSYDON yet lives. PSYDON yet ENDURES.
-Dae is far less dangerous than Night; Astrata-Noc’s gaze is far more searing to all forms of evils in a direct burn.
+Dae is far less dangerous than night; Astrata’s gaze is searing to many forms of evils in a direct burn.
 The Ten are less responsive to prayer than the Ascendant. The Holy See claims that this is a test of faith.
 I can jump further by getting a running start. Mind the overshoot.
 The world flooded for a thousand daes before Abyssor was finally put to rest. Some say he will one dae stir from his slumber; and wash away the sins of the world with his awakening.
@@ -19,7 +19,6 @@ Werewolves are those cursed by Dendor for their sins against nature, damned to c
 Werewolves are blessings sent by Dendor to restore us to a natural way of lyfe.
 Werewolves are the hideous creations of Dendor in his madness, blindly venerated by idiot worshippers of the Ten. 
 Challenging a Matthiosite is challenging a Ravoxian. Both fight for their deity, but both have vastly different senses of Justice.
-Astrata-Noc is the Twinned God, a dual-sexed creacher with two faces and four arms that shifts at dusk and dawn.
 Pestra is said to have slithered from the guts of Psydon, decayed and foetid, last of the Ten to emerge.
 Necra, in the oldest tomes, is said to be a being older than Psydon. The Holy See itself calls this heresy.
 It is claimed that Noc invented alchemy by the Holy See. The Holy Ecclesical claims it was the creation of Matthios.
@@ -101,5 +100,9 @@ Wearing a red tabard provokes even the most serene minotaur.
 An arcing arrow can only hit a target below you, not above you. A thrown rock, however...
 ASTRATA is a VILE TYRANT and must be CONSUMED AND SUBSUMED.
 ASTRATA is law made manifest and must be respected, lest society fall into chaos.
+NOC is a CARELESS FOOL and must be CONSUMED AND SUBSUMED.
+NOC is wisdom made manifest and must be respescted, lest society fall into ignorance.
 No pursuit was too perilous, no sacrifice too great. Until, well...
 Under the Heavens and the Many Stars, there are darker things than men may dream of.
+The Ten are indivisible and infallible.
+The Ten have more than a few grievances against each other.


### PR DESCRIPTION
## About The Pull Request

A slightly adjusted port of [#3870 from Azure Peak](https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3870). Turns Astrata and Noc into separate twin deities rather than two forms of the Twinned God.

Adds three more new day tips to accomodate this and the fact that some Tennites can be Wretcheretics now.

## Testing Evidence

Mere string changes. Noc smite me if it somehow breaks.

## Why It's Good For The Game

While the idea of Astrata and Noc being two sides of the same god is a cool one, it has never been properly realised in code or roleplay. E.g. Priest is exclusively Astratan, even though them being able to be either Astrata or Noccian (or both at the same time) would make far more sense in such lore.

Furthermore, it takes a stretch of imagination to justify something like Astrata-Noc schism or Noccian Wretcheretics if two gods are just the same being. With them separate, however, it makes plenty of sense.