### PR TITLE
Gold/silverface random item fix

### DIFF
--- a/code/modules/roguetown/roguemachine/merchant/goldface.dm
+++ b/code/modules/roguetown/roguemachine/merchant/goldface.dm
@@ -151,7 +151,7 @@
 		var/shoplength = PA.contains.len
 		var/l
 		for(l=1,l<=shoplength,l++)
-			var/pathi = pick(PA.contains)
+			var/pathi = PA.contains[l] //DM uses hashing to determine list ordering, so this is normally a bad idea, but we just want every item in the list.
 			new pathi(get_turf(M))
 	if(href_list["change"])
 		if(budget > 0)


### PR DESCRIPTION
## About The Pull Request

Fixes gold/silverfaces giving random items. What was happening here was that, for an amount of times equal to the number of items in the list of a purchased item, it would pick a random item in that list and drop it on the ground. This is fine for homogenous lists but anything with unique items (old polishing kits we don't use, tea sets, etc etc) had a pretty good chance of not giving you what you wanted. This fixes that.

## Testing Evidence

Fixed this twice on two different servers. Pic is here.



## Why It's Good For The Game

Nobody wants to purchase the fuck-you-death katana for 2.3e+293 mammon and then get two sheathes.