### PR TITLE
Examination Hammer Added to Surgery Bags

### DIFF
--- a/modular_azurepeak/code/game/objects/items/surgery_bag.dm
+++ b/modular_azurepeak/code/game/objects/items/surgery_bag.dm
@@ -20,6 +20,7 @@
 		/obj/item/rogueweapon/surgery/retractor,
 		/obj/item/rogueweapon/surgery/bonesetter,
 		/obj/item/rogueweapon/surgery/cautery,
+		/obj/item/rogueweapon/surgery/hammer,
 		/obj/item/natural/bundle/cloth,
 		/obj/item/needle
 	)


### PR DESCRIPTION
## About The Pull Request
Adds the examination hammer to all other surgery bags. This means crafted surgery bags and towner physicians will have one in their bag now. Currently there are two varieties. 

## Testing Evidence
<img width="744" height="446" alt="hammerproof" src="https://github.com/user-attachments/assets/2b840406-bb73-495e-b9d6-c3aa7737ca2d" />

## Why It's Good For The Game
It's a one line change QoL feature, and it helps figure out what is wrong with people for those who do not have the diagnose spell. The main difference between this and the ones apothecaries/court physician get is the pestra needle now... and that's it.

I found it odd that towner physicians wouldn't have a hammer in their bag. Also, it was annoying trying to become an aspiring physician after grinding up treatment and ordering a bag, only to not have something to examine people with (other than your eyes and lots of wasted time) as you lacked the spell to do so. You still take a few seconds to figure it out as intended, but now you can actually doctor people a bit more quickly before they bleed out since you'll actually know what is wrong with them instead of playing 20 questions on their death bed.
