### PR TITLE
Sawbones can buy revival potions

### DIFF
--- a/code/modules/cargo/packsrogue/Sawbones.dm
+++ b/code/modules/cargo/packsrogue/Sawbones.dm
@@ -193,4 +193,8 @@
 	name = "Emberwine"
 	cost = 100
 	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/emberwine)
-	
+
+/datum/supply_pack/rogue/Sawbones/revivalpot
+	name = "Revival potion"
+	cost = 50
+	contains = list(/obj/item/reagent_containers/glass/bottle/revival)


### PR DESCRIPTION
## About The Pull Request

Allows sawbones to buy revival potions.

## Testing Evidence

<img width="1041" height="656" alt="image" src="https://github.com/user-attachments/assets/af831bf5-8644-42e3-a75e-a5db416539dd" />
## Why It's Good For The Game

Less round removal.