### PR TITLE
Removes Lamia racelocks on Soilson, Innkeep, Tailor and Servant

### DIFF
--- a/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
@@ -10,9 +10,6 @@
 	selection_color = JCOLOR_PEASANT
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
-	disallowed_races = list(
-		/datum/species/lamia,
-	)
 	cmode_music = 'sound/music/combat_soilson.ogg'
 
 	tutorial = "It is a simple life you live, your basic understanding of life is something many would be envious of if they knew just how perfect it was. You know a good day's work, the sweat on your brow is yours: Famines and plague may take their toll, but you know how to celebrate life well. Till the soil and produce fresh food for those around you, and maybe you'll be more than an unsung hero someday."

--- a/code/modules/jobs/job_types/roguetown/yeomen/barkeep.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/barkeep.dm
@@ -7,10 +7,6 @@
 	spawn_positions = 1
 
 	allowed_races = RACES_ALL_KINDS
-	disallowed_races = list(
-		/datum/species/lamia,
-	)
-
 	tutorial = "Adventurers and warriors alike have two exit plans; the early grave or even earlier retirement. As the proud owner of this fine establishment, you took the latter: The Scarlet Pint, tavern, inn, and bathhouse! You even have an assortment of staff to help you, and plenty of business from the famished townsfolk looking to eat, weary travelers looking to rest, and characters of dubious repute seeking their own sort of success. Your bladework has gotten a little rusty, and the church across the street gives you the odd evil eye for the extra 'delights' of the bathhouse--but, well...you can't win 'em all!"
 
 	outfit = /datum/outfit/job/roguetown/barkeep

--- a/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
@@ -10,9 +10,6 @@
 	min_pq = 0
 	selection_color = JCOLOR_YEOMAN
 	allowed_races = RACES_ALL_KINDS
-	disallowed_races = list(
-		/datum/species/lamia,
-	)
 	display_order = JDO_TAILOR
 	outfit = /datum/outfit/job/roguetown/tailor
 	give_bank_account = 16

--- a/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
@@ -7,9 +7,6 @@
 	total_positions = 6
 	spawn_positions = 6
 	allowed_races = RACES_ALL_KINDS
-	disallowed_races = list(
-		/datum/species/lamia,
-	)
 	tutorial = "Granted a life of comfortable servitude in the Duke's manor, you follow the Seneschal's commands and spend your day performing necessary but menial tasks. This role offers an aesthetic choice between labor-servant, maid, and butler."
 	outfit = /datum/outfit/job/roguetown/servant
 	advclass_cat_rolls = list(CTAG_SERVANT = 20)


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin

## Testing Evidence

It's an extremely small change feel free to shoot it down if you think it's tested insufficiently

## Why It's Good For The Game

Lamia are more discriminated against than goblins, kobolds and verminkin. I think they've been in the game long enough to relax a few of these.

The following roles have all races allowed EXCEPT Lamia (and sometimes harpy):
Innkeep, Tailor, Soilson, Jester, Archivist, Druid, Guildmaster, Village Chief

Jester I don't especially want to mess with, the jester meta is alien to me
Archivist and Guildmaster are actually lowkey power classes that I understand wanting to restrict (even if goblins and kobolds can be them)
Druid is pretty tied with Dendor, until they add an Abyssor Druid variant, big whatever.
Village Chief is explicitly a town elder that the townies and even keep RP as having known for a long time, lamias being relatively recent arrivals, sure, why not. There are old goblins and kobolds for this role but no old lamia, whatever.

Innkeep is a retired adventurer, doesn't make much sense they'd be flat out denied the ability to own a business when goblins and kobolds can hold the same position. 
Tailor and soilson are just JOBS someone skilled at the task can have.
Servants again have the whole 'well goblins and kobolds can do it' argument. I don't know what makes lamias specifically the ultimate bottom of the barrel scum of the earth. 