### PR TITLE
Flailing my way downtown 

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -52,11 +52,11 @@
 /datum/intent/flail/strike/smash
 	name = "smash"
 	chargetime = 5
-	chargedrain = 2
+	chargedrain = 1
 	no_early_release = TRUE
 	penfactor = BLUNT_DEFAULT_PENFACTOR
 	recovery = 10
-	damfactor = 1.6
+	damfactor = 1.9
 	chargedloop = /datum/looping_sound/flailswing
 	keep_looping = TRUE
 	icon_state = "insmash"
@@ -69,7 +69,7 @@
 	reach = 2
 
 /datum/intent/flail/strike/smash/militia
-	damfactor = 1.35
+	damfactor = 1.4
 
 /datum/intent/flail/strike/smash/golgotha
 	hitsound = list('sound/items/beartrap2.ogg')
@@ -126,6 +126,8 @@
 	name = "swift journey"
 	desc = "The striking head is full of teeth, rattling viciously with ever strike, with every rotation. Each set coming from one the wielder has laid to rest. Carried alongside them as a great show of respect."
 	icon_state = "necraflail"
+    force = 35
+	is_silver = TRUE
 
 /obj/item/rogueweapon/flail/sflail/psyflail
 	name = "ornate flail"


### PR DESCRIPTION
## About The Pull Request

Added more dmg to the flail and reduced the drain by half. Also added more force to the necran unique flail and the silver trait.

## Testing Evidence

25 force was feeling very underwhelming for the weapon that has 0 defense, and it was a ABUSRD stamina drain for anyone to use it.

## Why It's Good For The Game

Blunt weapons have been in the limbo for a good while now. These changes will perhaps make it more reliable, with the blunt changes coming it will aid in the work on draining armor integrity, it is a FULLY offensive weapon so should be alright. Gave also silver trait to the holy necran weapon since the goddess whole gimmick is fighting the undead/lickers so it would make sense, also gave it a bit more force than the normal flail.

Not quite sure if I should keep the drain at 2 or 1, testing in my own run 1 seemed fine but I still want to hear some opinions.

Changes based on AP numbers btw
