### PR TITLE
Storage for martyr cloak. Martyr sword sharpness changes.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -371,14 +371,17 @@
 			if(STATE_SAFE)
 				end_activation = world.time + safe_duration	//Only a duration and nothing else.
 				adjust_stats(current_state)	//Lowers the damage of the sword due to safe activation.
+				I.max_blade_int = 500				//A burning sword shouldn't get dull easily.
 			if(STATE_MARTYR)
 				end_activation = world.time + martyr_duration
 				I.max_integrity = 2000				//If you're committing, we repair the weapon and give it a boost so it lasts the whole fight
+				I.max_blade_int = 2000
 				I.obj_integrity = I.max_integrity
 				adjust_stats(current_state)	//Gives them extra stats.
 			if(STATE_MARTYRULT)
 				end_activation = world.time + ultimate_duration
 				I.max_integrity = 9999				//why not, they got 2 mins anyway
+				I.max_blade_int = 9999
 				I.obj_integrity = I.max_integrity
 				current_holder.STASTR += stat_bonus_martyr
 				current_holder.STASPD += stat_bonus_martyr
@@ -693,6 +696,10 @@
 	flags_inv = HIDECROTCH|HIDEBOOB
 	var/overarmor = TRUE
 	sellprice = 300
+
+/obj/item/clothing/cloak/holysee/ComponentInitialize()
+    . = ..()
+    AddComponent(/datum/component/storage/concrete/roguetown/cloak)
 
 /obj/item/clothing/cloak/holysee/MiddleClick(mob/user)
 	overarmor = !overarmor


### PR DESCRIPTION
## About The Pull Request

Adds a storage to the martyr's cloak, like all cloaks should have.
Also makes their sword get a little more sharpness integrity when using safe-mode, and becoming high-undullable when committing to their oath.

## Testing Evidence

Soon:tm:

## Why It's Good For The Game

No more 40% sharpness on the martyr's sword after a few parries while they only have 6 or 2 minutes left to live.
