### PR TITLE
Lowers alpha on all buff filters

### DIFF
--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/fortitude.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/fortitude.dm
@@ -59,7 +59,7 @@
 	. = ..()
 	var/filter = owner.get_filter(FORTITUDE_FILTER)
 	if (!filter)
-		owner.add_filter(FORTITUDE_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
+		owner.add_filter(FORTITUDE_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 50, "size" = 1))
 	to_chat(owner, span_warning("My body feels lighter..."))
 	ADD_TRAIT(owner, TRAIT_FORTITUDE, MAGIC_TRAIT)
 

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/giants_strength.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/giants_strength.dm
@@ -62,7 +62,7 @@
 	. = ..()
 	var/filter = owner.get_filter(GIANTSSTRENGTH_FILTER)
 	if (!filter)
-		owner.add_filter(GIANTSSTRENGTH_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
+		owner.add_filter(GIANTSSTRENGTH_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 50, "size" = 1))
 		ADD_TRAIT(owner, TRAIT_STRENGTH_UNCAPPED, TRAIT_MIRACLE)
 	to_chat(owner, span_warning("My muscles strengthen."))
 

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/guidance.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/guidance.dm
@@ -59,7 +59,7 @@
 	. = ..()
 	var/filter = owner.get_filter(GUIDANCE_FILTER)
 	if (!filter)
-		owner.add_filter(GUIDANCE_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
+		owner.add_filter(GUIDANCE_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 50, "size" = 1))
 	to_chat(owner, span_warning("The arcyne aides me in battle."))
 	ADD_TRAIT(owner, TRAIT_GUIDANCE, MAGIC_TRAIT)
 

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/haste.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/haste.dm
@@ -66,7 +66,7 @@
 	. = ..()
 	var/filter = owner.get_filter(HASTE_FILTER)
 	if (!filter)
-		owner.add_filter(HASTE_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
+		owner.add_filter(HASTE_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 25, "size" = 1))
 	to_chat(owner, span_warning("My limbs move with uncanny swiftness."))
 
 /datum/status_effect/buff/haste/on_remove()

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/hawks_eyes.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/hawks_eyes.dm
@@ -61,7 +61,7 @@
 	. = ..()
 	var/filter = owner.get_filter(HAWKSEYES_FILTER)
 	if (!filter)
-		owner.add_filter(HAWKSEYES_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
+		owner.add_filter(HAWKSEYES_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 25, "size" = 1))
 	to_chat(owner, span_warning("My vision sharpens, like that of a hawk."))
 
 

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/stoneskin.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/stoneskin.dm
@@ -63,7 +63,7 @@
 	. = ..()
 	var/filter = owner.get_filter(STONESKIN_FILTER)
 	if (!filter)
-		owner.add_filter(STONESKIN_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
+		owner.add_filter(STONESKIN_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 50, "size" = 1))
 	to_chat(owner, span_warning("My skin hardens like stone."))
 
 /datum/status_effect/buff/stoneskin/on_remove()


### PR DESCRIPTION
## About The Pull Request
https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3851
> Lowers the alpha of all filters for buff spells from 200 to 50. Haste & Hawk Eyes lowered to 25 because yellow is more pronounced even on 50.

## Testing Evidence
> All 6 spells cast below on Giant character. Result varies depending on the order of spells cast.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
> to stop this 
> <img width="381" height="312" alt="489505525-0d4e0825-46e3-4ae3-bc3b-4738c606ce06" src="https://github.com/user-attachments/assets/139e708f-eda2-4785-92d5-70f462b82671" />

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
