### PR TITLE
fixes sleeves not appearing sometimes

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1861,6 +1861,14 @@ generate/load female uniform sprites matching all previously decided variables
 	//GENERATE NEW LIMBS
 	var/list/new_limbs = list()
 	var/hiden = FALSE //used to tell if we should hide boobs, basically
+	var/hidearms = FALSE //used to hide arm aux layer when clothing has integrated sleeves
+
+	// Check if any worn armor/shirt covers arms without sleeve overlays
+	if(wear_armor && (wear_armor.body_parts_covered & ARMS) && !wear_armor.sleeved)
+		hidearms = TRUE
+	if(wear_shirt && (wear_shirt.body_parts_covered & ARMS) && !wear_shirt.sleeved)
+		hidearms = TRUE
+
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/BP = X
 		if(BP.name == BODY_ZONE_CHEST)
@@ -1877,6 +1885,8 @@ generate/load female uniform sprites matching all previously decided variables
 				if(I.flags_inv & HIDEBOOB)
 					hiden = TRUE
 			new_limbs += BP.get_limb_icon(hideaux = hiden)
+		else if(BP.body_part == ARM_LEFT || BP.body_part == ARM_RIGHT)
+			new_limbs += BP.get_limb_icon(hideaux = hidearms)
 		else
 			new_limbs += BP.get_limb_icon()
 	if(new_limbs.len)


### PR DESCRIPTION
## About The Pull Request

- Fixes an oversight that caused certain items to generate an extra aux arm sprite that covered their sleeves when the character was facing EAST/WEST. This is due to the aux limb being intended to show the hand poking out of sleeves, but items that had inherited a "sleevestate" from a parent, but had their "sleeved" variable set to null were not handled correctly.

- This will have the side-effect of causing said items to appear to have sleeves that cannot be torn off and used for cloth (although the dismemberment mask will still remove them if someone loses an arm). I think this is a worthwhile tradeoff.

## Testing Evidence

<img width="107" height="140" alt="image" src="https://github.com/user-attachments/assets/76b4c912-9caa-441b-9888-80aeb1e4978e" />

## Why It's Good For The Game

It makes things looker more betterer.