### PR TITLE
Giant Virtue Buff

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1151,6 +1151,7 @@
 	var/mob/living/L = pulledby
 	var/combat_modifier = 1
 	var/agg_grab = FALSE
+	var/size_diff = 0
 
 	if(!L) // we're pulling ourself, abort
 		return FALSE
@@ -1159,6 +1160,11 @@
 		wrestling_diff += (get_skill_level(/datum/skill/combat/wrestling)) //NPCs don't use this
 	if(L.mind)
 		wrestling_diff -= (L.get_skill_level(/datum/skill/combat/wrestling))
+
+	if(HAS_TRAIT(src,TRAIT_BIGGUY))
+		size_diff++
+	if(HAS_TRAIT(L,TRAIT_BIGGUY))
+		size_diff--
 	if(L.grab_state > GRAB_PASSIVE)
 		agg_grab = TRUE
 
@@ -1181,6 +1187,8 @@
 			combat_modifier -= 0.15
 
 	resist_chance += max((wrestling_diff * 10), -20)
+	resist_chance += size_diff * 10 //20% better chance if you're bigger, -20% chance if they are. Size matters.
+
 	if(HAS_TRAIT(src, TRAIT_GARROTED))
 		resist_chance += (STACON - L.STASPD) * 5
 	else

--- a/modular_azurepeak/virtues/size.dm
+++ b/modular_azurepeak/virtues/size.dm
@@ -1,10 +1,13 @@
 /datum/virtue/size/giant
 	name = "Giant"
-	desc = "I've always been larger, stronger and hardier than the average person. I tend to lumber around a lot, and my immense size can break down frail, wooden doors."
+	desc = "I've always been larger, stronger and hardier than the average person. I tend to lumber around a lot. Very little can escape my holds, and my immense size can break down frail, wooden doors. +1 STR, +1 CON, -1 SPD"
 	added_traits = list(TRAIT_BIGGUY)
 	custom_text = "Increases your sprite size."
 
 /datum/virtue/size/giant/apply_to_human(mob/living/carbon/human/recipient)
+	recipient.change_stat("strength", 1)
+	recipient.change_stat("constitution", 1)
+	recipient.change_stat("speed",-1)
 	recipient.transform = recipient.transform.Scale(1.25, 1.25)
 	recipient.transform = recipient.transform.Translate(0, (0.25 * 16))
 	recipient.update_transform()


### PR DESCRIPTION
* Makes Giant a better virtue by improving its grappling ability against smaller targets and slightly increasing STR/CON while slightly reducing SPD.

## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
As it is right now, Giant isn't great beyond the meme value of being big. It's pretty taxing HP-wise to ram through doors and I haven't ever really found a scenario that benefitted from being able to throw someone on a non-reinforced grab. I propose it be made a little more impactful by making it add some strength/con and reduce speed, as well as give them an edge in grapples.
## Testing Evidence
<img width="595" height="268" alt="image" src="https://github.com/user-attachments/assets/f3924920-a419-4435-83e1-75c545b32541" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Size matters in a fight. I think it should matter in-game, too. Giant is a really cool trait and I think it's potential is wasted in its current state.
