### PR TITLE
Investigator Inquisitor Buff

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -71,22 +71,23 @@
 		)
 
 	subclass_stats = list(
-		STATKEY_CON = 3,
+		STATKEY_CON = 1,
 		STATKEY_PER = 3,
 		STATKEY_INT = 3,
-		STATKEY_STR = 2,
+		STATKEY_STR = 1,
 		STATKEY_END = 2,
-		STATKEY_SPD = 1,
+		STATKEY_SPD = 3,
 	)
 
 	subclass_skills = list(
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/tracking = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_MASTER,
+		/datum/skill/misc/stealing = SKILL_LEVEL_MASTER,
 		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
-		/datum/skill/combat/crossbows = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/crossbows = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
@@ -108,7 +109,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots/otavan/inqboots
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan
 	backr =  /obj/item/storage/backpack/rogue/satchel/otavan
-	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow
 	beltr = /obj/item/quiver/bolts
 	head = /obj/item/clothing/head/roguetown/inqhat
 	mask = /obj/item/clothing/mask/rogue/spectacles/inq/spawnpair

--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -81,7 +81,7 @@
 
 	subclass_skills = list(
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_MASTER,
-		/datum/skill/misc/tracking = SKILL_LEVEL_MASTER,
+		/datum/skill/misc/tracking = SKILL_LEVEL_LEGENDARY,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/stealing = SKILL_LEVEL_MASTER,
 		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
@@ -139,13 +139,13 @@
 		if("Eucharist (Rapier)")
 			H.put_in_hands(new /obj/item/rogueweapon/sword/rapier/psy/relic(H), TRUE)
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword, SLOT_BELT_L, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
 		if("Daybreak (Whip)")
 			H.put_in_hands(new /obj/item/rogueweapon/whip/antique/psywhip(H), TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 4, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 5, TRUE)
 		if("Stigmata (Halberd)")
 			H.put_in_hands(new /obj/item/rogueweapon/halberd/psyhalberd/relic(H), TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 5, TRUE)
 
 
 ///The dirty, violent side of the Inquisition. Meant for confrontational, conflict-driven situations as opposed to simply sneaking around and asking questions. Templar with none of the miracles, but with all the muscles and more. 


### PR DESCRIPTION
## About The Pull Request
Essentially a lighter version of https://github.com/Scarlet-Reach/Scarlet-Reach/pull/506.
Ordinator is untouched, as opposed to the former PR. Inquis given a slurbow, a general stat re-spec to make them more a more effective dodge/ranged class, as opposed to just being a worse Ordinator.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1919" height="674" alt="Screenshot 2025-09-26 164550" src="https://github.com/user-attachments/assets/0667628a-de79-4d2e-9813-271659a096d7" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
A similar PR was already approved, and I was told to work on this by Kite. The last PR was overwritten when the ENDVRE rework came about. At the moment, Inquisitor is just a drippier/worse version of Ordinator. That'd be fine if they had the benefits to make up for it - it isn't a joke/gimmick subclass like inbred - that allow them to be a more traditional dexterous witch-hunter type.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
