### PR TITLE
royal champ. int nerf + climbing skill reshuffle

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -188,7 +188,7 @@
 		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,	
 		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
@@ -280,7 +280,7 @@
 		/datum/skill/combat/bows = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
@@ -373,7 +373,7 @@
 	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_DODGEEXPERT)
 	subclass_stats = list(
 		STATKEY_STR = 1,
-		STATKEY_INT = 3,
+		STATKEY_INT = 1,
 		STATKEY_END = 2,
 		STATKEY_SPD = 2)
 
@@ -385,7 +385,7 @@
 		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,	
 		/datum/skill/combat/crossbows = SKILL_LEVEL_EXPERT, //Bows fit a light/speedy class pretty well, gave them ranged options.
 		/datum/skill/combat/bows = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/climbing = SKILL_LEVEL_MASTER,		
+		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,		
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,


### PR DESCRIPTION
## About The Pull Request

this pr reduces the statbuff from RC's intelligence from a +3 to a +1
it also sacrifices their master climbing in exchange for giving expert to every class

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="536" height="162" alt="image" src="https://github.com/user-attachments/assets/d1d780bc-0b3f-4215-a2bf-04e850e15e3b" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
<img width="1254" height="248" alt="image" src="https://github.com/user-attachments/assets/60e5343b-5827-470c-8e67-15fa176390ba" />

lets take into account this build. ignoring the town buff cuz it doesnt change intelligence - all this does is just change the 16 int to 14.

this is a good change because it makes RC into the not-meta, and allows other - weaker knight classes (such as mounted and heavy) to shine with their intelligence boost

the climbing adjustment was a requested change 
<img width="1240" height="206" alt="image" src="https://github.com/user-attachments/assets/b5a09636-cf4a-4376-aef2-1e5b70d7a64b" />
- tldr: people only pick RC cuz its utility in climbing is way too good compared to other classes
- this still makes the climbing ult there - it just makes it so that other knights can (kinda) keep up

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
