### PR TITLE
Construct healing fix

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/mending.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mending.dm
@@ -49,7 +49,7 @@
 				H.adjustFireLoss(-heal_amount, 0)
 				H.adjustOxyLoss(-heal_amount, 0)
 				H.adjustToxLoss(-heal_amount, 0)
-				H.adjustOrganLoss(-ORGAN_SLOT_BRAIN, heal_amount)
+				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, -heal_amount)
 				H.adjustCloneLoss(-heal_amount, 0)
 				H.visible_message(span_info("[H] glows in a faint mending light."), span_notice("I feel my body being repaired by arcyne energy."))
 				playsound(H, 'sound/foley/sewflesh.ogg', 50, TRUE, -2)


### PR DESCRIPTION
## About The Pull Request

Fixes an error where the mending spell is given an invalid target organ when healing constructs such as golems and dolls.

This error caused a runtime any time mending was used on a living target, and prevented the correct behavior of the mending spell.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="558" height="163" alt="image" src="https://github.com/user-attachments/assets/47e6f68c-fafd-4617-8041-63fdb8b4d31f" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

I fixxa da bug

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
