### PR TITLE
Priest-from-750-to-500-announcement

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -275,15 +275,15 @@ GLOBAL_LIST_EMPTY(heretical_players)
 	set category = "Priest"
 	if(stat)
 		return
-	if(!(devotion && devotion.devotion >= 750))
-		to_chat(src, span_warning("I need more devotion to channel Her voice! (750 required)"))
+	if(!(devotion && devotion.devotion >= 500))
+		to_chat(src, span_warning("I need more devotion to channel Her voice! (500 required)"))
 		return FALSE
 	var/inputty = input("Make an announcement", "SCARLET REACH") as text|null
 	if(inputty)
 		if(!istype(get_area(src), /area/rogue/indoors/town/church/chapel))
 			to_chat(src, span_warning("I need to do this from the chapel."))
 			return FALSE
-		devotion.update_devotion(-750)
+		devotion.update_devotion(-500)
 		priority_announce("[inputty]", title = "The Priest Speaks", sound = 'sound/misc/bell.ogg', sender = src)
 
 /mob/living/carbon/human/proc/churcheapostasy(var/mob/living/carbon/human/H in GLOB.player_list)


### PR DESCRIPTION
## About The Pull Request

750 is a bit much, 500 seems more reasonable

## Testing Evidence

just number changes

## Why It's Good For The Game

rn, it takes like forever for priest to get to announce, so just bring it down to 500 to encourage Priests to change miracle set more to just practice every single set in the Tenth. 