### PR TITLE
Psycross name change

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -391,6 +391,10 @@
 	grid_width = 32
 	grid_height = 32
 
+/obj/item/clothing/neck/roguetown/zcross/iron/New(loc, ...)
+	. = ..()
+	name = pick("inverted psycross", "psycross")
+
 /obj/item/clothing/neck/roguetown/psicross/astrata
 	name = "amulet of Astrata"
 	desc = "As sure as the sun rises, tomorrow will come."


### PR DESCRIPTION
## About The Pull Request
When examining an inverted psycross, it'll appear as a "psycross" similar to the matthios scomstone
## Testing Evidence
<img width="332" height="34" alt="Screenshot 2025-10-18 120746" src="https://github.com/user-attachments/assets/bc7c7f8e-41d9-4c9a-93c6-69ab31980b54" />
<img width="129" height="115" alt="Screenshot 2025-10-18 120723" src="https://github.com/user-attachments/assets/1c429213-28d6-4770-9230-672bcad2a23a" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
We can't have nice things since morons FUCKING suck!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
