### PR TITLE
Cache `get_missing_limbs()` for HUD

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -1285,9 +1285,10 @@
 
 	if(hud.mymob.stat != DEAD && ishuman(hud.mymob))
 		var/mob/living/carbon/human/H = hud.mymob
+		var/list/missing_bodyparts_zones = H.get_missing_limbs()
 		for(var/X in H.bodyparts)
 			var/obj/item/bodypart/BP = X
-			if(BP.body_zone in H.get_missing_limbs())
+			if(BP.body_zone in missing_bodyparts_zones)
 				continue
 			if(HAS_TRAIT(H, TRAIT_NOPAIN))
 				var/mutable_appearance/limby = mutable_appearance('icons/mob/roguehud64.dmi', "[H.gender == "male" ? "m" : "f"]-[BP.body_zone]")
@@ -1304,7 +1305,7 @@
 			. += limby
 			if(BP.get_bleed_rate())
 				. += mutable_appearance('icons/mob/roguehud64.dmi', "[H.gender == "male" ? "m" : "f"]-[BP.body_zone]-bleed") //apply healthy limb
-		for(var/X in H.get_missing_limbs())
+		for(var/X in missing_bodyparts_zones)
 			var/mutable_appearance/limby = mutable_appearance('icons/mob/roguehud64.dmi', "[H.gender == "male" ? "m" : "f"]-[X]") //missing limb
 			limby.color = "#2f002f"
 			. += limby


### PR DESCRIPTION
## About The Pull Request

This PR makes an optimization to proc `/atom/movable/screen/zone_sel/update_overlays()`

By caching mob `get_missing_limbs()` results, it will reduce the number of times needed to check for missing limbs.

## Testing Evidence

Before:
<img width="821" height="193" alt="before" src="https://github.com/user-attachments/assets/1d70f72a-e81b-40b2-a280-e1edf52282f4" />

After:
<img width="820" height="193" alt="after" src="https://github.com/user-attachments/assets/e053674f-4970-4011-b16c-7c1fae3020e5" />

## Why It's Good For The Game

Makes the server run slightly faster.