### PR TITLE
Virtue: Blueblood

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -10,6 +10,20 @@
 	var/obj/item/pouch = new /obj/item/storage/belt/rogue/pouch/coins/virtuepouch(get_turf(recipient))
 	recipient.put_in_hands(pouch, forced = TRUE)
 
+/datum/virtue/utility/blueblooded
+    name = "Blueblooded"
+    desc = "I have been raised since birth in the throes of a noble lineage, and bear exceptional beauty and the social standing to show for it - though none of the material benefits."
+    added_traits = list(TRAIT_NOBLE, TRAIT_BEAUTIFUL, TRAIT_GOODLOVER)
+    added_skills = list(list(/datum/skill/misc/reading, 1, 6))
+    added_stashed_items = list("Heirloom Amulet" = /obj/item/clothing/neck/roguetown/ornateamulet/noble, "Hand Mirror" = /obj/item/handmirror)
+
+/datum/virtue/utility/blueblooded/handle_traits(mob/living/carbon/human/recipient)
+	..()
+	if(HAS_TRAIT(recipient, TRAIT_UNSEEMLY))
+		to_chat(recipient, "Your social grace is cancelled out! You become normal.")
+		REMOVE_TRAIT(recipient, TRAIT_BEAUTIFUL, TRAIT_VIRTUE)
+		REMOVE_TRAIT(recipient, TRAIT_UNSEEMLY, TRAIT_VIRTUE)
+
 /datum/virtue/utility/socialite
 	name = "Socialite"
 	desc = "I thrive in social settings, easily reading the emotions of others and charming those around me. My presence is always felt at any gathering."


### PR DESCRIPTION
## About The Pull Request

Adds the virtue 'Blueblood' which gives you the noble trait, beautiful and goodlover. You don't, however, get your daily income or your rich pouch. Designed for characters who want to roleplay having noble blood but not the resources of a noble house - exiled nobles, stuff like that. 

## Testing Evidence

<img width="464" height="325" alt="image" src="https://github.com/user-attachments/assets/284122fe-2258-4b24-8f81-64c9cc22853f" />
<img width="309" height="260" alt="image" src="https://github.com/user-attachments/assets/f8786b06-9bd0-4ae3-91a9-ed49de67b734" />
<img width="508" height="289" alt="image" src="https://github.com/user-attachments/assets/056c8f99-4e2a-47e1-abab-82f2f550b460" />


## Why It's Good For The Game

Gives players more options for how they want to roleplay noble characters, allowing them to choose if they want the material benefits or not. Also bundles beautiful with nobility, which are two commonly chosen virtues that don't have extreme gameplay impact but are flavorful. 