### PR TITLE
Map spawns for mana-binding collars + crafting rename

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -64606,6 +64606,7 @@
 /obj/item/rogueweapon/sword/long/exe/cloth,
 /obj/item/natural/stone,
 /obj/item/storage/belt/rogue/surgery_bag/full,
+/obj/item/clothing/neck/roguetown/collar/leather/nomagic,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/cell)
 "sst" = (
@@ -68715,6 +68716,8 @@
 /obj/item/scrying,
 /obj/item/roguekey/manor,
 /obj/item/roguekey/manor,
+/obj/item/clothing/neck/roguetown/collar/leather/nomagic,
+/obj/item/clothing/gloves/roguetown/nomagic,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
 "tCv" = (

--- a/code/datums/magic_items/mages_mechanics.dm/arcana_crafring.dm
+++ b/code/datums/magic_items/mages_mechanics.dm/arcana_crafring.dm
@@ -54,7 +54,7 @@
 	name = "mana binding collar - (1 Collar, 1 Gem, 1 Dense Arcanic Meld)"
 	result = /obj/item/clothing/neck/roguetown/collar/leather/nomagic
 	reqs = list(/obj/item/clothing/neck/roguetown/collar = 1,
-				/obj/item/roguegem/amethyst = 1,
+				/obj/item/roguegem = 1,
 				/obj/item/magic/melded/t2 = 1)
 	craftdiff = 2
 
@@ -62,7 +62,7 @@
 	name = "mana binding gloves - (1 Gloves, 1 Gem, 1 Sorcerous Weave)"
 	result = /obj/item/clothing/gloves/roguetown/nomagic
 	reqs = list(/obj/item/clothing/gloves/roguetown/leather = 1,
-				/obj/item/roguegem/amethyst = 1,
+				/obj/item/roguegem = 1,
 				/obj/item/magic/melded/t3 = 1)
 	craftdiff = 3
 

--- a/code/datums/magic_items/mages_mechanics.dm/arcana_crafring.dm
+++ b/code/datums/magic_items/mages_mechanics.dm/arcana_crafring.dm
@@ -54,7 +54,7 @@
 	name = "mana binding collar - (1 Collar, 1 Gem, 1 Dense Arcanic Meld)"
 	result = /obj/item/clothing/neck/roguetown/collar/leather/nomagic
 	reqs = list(/obj/item/clothing/neck/roguetown/collar = 1,
-				/obj/item/roguegem = 1,
+				/obj/item/roguegem/amethyst = 1,
 				/obj/item/magic/melded/t2 = 1)
 	craftdiff = 2
 
@@ -62,7 +62,7 @@
 	name = "mana binding gloves - (1 Gloves, 1 Gem, 1 Sorcerous Weave)"
 	result = /obj/item/clothing/gloves/roguetown/nomagic
 	reqs = list(/obj/item/clothing/gloves/roguetown/leather = 1,
-				/obj/item/roguegem = 1,
+				/obj/item/roguegem/amethyst = 1,
 				/obj/item/magic/melded/t3 = 1)
 	craftdiff = 3
 

--- a/code/game/objects/items/rogueitems/gems.dm
+++ b/code/game/objects/items/rogueitems/gems.dm
@@ -1,6 +1,6 @@
 
 /obj/item/roguegem
-	name = "mother of all gems"
+	name = "gem"
 	icon_state = "ruby_cut"
 	icon = 'icons/roguetown/items/gems.dmi'
 	desc = "A debug tool to help us later"


### PR DESCRIPTION
This PR makes mana binding collars and gloves more accessable by spawning 2 collars (one in the dungeon master's bedroom and one in the court magicans bedroom drawer) and leaving an extra pair of mana binding gloves at the magos tower

It also renames the debug item "mother of all gems" to "gem" to remove any potential for confusions during crafting



![](https://i.gyazo.com/3f8fa7ad172847586194a2ab35779201.png)


![](https://i.gyazo.com/6b76969e897479e5f112efac4b8a5e73.jpg)


![](https://i.gyazo.com/3c08ebdbbafe4fed949f939fa599d589.png)


I think this is a good change because it allows for more RP options as a dungeoneer and court magican (punishing apprentices or actually having alive sorcerers as prisoners). It will no longer be required to gag someone and keep them restrained the entire time and allows them to properly engage in roleplay.

