### PR TITLE
Adds craftable sack masks

### DIFF
--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -1272,16 +1272,9 @@ datum/crafting_recipe/roguetown/sewing/Purdress
 	tools = list(/obj/item/needle)
 	craftdiff = 3
 
-/datum/crafting_recipe/roguetown/sewing/sackmask/psy2
-	name = "psydonian sack mask (ritual chalk)"
-	result = list(/obj/item/clothing/mask/rogue/sack/psy)
-	reqs = list(/obj/item/clothing/mask/rogue/sack = 1)
-	tools = list(/obj/item/ritechalk)
-	craftdiff = 0
-
-/datum/crafting_recipe/roguetown/sewing/sackmask/psy1
+/datum/crafting_recipe/roguetown/sewing/sackmask/psy
 	name = "psydonian sack mask (chalk)"
 	result = list(/obj/item/clothing/mask/rogue/sack/psy)
 	reqs = list(/obj/item/clothing/mask/rogue/sack = 1)
-	tools = list(/obj/item/chalk)
+	tools = list(/obj/item/ritechalk)
 	craftdiff = 0


### PR DESCRIPTION
## About The Pull Request
Lets you make sack masks with sewing skill, 2 cloth and 3 leather, as well as letting you draw a psycross on them with chalk (via crafting)
Adjusted to work alongside #1142 
## Testing Evidence
<img width="581" height="175" alt="image" src="https://github.com/user-attachments/assets/5a165aae-0a78-4c90-9953-4dcf79e372ca" />

## Why It's Good For The Game
face coverage alternative that is by far weaker than the metal masks in both durability and protection, in exchange for being semi decently accessible, as well as just serving as a good option to hide your face OR show your affection for Psydon by drawing a psycross on it. Shouldnt be a balance issue at all
