### PR TITLE
Auto-select subclass when there's only one.

### DIFF
--- a/code/controllers/subsystem/rogue/role_class_handler/class_select_handler/class_select_handler.dm
+++ b/code/controllers/subsystem/rogue/role_class_handler/class_select_handler/class_select_handler.dm
@@ -63,12 +63,14 @@
 	var/register_id = null
 
 
-// The normal route for first use of this list.
+/// The normal route for first use of this list. Returns TRUE if there is more than one advclass (need user input), FALSE - if just one (no need for select menu)
 /datum/class_select_handler/proc/initial_setup()
 	if(register_id)
 		SSrole_class_handler.add_class_register_listener(register_id, linked_client.mob)
-	assemble_the_CLASSES()
+	if(!assemble_the_CLASSES())
+		return FALSE
 	second_step()
+	return TRUE
 
 // The second step, aka we just want to make sure the resources are there and that the menu is being displayed
 /datum/class_select_handler/proc/second_step()
@@ -89,6 +91,7 @@
 	. = ..()
 
 // I hope to god you have a client before you call this, cause the checks on the SS
+/// Returns TRUE if there is more than one advclass, FALSE - if just one (no need for select menu)
 /datum/class_select_handler/proc/assemble_the_CLASSES()
 	var/mob/living/carbon/human/H = linked_client.mob
 
@@ -160,6 +163,12 @@
 	if(!rolled_classes.len)
 		linked_client.mob.returntolobby()
 		message_admins("CLASS_SELECT_HANDLER HAD PERSON WITH 0 CLASS SELECT OPTIONS. THIS IS REALLY BAD! RETURNED THEM TO LOBBY")
+
+	if(rolled_classes.len == 1)
+		SSrole_class_handler.finish_class_handler(linked_client.mob, pick(rolled_classes), src, plus_power, special_selected)
+		return FALSE
+
+	return TRUE
 
 // Something is calling to tell this datum a class it rolled is currently maxed out.
 // More shitcode!

--- a/code/controllers/subsystem/rogue/role_class_handler/role_class_handler.dm
+++ b/code/controllers/subsystem/rogue/role_class_handler/role_class_handler.dm
@@ -109,7 +109,8 @@ SUBSYSTEM_DEF(role_class_handler)
 				XTRA_MEATY.special_session_queue += XTRA_SPECIAL
 
 	XTRA_MEATY.register_id = register_id
-	XTRA_MEATY.initial_setup()
+	if(!XTRA_MEATY.initial_setup())
+		return // There was just one advclass that got automatically selected
 	class_select_handlers[H.client.ckey] = XTRA_MEATY
 
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -499,6 +499,7 @@ SUBSYSTEM_DEF(ticker)
 				S.Fade(TRUE)
 			livings += living
 			if(ishuman(living))
+				SSrole_class_handler.setup_class_handler(living)
 				try_apply_character_post_equipment(living)
 		else
 			continue

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -253,6 +253,9 @@
 			else
 				GLOB.actors_list[H.mobid] = "[H.real_name] as [H.mind.assigned_role]<BR>"
 
+	if(islist(advclass_cat_rolls))
+		hugboxify_for_class_selection(H)
+
 /client/verb/set_mugshot()
 	set category = "OOC"
 	set name = "Set Credits Mugshot"

--- a/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
@@ -42,14 +42,6 @@
 		/datum/advclass/absolver
 	)
 
-/datum/job/roguetown/absolver/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/absolver
 	name = "Absolver"
 	tutorial = "The Orthodoxy claims you are naught more than a 'cleric', but you know the truth; you are a sacrifical lamb. Your hands, unmarred through prayer and pacifism, have been gifted with the power to manipulate lux - to siphon away the wounds of others, so that you may endure in their stead. Let your censer's light shepherd the Inquisitor's retinue forth, lest they're led astray by wrath and temptation."

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthodoxist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthodoxist.dm
@@ -33,13 +33,3 @@
 		/datum/advclass/disciple,
 		/datum/advclass/confessor
 	)
-
-/datum/job/roguetown/orthodoxist/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(L)
-		var/mob/living/carbon/human/H = L
-		if(!H.mind)
-			return
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")

--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -40,15 +40,6 @@
 	job_bitflag = BITFLAG_CHURCH	//Counts as church.
 	allowed_patrons = list(/datum/patron/old_god)
 
-/datum/job/roguetown/puritan/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	. = ..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
-
 ////Classic Inquisitor with a much more underground twist. Use listening devices, sneak into places to gather evidence, track down suspicious individuals. Has relatively the same utility stats as Confessor, but fulfills a different niche in terms of their combative job as the head honcho. 
 
 /datum/advclass/puritan/inspector

--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -75,18 +75,6 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 		/datum/advclass/foreigner/yoruku,
 	)
 
-/datum/job/roguetown/adventurer/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(L)
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
-		if(GLOB.adventurer_hugbox_duration)
-			///FOR SOME silly FUCKING REASON THIS REFUSED TO WORK WITHOUT A FUCKING TIMER IT JUST FUCKED SHIT UP
-			addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, adv_hugboxing_start)), 1)
-
 /mob/living/carbon/human/proc/adv_hugboxing_start()
 	to_chat(src, span_warning("I will be in danger once I start moving."))
 	status_flags |= GODMODE

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -47,9 +47,6 @@
 		var/mob/living/carbon/human/H = L
 		if(!H.mind)
 			return
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
 		H.ambushable = FALSE
 
 /datum/outfit/job/roguetown/bandit/post_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/pilgrim.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/pilgrim.dm
@@ -25,15 +25,3 @@
 	advjob_examine = TRUE
 	always_show_on_latechoices = FALSE
 	same_job_respawn_delay = 0
-
-/datum/job/roguetown/pilgrim/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(L)
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
-		if(GLOB.adventurer_hugbox_duration)
-			///FOR SOME SILLY FUCKING REASON THIS REFUSED TO WORK WITHOUT A FUCKING TIMER IT JUST FUCKED SHIT UP
-			addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, adv_hugboxing_start)), 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/villager.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/villager.dm
@@ -24,14 +24,6 @@
 	class_setup_examine = FALSE	//Nooo thank you
 	cmode_music = 'sound/music/combat_towner.ogg'
 
-/datum/job/roguetown/villager/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(L)
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /*
 /datum/job/roguetown/adventurer/villager/New()
 	. = ..()

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -36,14 +36,6 @@
 		/datum/advclass/druid
 	)
 
-/datum/job/roguetown/druid/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/druid
 	name = "Druid"
 	tutorial = "You have always been drawn to the wild, and the wild drawn to you. When your calling came, it was from Dendor. \

--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -469,14 +469,6 @@
 		/datum/advclass/martyr
 	)
 
-/datum/job/roguetown/martyr/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/martyr
 	name = "Martyr"
 	tutorial = "Martyrs are hand-picked among the most devout of the Holy See. They are given one of the See's cherished relics to protect the Church, and to inspire hope and lead by example of grace, kindness and vicious intolerance to any who do not share the belief of the Ten. They have sworn an Oath in the sight of the gods, and will fulfill it to the bitter end."

--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -30,14 +30,6 @@
 		/datum/advclass/acolyte
 	)
 
-/datum/job/roguetown/monk/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/acolyte
 	name = "Acolyte"
 	tutorial = "Chores, some more chores- Even more chores. Oh, how the life of a humble acolyte is exhausting… You have faith, but even you know you gave up a life of adventure for that of the security in the Church. Assist the Priest in their daily tasks, maybe today will be the day something interesting happens."

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -47,14 +47,6 @@ GLOBAL_LIST_EMPTY(heretical_players)
 		/datum/advclass/bishop
 	)
 
-/datum/job/roguetown/priest/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/bishop
 	name = "Bishop"
 	tutorial = "The Divine is all that matters in a world of the immoral. \

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -39,14 +39,6 @@
 	id = /obj/item/clothing/ring/silver
 	backl = /obj/item/storage/backpack/rogue/satchel
 
-/datum/job/roguetown/templar/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	. = ..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/templar/monk
 	name = "Monk"
 	tutorial = "You are a monk of the Church, trained in pugilism and acrobatics. You bear no armor but your faith, and your hands are lethal weapons in service to your God."

--- a/code/modules/jobs/job_types/roguetown/courtier/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/butler.dm
@@ -24,14 +24,6 @@
 		/datum/advclass/seneschal/chiefbutler
 	)
 
-/datum/job/roguetown/butler/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	. = ..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup") // Classes are for aesthetic clothing only, mechanically they're identical.
-
 /datum/advclass/seneschal
 	traits_applied = list(TRAIT_CICERONE)
 	category_tags = list(CTAG_SENESCHAL)

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -30,14 +30,6 @@
 		/datum/advclass/councillor
 	)
 
-/datum/job/roguetown/councillor/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/councillor
 	name = "Councillor"
 	tutorial = "You may have inherited this position, bought your way into it, or were appointed to it by merit--perish the thought! Whatever the case though, you work as an assistant and agent of the crown in matters of state. Whether this be aiding the steward, the sheriff, or the crown itself, or simply enjoying the free food of the keep, your duties vary day by day. You may be the lowest rung of the ladder, but that rung still towers over everyone else in town."

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -69,14 +69,6 @@
 	job_bitflag = BITFLAG_ROYALTY
 	has_loadout = TRUE
 
-/datum/job/roguetown/magician/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/outfit/job/roguetown/magician/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
 	if(H.age == AGE_OLD)

--- a/code/modules/jobs/job_types/roguetown/courtier/physician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/physician.dm
@@ -27,14 +27,6 @@
 		/datum/advclass/physician
 	)
 
-/datum/job/roguetown/physician/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/physician
 	name = "Court Physician"
 	tutorial = "You were a child born into good wealth--but poor health. \

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -43,14 +43,6 @@
 	for(var/X in GLOB.courtier_positions)
 		peopleknowme += X
 
-/datum/job/roguetown/dungeoneer/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/outfit/job/roguetown/dungeoneer
 	job_bitflag = BITFLAG_GARRISON
 

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -41,9 +41,6 @@
 	. = ..()
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
 		if(istype(H.cloak, /obj/item/clothing/cloak/stabard/surcoat/guard))
 			var/obj/item/clothing/S = H.cloak
 			var/index = findtext(H.real_name, " ")

--- a/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
@@ -40,9 +40,6 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		if(ishuman(L))
-			H.advsetup = 1
-			H.invisibility = INVISIBILITY_MAXIMUM
-			H.become_blind("advsetup")
 			if(istype(H.cloak, /obj/item/clothing/cloak/stabard/surcoat/guard))
 				var/obj/item/clothing/S = H.cloak
 				var/index = findtext(H.real_name, " ")

--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -48,9 +48,6 @@
 	. = ..()
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
 		if(istype(H.cloak, /obj/item/clothing/cloak/stabard/surcoat/guard))
 			var/obj/item/clothing/S = H.cloak
 			var/index = findtext(H.real_name, " ")

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -34,9 +34,6 @@
 	. = ..()
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
 		if(istype(H.cloak, /obj/item/clothing/cloak/stabard/guard))
 			var/obj/item/clothing/S = H.cloak
 			var/index = findtext(H.real_name, " ")

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -36,9 +36,6 @@
 	. = ..()
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
 		if(istype(H.cloak, /obj/item/clothing/cloak/half/vet))
 			var/obj/item/clothing/S = H.cloak
 			var/index = findtext(H.real_name, " ")

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -40,14 +40,6 @@
 	id = /obj/item/scomstone/bad/garrison
 	job_bitflag = BITFLAG_GARRISON
 
-/datum/job/roguetown/warden/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/warden/ranger
 	name = "Ranger"
 	tutorial = "You are a ranger, a hunter who volunteered to become a part of the wardens. You have experience using bows and daggers."

--- a/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
@@ -48,11 +48,3 @@
 		/datum/advclass/mercenary/grudgebearer,
 		/datum/advclass/mercenary/grudgebearer/soldier
 	)
-
-/datum/job/roguetown/mercenary/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(L)
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")

--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -45,14 +45,6 @@
 	H.verbs |= /mob/proc/haltyell
 	H.verbs |= list(/mob/living/carbon/human/proc/request_outlaw, /mob/living/carbon/human/proc/request_law, /mob/living/carbon/human/proc/request_law_removal, /mob/living/carbon/human/proc/request_purge)
 
-/datum/job/roguetown/marshal/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	. = ..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/marshal/classic
 	name = "Marshal"
 	tutorial = "You've spent your daes in the courts and garrisons of the city. You've studied the law tome from back to front and enforce your word with the iron hand of justice, and the iron mace in your hands. More men have spent days rotting in the dungeon than that Knight Commander could ever have claimed, and every person in the realm respects your authority in matters of law and order."

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -69,10 +69,6 @@
 					MF.known_people -= prev_real_name
 					H.mind.person_knows_me(MF)
 
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/captain/infantry
 	name = "Infantry Captain"
 	tutorial = "You've fought shoulder to shoulder with the realm's worthiest Knights while embedded directly within \

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -48,13 +48,7 @@
 
 /datum/job/roguetown/hand/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
-		addtimer(CALLBACK(src, PROC_REF(know_agents), H), 50)
+	addtimer(CALLBACK(src, PROC_REF(know_agents), L), 5 SECONDS)
 
 /datum/job/roguetown/hand/proc/know_agents(var/mob/living/carbon/human/H)
 	if(!GLOB.court_agents.len)

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -39,9 +39,6 @@
 	..()
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
 		if(istype(H.cloak, /obj/item/clothing/cloak/stabard/surcoat/guard))
 			var/obj/item/clothing/S = H.cloak
 			var/index = findtext(H.real_name, " ")

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -46,11 +46,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 
 /datum/job/roguetown/lord/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/Q = L
-		Q.advsetup = 1
-		Q.invisibility = INVISIBILITY_MAXIMUM
-		Q.become_blind("advsetup")
 	if(L)
 		var/list/chopped_name = splittext(L.real_name, " ")
 		if(length(chopped_name) > 1)

--- a/code/modules/jobs/job_types/roguetown/nobility/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/steward.dm
@@ -29,14 +29,6 @@
 		/datum/advclass/steward
 	)
 
-/datum/job/roguetown/steward/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/steward
 	name = "Steward"
 	tutorial = "Coin, Coin, Coin! Oh beautiful coin: You're addicted to it, and you hold the position as the Grand Duke's personal treasurer of both coin and information. You know the power silver and gold has on a man's mortal soul, and you know just what lengths they'll go to in order to get even more. Keep your festering economy alive- for it is the only thing you can weigh any trust into anymore."

--- a/code/modules/jobs/job_types/roguetown/nobility/suitor.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/suitor.dm
@@ -18,14 +18,6 @@
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_noble.ogg'
 
-/datum/job/roguetown/suitor/after_spawn(mob/living/H, mob/M, latejoin)
-	. = ..()
-	if(ishuman(H))
-		var/mob/living/carbon/human/Q = H
-		Q.advsetup = 1
-		Q.invisibility = INVISIBILITY_MAXIMUM
-		Q.become_blind("advsetup")
-
 /datum/outfit/job/roguetown/suitor
 	job_bitflag = BITFLAG_ROYALTY
 

--- a/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
@@ -31,14 +31,6 @@
 		/datum/advclass/nightmaiden/courtesan
 	)
 
-/datum/job/roguetown/nightmaiden/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	. = ..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup") // Classes are for aesthetic clothing only, mechanically they're identical.
-
 /datum/outfit/job/roguetown/nightmaiden
 	name = "Nightmaiden"
 	// This is just a base outfit, the actual outfits are defined in the advclasses

--- a/code/modules/jobs/job_types/roguetown/peasants/cook.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/cook.dm
@@ -23,14 +23,6 @@
 		/datum/advclass/cook
 	)
 
-/datum/job/roguetown/cook/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/cook
 	name = "Cook"
 	tutorial = "There are many mouths to feed in town, and most look to you for it. You work under the care of the innkeeper and craft such culinary delights that even the crown stops by from time to time. All the while, you try to get the rest of the staff up to speed as well--before you get too many burn marks on your body from slaving over your hot hearths."

--- a/code/modules/jobs/job_types/roguetown/peasants/knavewench.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/knavewench.dm
@@ -24,14 +24,6 @@
 		/datum/advclass/tapster
 	)
 
-/datum/job/roguetown/knavewench/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/tapster
 	name = "Tapster"
 	tutorial = "You have a simple role at the Azurian Pint; please. You wait tables and help guests, clean the rooms, grow and brew more drink, and assist in the kitchens as need be. Bring a smile to the masses--and those cheapsake townsfolk and adventures might just give you an extra coin...assuming you've not already pilfered their pouch while they're in a drunken stupor off your latest brew."

--- a/code/modules/jobs/job_types/roguetown/peasants/lunatic.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/lunatic.dm
@@ -30,14 +30,6 @@
 		/datum/advclass/lunatic
 	)
 
-/datum/job/roguetown/lunatic/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/lunatic
 	name = "Lunatic"
 	tutorial = "The Lunatic, shunned by society and a magnet for misfortune. Your task is simple yet perilous: survive by any means, though your very existence invites danger from every corner. It is said that Azure Peak drives those most familiar with it, the most insane."

--- a/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
@@ -33,14 +33,6 @@
 		/datum/advclass/soilson
 	)
 
-/datum/job/roguetown/farmer/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/soilson
 	name = "Soilson"
 	tutorial = "It is a simple life you live, your basic understanding of life is something many would be envious of if they knew just how perfect it was. You know a good day's work, the sweat on your brow is yours: Famines and plague may take their toll, but you know how to celebrate life well. Till the soil and produce fresh food for those around you, and maybe you'll be more than an unsung hero someday."

--- a/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
@@ -26,14 +26,6 @@
 		/datum/advclass/archivist
 	)
 
-/datum/job/roguetown/archivist/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/archivist
 	name = "Archivist"
 	tutorial = "The Archivist meticulously preserves and organizes ancient scrolls and tomes, safeguarding the collective knowledge of the realm for generations to come. Nobles and Peasants alike often seek your expertise on matters of history and fact, and your keenly-kept records on the events of this week will likely stand a testament to your Duke's benevolence and their realm's prosperity...or not. After all, you hold the true power: \

--- a/code/modules/jobs/job_types/roguetown/yeomen/barkeep.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/barkeep.dm
@@ -24,14 +24,6 @@
 		/datum/advclass/barkeep
 	)
 
-/datum/job/roguetown/barkeep/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/barkeep
 	name = "Innkeeper"
 	tutorial = "Adventurers and warriors alike have two exit plans; the early grave or even earlier retirement. As the proud owner of this fine establishment, you took the latter: The Azurian Pint, tavern, inn, and bathhouse! You even have an assortment of staff to help you, and plenty of business from the famished townsfolk looking to eat, weary travelers looking to rest, and characters of dubious repute seeking their own sort of success. Your bladework has gotten a little rusty, and the church across the street gives you the odd evil eye for the extra 'delights' of the bathhouse--but, well...you can't win 'em all!"

--- a/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
@@ -71,14 +71,6 @@
 /datum/outfit/job/roguetown/guildmaster
 	has_loadout = TRUE
 
-/datum/job/roguetown/guildmaster/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/outfit/job/roguetown/guildmaster/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
 	if(H.age == AGE_OLD)

--- a/code/modules/jobs/job_types/roguetown/yeomen/guildsman.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildsman.dm
@@ -26,14 +26,6 @@
 		/datum/advclass/guildsman/architect
 	)
 
-/datum/job/roguetown/guildsman/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	. = ..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/guildsman/blacksmith
 	name = "Guild Blacksmith"
 	tutorial = "You've studied for many yils under quite a number of master smiths. Whether it's cookware or tools of war, you're unmatched at the art of bending metal to your will."

--- a/code/modules/jobs/job_types/roguetown/yeomen/loudmouth.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/loudmouth.dm
@@ -24,14 +24,6 @@
 		/datum/advclass/loudmouth
 	)
 
-/datum/job/roguetown/loudmouth/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/loudmouth
 	name = "Loudmouth"
 	tutorial = "Keeper of the Horn, Master of the Jabberline, and self-appointed Voice of Reason. From your desk in the SCOM atelier, you decide which words will thunder across the realm and which will die in the throats of petitioners who didn�t pay enough ratfeed. Nobles and cutpurses alike shuffle up to your counter, coins in hand, desperate for a moment in the golden glow of the broadcast horn. In your upstairs �studio,� you host debates, recite gossip, and spin tales that will ripple through every corner of town. After all, you hold the true power: the power to decide what all of the city hears... and how loudly. You work closely with the Archivist, though it's obvious which of you the people truly respect."

--- a/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
@@ -30,14 +30,6 @@
 		/datum/advclass/merchant
 	)
 
-/datum/job/roguetown/merchant/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/merchant
 	name = "Merchant"
 	tutorial = "You were born into wealth, learning from before you could talk about the basics of mathematics. \

--- a/code/modules/jobs/job_types/roguetown/yeomen/nightmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/nightmaster.dm
@@ -24,14 +24,6 @@
 		/datum/advclass/bathmaster
 	)
 
-/datum/job/roguetown/niteman/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/bathmaster
 	name = "Bathmaster"
 	tutorial = "You are renting out the bathhouse in a joint operation with the Innkeep. You provide security for the bathwenches and help them to find work--when you're not being a trouble-making rake that others suffer to tolerate."

--- a/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
@@ -25,14 +25,6 @@
 		/datum/advclass/tailor
 	)
 
-/datum/job/roguetown/tailor/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/tailor
 	name = "Tailor"
 	tutorial = "You have worked sleepless nights on honing your craft. From sacks, to tapestry and luxurious clothing, there is little you cannot sew into existence. Use your storefront to turn even the ugliest peasant into a proper gentleman; who knows, even the nobility may pay you a visit."

--- a/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
@@ -22,14 +22,6 @@
 		/datum/advclass/apothecary
 	)
 
-/datum/job/roguetown/apothecary/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/apothecary
 	name = "Apothecary"
 	tutorial = "Working under the tutelage of the court physician, you still remain a mere apprentice in the medical arts. \

--- a/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
@@ -24,14 +24,6 @@
 		/datum/advclass/churchling
 	)
 
-/datum/job/roguetown/churchling/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/churchling
 	name = "Churchling"
 	tutorial = "Your family were zealots. They scolded you with a studded belt and prayed like sinners every waking hour of the day they weren't toiling in the fields. You escaped them by becoming a churchling--and a guaranteed education isn't so bad."

--- a/code/modules/jobs/job_types/roguetown/youngfolk/clerk.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/clerk.dm
@@ -51,14 +51,6 @@
 		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,
 	)
 
-/datum/job/roguetown/clerk/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/outfit/job/roguetown/clerk/basic/pre_equip(mob/living/carbon/human/H)
 	..()
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -39,14 +39,6 @@
 	backr = /obj/item/rogueweapon/woodstaff
 	shoes = /obj/item/clothing/shoes/roguetown/gladiator // FANCY SANDALS
 
-/datum/job/roguetown/wapprentice/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	. = ..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/wapprentice/associate
 	name = "Magician's Associate"
 	tutorial = "You were once an apprentice, though through your studies and practice you've mastered the basics of the arcyne. You now spend your days working under your master, honing your skills so that you might one day be considered a true master yourself."

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -30,15 +30,6 @@
 		/datum/advclass/heir/inbred,
 	)
 
-/datum/job/roguetown/prince/after_spawn(mob/living/H, mob/M, latejoin)
-	. = ..()
-	if(ishuman(H))
-		var/mob/living/carbon/human/Q = H
-		Q.advsetup = 1
-		Q.invisibility = INVISIBILITY_MAXIMUM
-		Q.become_blind("advsetup")
-
-
 /datum/outfit/job/roguetown/heir/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.verbs |= /mob/living/carbon/human/proc/declarechampion

--- a/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
@@ -27,15 +27,6 @@
 		/datum/advclass/servant/butler
 	)
 
-
-/datum/job/roguetown/servant/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	. = ..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup") // Classes are for aesthetic clothing only, mechanically they're identical.
-
 /datum/advclass/servant
 	traits_applied = list(TRAIT_CICERONE)
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
@@ -23,14 +23,6 @@
 		/datum/advclass/shophand
 	)
 
-/datum/job/roguetown/shophand/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
 /datum/advclass/shophand
 	name = "Shophand"
 	tutorial = "You work the largest store in the Peaks by grace of the Merchant who has shackled you to this drudgery. \

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -582,6 +582,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 		GLOB.respawncounts[character.ckey] = 1
 //	add_roundplayed(character.ckey)
 	if(humanc)
+		SSrole_class_handler.setup_class_handler(humanc)
 		try_apply_character_post_equipment(humanc)
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 

--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/vagabond.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/vagabond.dm
@@ -11,14 +11,3 @@
 	job_reopens_slots_on_death = TRUE
 	same_job_respawn_delay = 10 SECONDS
 	announce_latejoin = FALSE
-
-/datum/job/roguetown/orphan/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(L)
-		var/mob/living/carbon/human/H = L
-		H.advsetup = 1
-		H.invisibility = INVISIBILITY_MAXIMUM
-		H.become_blind("advsetup")
-
-		if(GLOB.adventurer_hugbox_duration)
-			addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, adv_hugboxing_start)), 1)


### PR DESCRIPTION
## About The Pull Request
https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3886
Fixes the issue of having to pick a subclass when there's only a single subclass for a job.
## Testing Evidence

https://github.com/user-attachments/assets/514bf006-a2ab-450b-bf0e-b9770286df0b

## Why It's Good For The Game
Having to select a subclass when there is only one is extremely annoying.