### PR TITLE
Only player characters create tracks

### DIFF
--- a/modular_hearthstone/code/game/objects/effects/track.dm
+++ b/modular_hearthstone/code/game/objects/effects/track.dm
@@ -376,6 +376,8 @@
 /mob/living/proc/check_track_creation(turf/new_turf)
 	if(!new_turf)
 		return //Guh?
+	if(isnull(mind))
+		return
 	if(!(movement_type & GROUND) || (movement_type & (FLOATING|FLYING))) //For some reason some mobs have both ground and flying at once.
 		return
 	var/probability = round(track_creation_prob(new_turf), 0.1) 


### PR DESCRIPTION
## About The Pull Request
Port of: https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3188

## Testing Evidence

## Why It's Good For The Game
> an azurillion mobs (over 1K) each rolling to create a track on every Move() which in turn creates an addtimer is a bad bad bad bad
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
