### PR TITLE
Prolong Round verb for admins

### DIFF
--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -575,7 +575,7 @@ SUBSYSTEM_DEF(gamemode)
 	var/ttime = world.time - SSticker.round_start_time
 	if(ttime >= GLOB.round_timer)
 		if(roundvoteend)
-			if(ttime >= round_ends_at)
+			if(world.time >= round_ends_at)
 				return TRUE
 		else
 			if(!SSvote.mode)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -155,7 +155,7 @@ SUBSYSTEM_DEF(vote)
 			if("endround")
 				if(. == "Continue Playing")
 					log_game("LOG VOTE: CONTINUE PLAYING AT [REALTIMEOFDAY]")
-					GLOB.round_timer = GLOB.round_timer + ROUND_EXTENSION_TIME
+					GLOB.round_timer = world.time + ROUND_EXTENSION_TIME
 				else
 					log_game("LOG VOTE: ELSE  [REALTIMEOFDAY]")
 					log_game("LOG VOTE: ROUNDVOTEEND [REALTIMEOFDAY]")
@@ -389,7 +389,12 @@ SUBSYSTEM_DEF(vote)
 			return
 		if("cancel")
 			if(usr.client.holder)
+				if(mode == "endround")
+					GLOB.round_timer = world.time + ROUND_EXTENSION_TIME // admin cancels an endround, defaults to same as continue playing
+					log_admin("[key_name(usr)] canceled end round vote.")
+					message_admins("[key_name(usr)] canceled end round vote.")
 				reset()
+
 		if("toggle_restart")
 			if(usr.client.holder && trialmin)
 				CONFIG_SET(flag/allow_vote_restart, !CONFIG_GET(flag/allow_vote_restart))

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -889,3 +889,30 @@
 			M.set_resting(FALSE, TRUE)
 
 	message_admins("[key_name(usr)] used Toggle Wake In View.")
+
+GLOBAL_VAR_INIT(extend_round_timestamp, 0)
+/datum/admins/proc/extend_round()
+	set name = "Extend Round"
+	set category = "-Server-"
+	set hidden = FALSE
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(alert("Prolong the end of the round by 30 minutes. This delays the vote, or delays the end after the vote is successful. Are you sure?",,"Yes","Cancel") == "Cancel")
+		return
+
+	if(world.time < GLOB.extend_round_timestamp + (1 MINUTES))
+		to_chat(usr, "<span class='notice'>Someone recently pressed this button! Wait a minute before pressing it again.</span>")
+		return
+
+	if((GLOB.round_timer > world.time + (3 * ROUND_EXTENSION_TIME)) || SSgamemode.round_ends_at - world.time > (3 * ROUND_EXTENSION_TIME))
+		to_chat(usr, "<span class='notice'>Failsafe! Round end is already over 3 times out! Ignoring.</span>")
+		return
+	if(SSgamemode.round_ends_at != 0) // End round is already ticking.
+		SSgamemode.round_ends_at += ROUND_EXTENSION_TIME
+	else //We push back the automated endround vote.
+		GLOB.round_timer = GLOB.round_timer + ROUND_EXTENSION_TIME
+	log_admin("[key_name(usr)] extended the round by 30 minutes.")
+	message_admins("[key_name(usr)] extended the round by 30 minutes.")
+	GLOB.extend_round_timestamp = world.time

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -112,6 +112,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/discord_id_manipulation, /* No Discord implementation? */
 	/datum/admins/proc/sleep_view,
 	/datum/admins/proc/wake_view,
+	/datum/admins/proc/extend_round,
 	)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(
 	/client/proc/unban_panel,

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -783,8 +783,7 @@ GLOBAL_VAR_INIT(mobids, 1)
 /mob/Stat()
 	..()
 	// && check_rights(R_ADMIN,0)
-	var/ticker_time = world.time - SSticker.round_start_time
-	var/time_left = SSgamemode.round_ends_at - ticker_time
+	var/time_left = SSgamemode.round_ends_at - world.time
 	if(client && client.holder)
 		if(statpanel("Status"))
 			if (client)


### PR DESCRIPTION
## About The Pull Request
https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/4127

>"Gives admins a verb that will delay the end of the round by thirty minutes - either by pushing the 3 hour vote 30 minutes ahead, or pushing the end state 30 minutes ahead if the vote is successful and currently ticking."


>"Also fixes a bug with end round votes being canceled and then hurry-up preempting on subsequent end round votes."


<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
[500221467-8c1087de-a92d-431d-a75d-3cf406ee9125.webm](https://github.com/user-attachments/assets/1e1800c4-ecf3-4990-90d2-ee978c74ee28)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
We did not have one before and its helpful for anything related to events or ongoing roleplay.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
