### PR TITLE
Takes away the Omega-3 from Muscular's protein shake.(Muscular nerf)

### DIFF
--- a/modular_azurepeak/statpacks/physical.dm
+++ b/modular_azurepeak/statpacks/physical.dm
@@ -8,7 +8,7 @@
 /datum/statpack/physical/muscular
 	name = "Muscular"
 	desc = "Hard labor has honed you into a mass of sinew - a valuable trait in a world where might makes right."
-	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 1, STAT_INTELLIGENCE = 1, STAT_SPEED = -2)
+	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 1, STAT_PERCEPTION = -1, STAT_SPEED = -2)
 
 /datum/statpack/physical/tactician
 	name = "Alert"


### PR DESCRIPTION
## About The Pull Request

Muscular no longer provides 1 INT(+2STR, +1CON, +1INT, -2SPD) but instead reduces your PER for 1 point(+2STR, +1CON, -1PER, -2SPD).

## Testing Evidence

Just a 1-line code change.

## Why It's Good For The Game

Explain to me with pears and apples of why shouldn't be nerfed a statpack in the physical group that offers good stats like Strength, Constitution and Intelligence together in trade of 2 points of your Speed?