### PR TITLE
Gives Lunacy Embracers some traits and fixes a typo

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
@@ -15,7 +15,11 @@
 		TRAIT_STRONGBITE,
 		TRAIT_WOODWALKER,
 		TRAIT_NASTY_EATER,
-		TRAIT_CALTROPIMMUNE
+		TRAIT_CALTROPIMMUNE,
+		TRAIT_LONGSTRIDER,
+		TRAIT_OUTDOORSMAN,
+		TRAIT_WOODSMAN
+
 	)
 	subclass_stats = list(
 		STATKEY_STR = 3,
@@ -52,4 +56,4 @@
 
 	H.cmode_music = 'sound/music/combat_berserker.ogg'
 	to_chat(H, span_danger("You have abandoned your humanity to run wild under the moon. The call of nature fills your soul!"))
-	wretch_select_bounty(H) 
+	wretch_select_bounty(H)

--- a/code/modules/surgery/surgeries/mouth_to_mouth.dm
+++ b/code/modules/surgery/surgeries/mouth_to_mouth.dm
@@ -39,8 +39,8 @@
 
 /datum/surgery_step/mouth_to_mouth/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
 	display_results(user, target, span_notice("I attempt to breath air into [target]'s mouth."),
-			span_notice("[user] attempts to breath air into [target]'s mouth."),
-			span_notice("[user] attempts to breath air into [target]'s mouth."))
+			span_notice("[user] attempts to breathe air into [target]'s mouth."),
+			span_notice("[user] attempts to breathe air into [target]'s mouth."))
 	return TRUE
 
 /datum/surgery_step/mouth_to_mouth/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Gives LE's:
Experienced Woodsman: Which helps deal with their absolutely dogshit default perception, which makes me honestly think this was not included by accident. 
Gives them Longstrider, strengthening their territorial advantage and giving them a better chance of getting away without instantly being maneatered and thus, fragged.
Outdoorsman lets them sleep in trees comfortably. I thought it was odd they could not.


also i fixed a typo
## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
string addition, compiles
## Why It's Good For The Game
See description. It basically assists in increasing the home turf advantage embracers are allegedly supposed to have, but do not really feel as if they have. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
