### PR TITLE
Gives Hunters Athletics

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
@@ -22,6 +22,7 @@
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,


### PR DESCRIPTION
## About The Pull Request
What the title says... They didn't have it before.

## Testing Evidence
<img width="291" height="109" alt="Hunter" src="https://github.com/user-attachments/assets/ed7bf642-2601-4237-a8e6-1747552c68dc" />

## Why It's Good For The Game
Fisherman, potter, and a few other towners have athletics between apprentice and journeyman. It makes sense for a hunter to have it too, as their job is physically tiring. Before they had absolutely none. Let me know if you would prefer this at apprentice... but for now it's journeyman like fishers.
