### PR TITLE
Halves 'Leap' Spell Cooldown

### DIFF
--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/leap.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/leap.dm
@@ -5,7 +5,7 @@
 	releasedrain = 35
 	chargedrain = 1
 	chargetime = 1 SECONDS
-	recharge_time = 2 MINUTES
+	recharge_time = 1 MINUTES
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE


### PR DESCRIPTION
## About The Pull Request

Reduces the leap cooldown from 2 minutes to 1 minute. 

## Testing Evidence

<img width="1068" height="767" alt="image" src="https://github.com/user-attachments/assets/0a689a48-b8da-41f5-8101-d6cc88de753f" />


## Why It's Good For The Game

Leap has some fun functionality for letting mages get places they usually shouldn't be able to get, but the 2 minute cooldown makes it punishing to use to really navigate anywhere with. Especially with time dilation later in the round, you can be waiting ages for leap to come off cooldown. 1 minute is still a sizeable chunk of time, so guards won't have to deal with jester-tier casters hopping around constantly, but hopefully short enough that leap is worth the spellpoint investment.

Also, we have characters who can just fly at will now, so if someone really wanted to abuse Z-levels they'd just make a harpy caster. 
