### PR TITLE
Grenzelhoft drip allowance

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -1902,7 +1902,7 @@
 	item_state = "grenzelhat"
 	icon = 'icons/roguetown/clothing/head.dmi'
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/stonekeep_merc.dmi'
-	slot_flags = ITEM_SLOT_HEAD
+	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK
 	detail_tag = "_detail"
 	altdetail_tag = "_detailalt"
 	dynamic_hair_suffix = ""


### PR DESCRIPTION
## About The Pull Request

Allows the Grenzelhoft hat to be worn on the mask slot. Allowing helmet + Hat. The hat is a SYMBOL of Grenzelhoft Mercs, they should be able to wear it without sacrificing protection.

## Testing Evidence

## Why It's Good For The Game

Drip ++