### PR TITLE
Rogue mages can buy the chalk and magebags keep thralls start with

### DIFF
--- a/code/modules/cargo/packsrogue/Mage.dm
+++ b/code/modules/cargo/packsrogue/Mage.dm
@@ -178,3 +178,11 @@
 	name = "Cinnabar Ore"
 	cost = 10
 	contains = list(/obj/item/rogueore/cinnabar = 1)
+
+/datum/supply_pack/rogue/Mage/Summonerkit
+	name = "Beginner's summoner kit"
+	cost = 30
+	contains = list(
+		/obj/item/storage/magebag/starter,
+		/obj/item/ritechalk,
+	)


### PR DESCRIPTION
## About The Pull Request

Let's bandit mages buy the chalk/bag that keep thralls begin the round with.

## Testing Evidence

<img width="431" height="686" alt="image" src="https://github.com/user-attachments/assets/2c67432f-c620-468c-999a-1b8f4f55e943" />
<img width="1687" height="958" alt="image" src="https://github.com/user-attachments/assets/ca678299-9cae-4432-b26f-b3cbbba6f899" />

## Why It's Good For The Game

I don't really see a reason why one of the mage's coolest toys and gameplay loops is locked exclusively to the keep?
