### PR TITLE
adds a sanity check for hole digging when there's a spike pit

### DIFF
--- a/code/modules/roguetown/roguejobs/gravedigger/tools.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/tools.dm
@@ -80,7 +80,7 @@
 				if(D.holie)
 					D.holie.attackby(src, user)
 				else
-					if(istype(T, /turf/open/floor/rogue/dirt/road))
+					if(istype(T, /turf/open/floor/rogue/dirt/road) && !locate(/obj/structure/spike_pit) in T)//No double holing a spike pit you fuck.
 						new /obj/structure/closet/dirthole(T)
 					else
 						T.ChangeTurf(/turf/open/floor/rogue/dirt/road, flags = CHANGETURF_INHERIT_AIR)
@@ -89,9 +89,9 @@
 					update_icon()
 			return
 		if(heldclod)
-			if(istype(T, /turf/open/water))
+			if(istype(T, /turf/open/water/swamp)) //No filling the ocean for you.
 				qdel(heldclod)
-//				T.ChangeTurf(/turf/open/floor/rogue/dirt/road, flags = CHANGETURF_INHERIT_AIR)
+				T.ChangeTurf(/turf/open/floor/rogue/dirt/road, flags = CHANGETURF_INHERIT_AIR)
 			else
 				heldclod.forceMove(T)
 			heldclod = null


### PR DESCRIPTION
uncomments some unflooding code. The wardens will love this.
Speedmerge please.

## About The Pull Request
you cannot dig a hole over a pit of spikes anymore.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
it compiles. the syntax is correct.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
<img width="353" height="263" alt="image" src="https://github.com/user-attachments/assets/aa61f4b9-e679-446c-a05f-360e16719d2a" />

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
