### PR TITLE
Port SOME of the Jannisary changes from RW2

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -1,6 +1,6 @@
 /datum/advclass/mercenary/desert_rider
 	name = "Desert Rider Janissary"
-	tutorial = "The Janissaries are the Empire's elite infantry units, wielding mace and shield. We do not break."
+	tutorial = "The Janissaries are the Empire's elite infantry units, shield and weapon in hand. We do not break."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/mercenary/desert_rider
@@ -16,12 +16,12 @@
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_END = 2,
-		STATKEY_SPD = 2,
-		STATKEY_PER = -1
+		STATKEY_CON = 2,
+		STATKEY_PER = 1
 	)
 
 	subclass_skills = list(
-		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
@@ -38,7 +38,7 @@
 
 /datum/outfit/job/roguetown/mercenary/desert_rider/pre_equip(mob/living/carbon/human/H)
 	..()
-	to_chat(H, span_warning("The Janissaries are the Empire's elite infantry units, wielding mace and shield. We do not break."))
+	to_chat(H, span_warning("The Janissaries are the Empire's elite infantry units, shield and weapon in hand. We do not break."))
 
 	head = /obj/item/clothing/head/roguetown/helmet/sallet/raneshen
 	neck = /obj/item/clothing/neck/roguetown/bevor
@@ -57,16 +57,18 @@
 		/obj/item/storage/belt/rogue/pouch/coins/poor
 		)
 
-	var/weapons = list("Heavy Mace","Shamshir and Shield","Spear and Shield")
+	var/weapons = list("Axe and Shield","Shamshir and Shield","Spear and Shield")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
-		if("Heavy Mace")
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
-			backl = /obj/item/rogueweapon/mace/goden
+		if("Axe and Shield")
+			H.adjust_skillrank_up_to(/datum/skill/combat/axes, 4, TRUE)
+			backl = /obj/item/rogueweapon/shield/tower/raneshen
+			r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
 		if("Shamshir and Shield")
 			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
 			r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
+			beltr = /obj/item/rogueweapon/scabbard/sword
 			backl = /obj/item/rogueweapon/shield/tower/raneshen
 		if("Spear and Shield")
 			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
@@ -76,7 +78,6 @@
 	shoes = /obj/item/clothing/shoes/roguetown/shalal
 	belt = /obj/item/storage/belt/rogue/leather/shalal
 	beltl = /obj/item/rogueweapon/scabbard/sword
-	beltr = /obj/item/rogueweapon/scabbard/sword
 	l_hand = /obj/item/rogueweapon/sword/sabre/shamshir
 
 /datum/advclass/mercenary/desert_rider/zeybek


### PR DESCRIPTION
## About The Pull Request
Ports part of https://github.com/Rotwood-Vale/Ratwood-2.0/pull/72, which includes:
- Jannisaries **lose the +2SPD and the -1 PER** in exchange for **+2 CON and +1 PER**
- They no longer get a Goedendang start, but rather **axe and shield**. This includes jman axes, leveled up to expert if they pick said start.
- Removed 1 of the 2 starting scabbards, added it to the Shamshir start (so you don't just get two scabbards 4noresin)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Little Lines of Code that were literally ripped out from the PR.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Jannisaries were on the less-picked side, mostly because the rider's main attraction was the two dodge expert classes. I've been checking RW2 out and jannisaries are being picked more often since when their scalemail breaks *(As it always does)*,  they at least have some CON to back up the fact they'll bleed like pigs soon enough. Figured it'd be a good test here!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
