### PR TITLE
Zwei/Estoc on back tweak

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -903,6 +903,8 @@
 				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 			if("altgrip")
 				return list("shrink" = 0.6,"sx" = 4,"sy" = 0,"nx" = -7,"ny" = 1,"wx" = -8,"wy" = 0,"ex" = 8,"ey" = -1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -135,"sturn" = -35,"wturn" = 45,"eturn" = 145,"nflip" = 8,"sflip" = 8,"wflip" = 1,"eflip" = 0)
+			if("onback")
+				return list("shrink" = 0.6,"sx" = -1,"sy" = 2,"nx" = 0,"ny" = 2,"wx" = 2,"wy" = 1,"ex" = 0,"ey" = 1,"nturn" = 0,"sturn" = 0,"wturn" = 70,"eturn" = 15,"nflip" = 1,"sflip" = 1,"wflip" = 1,"eflip" = 1,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
 
 /obj/item/rogueweapon/greatsword/equipped(mob/user, slot, initial = FALSE)
 	pickup_sound = pickup_sound
@@ -1118,7 +1120,30 @@
 					"wflip" = 8,
 					"eflip" = 0,
 					)
-
+			if("onback")
+				return list(
+					"shrink" = 0.6,
+					"sx" = -1,
+					"sy" = 2,
+					"nx" = 0,
+					"ny" = 2,
+					"wx" = 2,
+					"wy" = 1,
+					"ex" = 0,
+					"ey" = 1,
+					"nturn" = 0,
+					"sturn" = 0,
+					"wturn" = 70,
+					"eturn" = 15,
+					"nflip" = 1,
+					"sflip" = 1,
+					"wflip" = 1,
+					"eflip" = 1,
+					"northabove" = 1,
+					"southabove" = 0,
+					"eastabove" = 0,
+					"westabove" = 0,
+					)
 
 /obj/item/rogueweapon/estoc/equipped(mob/user, slot, initial = FALSE)
 	pickup_sound = pickup_sound


### PR DESCRIPTION
## About The Pull Request

Tweaks the orientation of the Zwei/Estoc on back so it doesn't looks weird.
As it looked with the Greatsword Straps.

## Testing Evidence

Before
<img width="57" height="68" alt="image" src="https://github.com/user-attachments/assets/4e705c1d-011b-45b2-a8d3-e0c2334168b2" />
<img width="76" height="66" alt="image" src="https://github.com/user-attachments/assets/0494fe9a-7a75-4d13-8965-1b3c8b6d1b2d" />

After
<img width="75" height="70" alt="image" src="https://github.com/user-attachments/assets/f6b047cb-7c90-4b80-bf11-e8514f8f3251" />
<img width="78" height="87" alt="image" src="https://github.com/user-attachments/assets/4bbe943e-95e8-4c9d-bf8d-3f252175ab18" />

## Why It's Good For The Game

Its how it used to look before the remove of Straps, looks better like this.
