### PR TITLE
Tiny, Super Small, OCD Fix.

### DIFF
--- a/code/modules/clothing/masks/_masks.dm
+++ b/code/modules/clothing/masks/_masks.dm
@@ -9,8 +9,8 @@
 	var/mask_adjusted = 0
 	var/adjusted_flags = null
 
-	grid_width = 64
-	grid_height = 32
+	grid_width = 32
+	grid_height = 64
 
 /obj/item/clothing/mask/attack_self(mob/user)
 	if(CHECK_BITFIELD(clothing_flags, VOICEBOX_TOGGLABLE))


### PR DESCRIPTION
## About The Pull Request

Makes masks vertical by default, not horizontal.

## Testing Evidence

2 number swaps, if this fucks up we've got bigger problems.

## Why It's Good For The Game

I'm super fucking special in the head and I will go insane, look at the sprite and tell me it should be horizontal without lying through your teeth.
