### PR TITLE
Fix runtime error when grabbing our own character in combat mode

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1151,6 +1151,9 @@
 	var/combat_modifier = 1
 	var/agg_grab = FALSE
 
+	if(!L) // we're pulling ourself, abort
+		return FALSE
+
 	if(mind)
 		wrestling_diff += (get_skill_level(/datum/skill/combat/wrestling)) //NPCs don't use this
 	if(L.mind)


### PR DESCRIPTION
## About The Pull Request

This PR adds an additional null check when grabbing ourselves while in combat mode.

It will abort early if it doesn't detected a pulledby mob.

## Testing Evidence

I've tested this and confirm the proc properly exits as expected.

## Why It's Good For The Game

Fixes a bug.