### PR TITLE
Task-based Necromancy (small necromancer QOL change) 

### DIFF
--- a/code/game/objects/items/rogueitems/necro_relics.dm
+++ b/code/game/objects/items/rogueitems/necro_relics.dm
@@ -20,6 +20,13 @@
 		to_chat(user, span_warning("The crystal thrums under your touch, but remains inert."))
 		return FALSE
 
+	// Ask the Necromancer for a task for the skeleton BEFORE the timer
+	var/tasks = list("TOIL","FIGHT","GUARD","SEEK")
+	var/tasks_choice = input(user, "WHAT IS THY BIDDING?", "IN HER NAME") as anything in tasks
+	if(!tasks_choice)
+		to_chat(user, span_warning("You must assign a task for your skeleton!"))
+		return FALSE
+
 	src.last_use_time = world.time
 
 	if(!do_after(user, 60, src))
@@ -38,7 +45,8 @@
 		to_chat(user, span_warning("The targeted location is blocked. My summon fails to come forth."))
 		return FALSE
 
-	var/list/candidates = pollGhostCandidates("Do you want to play as a Necromancer's skeleton?", ROLE_NECRO_SKELETON, null, null, 10 SECONDS, POLL_IGNORE_NECROMANCER_SKELETON)
+	var/necro_name = user.real_name ? user.real_name : user.name
+	var/list/candidates = pollGhostCandidates("The veil splits! A hand reaches forth! Serve [necro_name] in undeath as a Greater Skeleton? YOU WILL [tasks_choice]", ROLE_NECRO_SKELETON, null, null, 10 SECONDS, POLL_IGNORE_NECROMANCER_SKELETON)
 	if(!LAZYLEN(candidates))
 		to_chat(user, span_warning("The depths are hollow."))
 		return FALSE
@@ -72,9 +80,9 @@
 	set_light(2, 2, 1, l_color = "#551c1c")
 
 /mob/living/carbon/human/proc/choose_pronouns_and_body()
-    var/p_input = input(src, "Choose your character's pronouns", "Pronouns") as null|anything in GLOB.pronouns_list
+    var/p_input = input(src, "Choose your character's pronouns", "Pronouns") as anything in GLOB.pronouns_list
     if(p_input)
         src.pronouns = p_input
     if(alert(src, "Do you wish to change your frame?", "Body Type", "Yes", "No") == "Yes")
-        src.gender = (src.gender == "male") ? "female" : "male"
+	src.gender = (src.gender == MALE) ? FEMALE : MALE
     src.regenerate_icons()


### PR DESCRIPTION
## About The Pull Request
Port of: https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3952

> Necromancers now set a task for their Skeletons, before summoning. This is to give the potential Skeleton player a hint as to what their round might be like.

Unfortunately, not every Skeleton wants to be turned into a Mining Machine for an hour and a half.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="569" height="128" alt="494707229-7d097c39-8be8-4053-9fb5-016a6c69a614" src="https://github.com/user-attachments/assets/92266f83-9b52-42fb-bd64-098a4024b17b" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
<img width="588" height="55" alt="Screenshot 2025-10-03 192657" src="https://github.com/user-attachments/assets/027545b2-a29b-47ab-8dce-c541ea71cf9f" />

> skeletons won't be hot-dropping into an unknown battlefield. They'll at least get a sense of who they're working for, and what they'll be doing. This helps them invested, and might intrigue other players who might never play a skeleton.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
