### PR TITLE
Garrison Role: Gatemaster

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -112,10 +112,11 @@
 #define GUARDSMAN	(1<<0)
 #define MANATARMS	(1<<1)
 #define DUNGEONEER	(1<<2)
-#define SQUIRE		(1<<3)
-#define BOGGUARD	(1<<4)
-#define SERGEANT	(1<<5)
-#define SHERIFF		(1<<6)
+#define GATEMASTER	(1<<3)
+#define SQUIRE		(1<<4)
+#define BOGGUARD	(1<<5)
+#define SERGEANT	(1<<6)
+#define SHERIFF		(1<<7)
 
 #define CHURCHMEN		(1<<2)
 

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -451,6 +451,7 @@ GLOBAL_LIST_EMPTY(round_join_times)
 #define CTAG_HEIR			"CAT_HEIR"			// Prince(cess) class - Handles Heir class selector
 #define CTAG_LORD			"CAT_LORD"			// Lord class - Handles Lord class selector
 #define CTAG_SQUIRE			"CAT_SQUIRE"		// Squire class - Handles Squire class selector
+#define CTAG_GATEMASTER		"CAT_GATEMASTER"	// Gatemaster class - Handles Gatemaster class selector
 #define CTAG_VETERAN		"CAT_VETERAN"		// Veteran class - Handles Veteran class selector
 #define CTAG_MARSHAL		"CAT_MARSHAL"		// Marshal class
 #define CTAG_SENESCHAL		"CAT_SENESCHAL"		// Seneschal's aesthetic choices.

--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -23,7 +23,7 @@
 
 	cmode_music = 'sound/music/combat_guard.ogg'
 
-	job_traits = list(TRAIT_GUARDSMAN, TRAIT_STEELHEARTED)
+	job_traits = list(TRAIT_GUARDSMAN, TRAIT_STEELHEARTED, TRAIT_MEDIUMARMOR)
 	job_subclasses = list(
 		/datum/advclass/gatemaster
 	)
@@ -42,7 +42,7 @@
 	outfit = /datum/outfit/job/roguetown/gatemaster
 	category_tags = list(CTAG_GATEMASTER)
 	subclass_stats = list(
-		STATKEY_STR = 1,
+		STATKEY_STR = 2,
 		STATKEY_INT = 1,
 		STATKEY_CON = 1,
 		STATKEY_PER = 2,
@@ -52,13 +52,18 @@
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/crossbows = SKILL_LEVEL_MASTER,
-		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/bows = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/slings = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/traps = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT, //Paperwork RP
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/carpentry = SKILL_LEVEL_JOURNEYMAN, //For fixing the door.
+		/datum/skill/craft/engineering = SKILL_LEVEL_JOURNEYMAN, //lets them change stuff like the levers and gate
 	)
 
 /datum/outfit/job/roguetown/gatemaster

--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -1,0 +1,87 @@
+/datum/job/roguetown/gatemaster
+	title = "Gatemaster"
+	flag = GATEMASTER
+	department_flag = GARRISON
+	faction = "Station"
+	total_positions = 1
+	spawn_positions = 1
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_FEARED_UP
+	disallowed_races = list(
+		/datum/species/lamia,
+	)
+	allowed_patrons = ALL_DIVINE_PATRONS
+	tutorial = "Tales speak of the Gatemaster's legendary ability to stand still at a gate and ask people questions."
+	display_order = JDO_GATEMASTER
+
+	outfit = /datum/outfit/job/roguetown/gatemaster
+	advclass_cat_rolls = list(CTAG_GATEMASTER = 20)
+	give_bank_account = 3
+	min_pq = 4
+	max_pq = null
+	round_contrib_points = 3
+
+	cmode_music = 'sound/music/combat_guard.ogg'
+
+	job_traits = list(TRAIT_GUARDSMAN, TRAIT_STEELHEARTED)
+	job_subclasses = list(
+		/datum/advclass/gatemaster
+	)
+
+/datum/job/roguetown/gatemaster/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	..()
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.advsetup = 1
+		H.invisibility = INVISIBILITY_MAXIMUM
+		H.become_blind("advsetup")
+
+/datum/advclass/gatemaster
+	name = "Gatemaster"
+	tutorial = "Tales speak of the Gatemaster's legendary ability to stand still at a gate and ask people questions."
+	outfit = /datum/outfit/job/roguetown/gatemaster
+	category_tags = list(CTAG_GATEMASTER)
+	subclass_stats = list(
+		STATKEY_STR = 1,
+		STATKEY_INT = 1,
+		STATKEY_CON = 1,
+		STATKEY_PER = 2,
+	)
+
+	subclass_skills = list(
+		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/crossbows = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/traps = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+	)
+
+/datum/outfit/job/roguetown/gatemaster
+	name = "Gatemaster"
+	has_loadout = TRUE
+	jobtype = /datum/job/roguetown/gatemaster
+	job_bitflag = BITFLAG_GARRISON
+
+/datum/outfit/job/roguetown/gatemaster/pre_equip(mob/living/carbon/human/H)
+	..()
+	head = /obj/item/clothing/head/roguetown/roguehood/red
+	neck = /obj/item/clothing/neck/roguetown/gorget
+	cloak = /obj/item/clothing/cloak/stabard/surcoat/guard
+	armor = /obj/item/clothing/suit/roguetown/armor/chainmail
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	pants = /obj/item/clothing/under/roguetown/chainlegs
+	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	belt = /obj/item/storage/belt/rogue/leather/black
+	beltl = /obj/item/storage/keyring/guardcastle
+	beltr = /obj/item/quiver/bolts
+	backr = /obj/item/storage/backpack/rogue/satchel/black
+	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+	id = /obj/item/scomstone/bad/garrison
+	backpack_contents = list(/obj/item/rope/chain = 1)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -83,6 +83,7 @@ GLOBAL_LIST_INIT(garrison_positions, list(
 	"Watchman",
 	"Warden",
 	"Sergeant",
+	"Gatemaster",
 	"Man at Arms",
 	"Squire",
 	"Dungeoneer",

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1549,6 +1549,7 @@
 #include "code\modules\jobs\job_types\roguetown\courtier\magician.dm"
 #include "code\modules\jobs\job_types\roguetown\courtier\physician.dm"
 #include "code\modules\jobs\job_types\roguetown\garrison\dungeoneer.dm"
+#include "code\modules\jobs\job_types\roguetown\garrison\gatemaster.dm"
 #include "code\modules\jobs\job_types\roguetown\garrison\manorguard.dm"
 #include "code\modules\jobs\job_types\roguetown\garrison\sergeant.dm"
 #include "code\modules\jobs\job_types\roguetown\garrison\squire.dm"


### PR DESCRIPTION
## About The Pull Request

Brings back the garrison role: gatemaster.  Sit at the gate and open and close it for incoming petitioners to the court and defend it from invaders. 

## Testing Evidence
>
<img width="368" height="28" alt="Screenshot 2025-09-27 153501" src="https://github.com/user-attachments/assets/52c22d95-5910-4751-acab-11ae4b4733ad" />

<img width="490" height="520" alt="Screenshot 2025-09-27 152145" src="https://github.com/user-attachments/assets/8758789f-48bd-4e9b-acff-cc2a6afe90d4" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Because in the current state, it is definitely needed for the flow of RP in a round. Especially when most of the roleplay on the server takes place in the court.

> "Yeah but any MAA can do this!"

But they won't.

> "It's a bloat role!"

It is a job that serves it purpose as to what it is described to be. You open and close the gate for the keep.



<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
