### PR TITLE
aasimar knights

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -6,7 +6,7 @@
 	faction = "Station"
 	total_positions = 3
 	spawn_positions = 3
-	allowed_races = RACES_NOBILITY_ELIGIBLE_UP
+	allowed_races = RACES_CHURCH_FAVORED_UP
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	tutorial = "Having proven yourself both loyal and capable, you have been knighted to serve the realm as the royal family's sentry. \


### PR DESCRIPTION
## About The Pull Request

The races allowed to play knight was races_nobility_eligible_up and replaced with races_church_favored_up

## Testing Evidence

<img width="694" height="299" alt="image_2025-09-28_113238541" src="https://github.com/user-attachments/assets/8ddfe4db-6377-41bb-b6ab-84489ec35abc" />


## Why It's Good For The Game

Of all the races people are asking to be playable as knights, aasimar have the greatest cause for it. They're blessed by the ten, they have no association with any inhumen gods, they are known to be civil and respectful to authority, unlike most animalistic races and horcs.