### PR TITLE
Adds 'Damned' Vice

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	"Mute"=/datum/charflaw/mute,
 	"Critical Weakness"=/datum/charflaw/critweakness,
 	"Foreigner"=/datum/charflaw/foreigner,
+	"Damned"=/datum/charflaw/damned,
 	"Random or No Flaw"=/datum/charflaw/randflaw,
 	"No Flaw (3 TRIUMPHS)"=/datum/charflaw/noflaw,
 	))
@@ -504,7 +505,14 @@ GLOBAL_LIST_INIT(character_flaws, list(
 /datum/charflaw/critweakness/on_mob_creation(mob/user)
 	ADD_TRAIT(user, TRAIT_CRITICAL_WEAKNESS, TRAIT_GENERIC)
 
-/datum/charflaw/foreigner	
+/datum/charflaw/damned
+	name = "Damned"
+	desc = "I am cursed! Holy magic and silver metal burns my body."
+
+/datum/charflaw/damned/on_mob_creation(mob/user)
+	ADD_TRAIT(user, TRAIT_HOLLOW_LIFE, TRAIT_GENERIC)
+
+/datum/charflaw/foreigner
 	name = "Foreigner"
 	desc = "You never learned Imperial. You cannot understand or speak it."
 

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -510,6 +510,7 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	desc = "I am cursed! Holy magic and silver metal burns my body."
 
 /datum/charflaw/damned/on_mob_creation(mob/user)
+	..()
 	ADD_TRAIT(user, TRAIT_HOLLOW_LIFE, TRAIT_GENERIC)
 
 /datum/charflaw/foreigner

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -511,6 +511,10 @@ GLOBAL_LIST_INIT(character_flaws, list(
 
 /datum/charflaw/damned/on_mob_creation(mob/user)
 	..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	H.mob_biotypes |= MOB_UNDEAD
 	ADD_TRAIT(user, TRAIT_HOLLOW_LIFE, TRAIT_GENERIC)
 
 /datum/charflaw/foreigner

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -182,6 +182,12 @@
 
 /datum/virtue/combat/hollow_life/apply_to_human(mob/living/carbon/human/recipient)
 	recipient.change_stat(STATKEY_CON, -2)
-	recipient.mob_biotypes |= MOB_UNDEAD
 	recipient.dna.species.soundpack_m = new /datum/voicepack/hollow()
 	recipient.dna.species.soundpack_f = new /datum/voicepack/hollow_fem()
+	if(recipient.charflaw)
+		if(recipient.charflaw.type == /datum/charflaw/damned)
+			to_chat(recipient, "Your body is plagued by curses!")
+			ADD_TRAIT(recipient, TRAIT_NORUN, TRAIT_GENERIC)
+		else
+			recipient.mob_biotypes |= MOB_UNDEAD //Undead biotype is already applied by damned vice.
+


### PR DESCRIPTION
## About The Pull Request

This basically gives you the negatives of the 'Hollow Lyfe' virtue but without any of the upsides. Silver weakness and miracles burn you. 
Also the trait innately comes with werewolf infection immunity, uuuhhhhhhhhhhh. No good way to disable that. I presume the negatives still outweigh it, but like tell me if you disagree.

Also if you try to game the system by taking Hollow Lyfe and Damned to get a free vice, it gives you Decayed Flesh (no run). 

## Testing Evidence

<img width="128" height="37" alt="image" src="https://github.com/user-attachments/assets/b3fbbb77-ded4-476d-a4f7-79bd6f1bc15f" />

<img width="398" height="30" alt="image" src="https://github.com/user-attachments/assets/cab5b93b-3b36-4662-878d-fc7b1ddba53e" />

<img width="660" height="50" alt="image" src="https://github.com/user-attachments/assets/c9231c88-9247-4f34-af27-1bd742a472e8" />

<img width="282" height="62" alt="image" src="https://github.com/user-attachments/assets/fafbfd55-6c41-457c-99e7-053c3319ac28" />

Tested everything on a localhost. Ran Damned, Hollow Lyfe + Damned, and just Hollow Lyfe. All worked as expected.

## Why It's Good For The Game

Players can roleplay being cursed & evil.
