### PR TITLE
nerfs the FUCK out of frost spells to not be TWENTY SECONDS of being unable to move

### DIFF
--- a/code/modules/spells/spell_types/wizard/spells_status_effects.dm
+++ b/code/modules/spells/spell_types/wizard/spells_status_effects.dm
@@ -17,7 +17,7 @@
 	target.update_vision_cone()
 	var/newcolor = rgb(136, 191, 255)
 	target.add_atom_colour(newcolor, TEMPORARY_COLOUR_PRIORITY)
-	addtimer(CALLBACK(target, TYPE_PROC_REF(/atom, remove_atom_colour), TEMPORARY_COLOUR_PRIORITY, newcolor), 20 SECONDS)
+	addtimer(CALLBACK(target, TYPE_PROC_REF(/atom, remove_atom_colour), TEMPORARY_COLOUR_PRIORITY, newcolor), 6 SECONDS)
 	target.add_movespeed_modifier(MOVESPEED_ID_ADMIN_VAREDIT, update=TRUE, priority=100, multiplicative_slowdown=4, movetypes=GROUND)
 
 /datum/status_effect/buff/frostbite/on_remove()


### PR DESCRIPTION
## About The Pull Request

currently spells like frost bolt allow you to wombo combo people with multiple spells in sequence and essentially kill someone from full health no matter their armor
frost bolt and other spells in the frost subcategory are inherently fucking insane because being able to apply a twenty second debuff that slows you down to a CRAWL pace is super powerful both offensively to set people up for wombo combos and defensively cause nobody can chase you if you turn them into a statue

that's not to mention that you can chain frost bolt into frost bolt because the cooldown is so short that you can just refresh the debuff while they're unable to dodge
frost bolt is a fight ending spell and it really shouldn't be

this just quarters the slowdown to six seconds down from TWENTY so it's closer to landing a feint in terms of effectiveness and being able to get off a free spell or two while they're slowed down

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

webedit bruh

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

overpowered mage strategies that can turn someone wearing full blacksteel to dead in ten spell casts shouldn't exist

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
