### PR TITLE
Bandit Smelting/Selling Nerf

### DIFF
--- a/code/modules/roguetown/roguemachine/hoardmaster.dm
+++ b/code/modules/roguetown/roguemachine/hoardmaster.dm
@@ -68,6 +68,14 @@
 			var/pathi = pick(PA.contains)
 			var/atom/hmasteritem = new pathi(get_turf(M))
 			hmasteritem.flags_1 |= HOARDMASTER_SPAWNED_1
+
+			if (istype(hmasteritem, /obj/item))
+				var/obj/item/newitem = hmasteritem
+				newitem.sellprice = 0
+				if(newitem.smeltresult)
+					newitem.smeltresult = /obj/item/ash
+				if(newitem.salvage_result)
+					newitem.salvage_result = /obj/item/ash
 	if(href_list["changecat"])
 		current_cat = href_list["changecat"]
 	return attack_hand(usr)


### PR DESCRIPTION
## About The Pull Request

Items spawned by the hoardmaster will now smelt and salvage into ashes, if they smelted or salvaged into anything.

Hoardmaster spawned items that shatter into debris also shatter into ashes. This prevents using hoardmaster potion bottles for a similar exploit involving glass shards and pottery. It's also just consistent.

Items spawned by the hoardmaster also no longer have sell value. Just in case.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="539" height="332" alt="image" src="https://github.com/user-attachments/assets/39105981-c0f0-4821-8499-bc5bd6aaa6b5" />

<img width="313" height="271" alt="image" src="https://github.com/user-attachments/assets/bd2b6d9d-4974-4e77-8825-6868bf085e7a" />



<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

A huge blow to banditnomics and the exploiting of hoardmaster mechanics to generate infinite wealth loops. Also a bit cooler and more immersive than just "You can't smelt that". No! It turns to ASH!

Malum spits upon thee, Matthiosan. The craft is withdrawn from thee, thou works shall turn to ash between thy fingers.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
