### PR TITLE
Fixes missing storage component on dice pouches

### DIFF
--- a/code/datums/components/storage/storage_types.dm
+++ b/code/datums/components/storage/storage_types.dm
@@ -182,3 +182,12 @@
 	screen_max_rows = 8
 	screen_max_columns = 6
 
+/datum/component/storage/concrete/roguetown/dice_pouch
+	screen_max_rows = 4
+	screen_max_columns = 2
+	max_w_class = WEIGHT_CLASS_TINY
+	not_while_equipped = FALSE
+
+/datum/component/storage/concrete/roguetown/dice_pouch/New(datum/P, ...)
+	. = ..()
+	can_hold = typecacheof(list(/obj/item/dice))

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -18,6 +18,7 @@
 				/obj/item/dice/fourdd6,
 				/obj/item/dice/d100
 				)
+	component_type = /datum/component/storage/concrete/roguetown/dice_pouch
 
 /obj/item/storage/pill_bottle/dice/PopulateContents()
 	new /obj/item/dice/d4(src)


### PR DESCRIPTION
## About The Pull Request

Fixes a stupid omission that made dice pouches 1 space 64 slot containers. Probably originated from the tgstation debloat AP did a long time ago - the pill_bottle subtype was eradicated (for obvious reasons) and was resorting to default.

Admins should've killed the guy abusing this until he stopped moving, for what it's worth.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="705" height="756" alt="image" src="https://github.com/user-attachments/assets/0c8b65d6-9474-4b6a-86ce-88e096f4ab97" />

<img width="316" height="199" alt="image" src="https://github.com/user-attachments/assets/a952e97e-6f44-4b4c-be08-8606b46d6a42" />

<img width="533" height="119" alt="image" src="https://github.com/user-attachments/assets/f0416325-ca63-41bf-8f5f-39ffd572b1ae" />

## Why It's Good For The Game

I don't think this needs explanation.
