### PR TITLE
Ambient Occlusion & Lighting Tweaks

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -14,15 +14,18 @@
 #define WEATHER_RENDER_TARGET "*WEATHER_OVERLAY_PLANE"
 
 #define OPENSPACE_LAYER 17 //Openspace layer over all
-#define OPENSPACE_PLANE -7 //Openspace plane below all turfs
-#define OPENSPACE_BACKDROP_PLANE -6
+#define OPENSPACE_PLANE -10 //Openspace plane below all turfs
+#define OPENSPACE_BACKDROP_PLANE -9
 
-#define FLOOR_PLANE -5
-#define GAME_PLANE -4
-#define GAME_PLANE_FOV_HIDDEN -3
-#define GAME_PLANE_UPPER -2
+#define FLOOR_PLANE -8
+#define WALL_PLANE -7
+#define GAME_PLANE_LOWER -6
+#define GAME_PLANE -5
+#define GAME_PLANE_FOV_HIDDEN -4
+#define GAME_PLANE_UPPER -3
+#define GAME_PLANE_HIGHEST -2
 #define WEATHER_EFFECT_PLANE -1
-#define BLACKNESS_PLANE 0 //To keep from conflicts with SEE_BLACKNESS internals
+#define BLACKNESS_PLANE 0
 
 #define SPACE_LAYER 1.8
 //#define TURF_LAYER 2 //For easy recordkeeping; this is a byond define

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -456,7 +456,8 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 #define PDAIMG(what) {"<span class="pda16x16 [#what]"></span>"}
 
 //Filters
-#define AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-0, size=1, offset = 0, color="#04080FAA")
+#define AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-2, size=3, offset=1, color="#04080f96")
+#define AMBIENT_OCCLUSION_WALLS filter(type="drop_shadow", x=0, y=-2, size=8, offset=4, color="#000000ff")
 #define GAUSSIAN_BLUR(filter_size) filter(type="blur", size=filter_size)
 
 #define STANDARD_GRAVITY 1 //Anything above this is high gravity, anything below no grav

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -198,6 +198,52 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	blend_mode = BLEND_MULTIPLY
 
+/atom/movable/screen/plane_master/game_world_below
+	name = "lowest game world plane master"
+	plane = GAME_PLANE_LOWER
+	appearance_flags = PLANE_MASTER
+	blend_mode = BLEND_OVERLAY
+
+/atom/movable/screen/plane_master/game_world_below/backdrop(mob/mymob)
+	clear_filters()
+	if(istype(mymob) && mymob.client && mymob.client.prefs && mymob.client.prefs.ambientocclusion)
+		filters = list()
+		filters += AMBIENT_OCCLUSION
+		if(istype(mymob) && mymob.eye_blurry)
+			filters += GAUSSIAN_BLUR(CLAMP(mymob.eye_blurry*0.1,0.6,3))
+		if(istype(mymob))
+			if(isliving(mymob))
+				var/mob/living/L = mymob
+				if(L.has_status_effect(/datum/status_effect/buff/druqks))
+					filters += filter(type="ripple",x=80,size=50,radius=0,falloff = 1)
+					var/F1 = filters[filters.len]
+					filters += filter(type="color", color = list(0,0,1,0, 0,1,0,0, 1,0,0,0, 0,0,0,1, 0,0,0,0))
+					F1 = filters[filters.len-1]
+					animate(F1, size=50, radius=480, time=10, loop=-1, flags=ANIMATION_PARALLEL)
+
+
+/atom/movable/screen/plane_master/game_world_walls
+	name = "game world walls"
+	plane = WALL_PLANE
+	appearance_flags = PLANE_MASTER
+	blend_mode = BLEND_OVERLAY
+
+/atom/movable/screen/plane_master/game_world_walls/backdrop(mob/mymob)
+	clear_filters()
+	if(istype(mymob) && mymob.client && mymob.client.prefs && mymob.client.prefs.ambientocclusion)
+		filters = list()
+		filters += AMBIENT_OCCLUSION_WALLS
+		if(istype(mymob) && mymob.eye_blurry)
+			filters += GAUSSIAN_BLUR(CLAMP(mymob.eye_blurry*0.1,0.6,3))
+		if(istype(mymob))
+			if(isliving(mymob))
+				var/mob/living/L = mymob
+				if(L.has_status_effect(/datum/status_effect/buff/druqks))
+					filters += filter(type="ripple",x=80,size=50,radius=0,falloff = 1)
+					var/F1 = filters[filters.len]
+					filters += filter(type="color", color = list(0,0,1,0, 0,1,0,0, 1,0,0,0, 0,0,0,1, 0,0,0,0))
+					F1 = filters[filters.len-1]
+					animate(F1, size=50, radius=480, time=10, loop=-1, flags=ANIMATION_PARALLEL)
 
 //Contains all weather overlays
 /atom/movable/screen/plane_master/weather_overlay

--- a/code/controllers/subsystem/particle_weather_outdoors.dm
+++ b/code/controllers/subsystem/particle_weather_outdoors.dm
@@ -10,7 +10,7 @@
 
 /datum/time_of_day/sunrise
 	name = "Sunrise"
-	color = "#F598AB"
+	color = list("#F598AB","#e26d6d", "#e96e4f")
 	start = 9.5 HOURS  //9:30:00 AM
 
 /datum/time_of_day/daytime

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -4,6 +4,7 @@
 	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_UI_INTERACT
 	layer = BELOW_OBJ_LAYER
 	anchored = TRUE
+	plane = GAME_PLANE_LOWER
 	var/climb_time = 20
 	var/climb_stun = 0
 	var/climb_sound = 'sound/foley/woodclimb.ogg'

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -2,6 +2,7 @@
 	resistance_flags = FLAMMABLE
 	max_integrity = 150
 	anchored = TRUE
+	plane = GAME_PLANE_UPPER
 
 /obj/structure/flora/Initialize()
 	. = ..()

--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -12,7 +12,6 @@
 	blade_dulling = DULLING_CUT
 	pixel_x = -16
 	layer = 4.81
-	plane = GAME_PLANE_UPPER
 	attacked_sound = 'sound/misc/woodhit.ogg'
 	destroy_sound = 'sound/misc/woodhit.ogg'
 	debris = list(/obj/item/grown/log/tree/stick = 2)

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -11,8 +11,9 @@
 	icon = 'icons/obj/stairs.dmi'
 	icon_state = "stairs"
 	anchored = TRUE
-	layer = 2
+	layer = 5
 	nomouseover = TRUE
+	plane = FLOOR_PLANE
 
 /obj/structure/stairs/stone
 	name = "stone stairs"

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -5,6 +5,7 @@
 	density = TRUE
 	blocks_air = TRUE
 	baseturfs = list(/turf/open/floor/rogue/naturalstone, /turf/open/transparent/openspace)
+	plane = WALL_PLANE
 	var/above_floor
 	var/wallpress = TRUE
 	var/wallclimb = FALSE

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -172,12 +172,12 @@
 					playsound(AM, pick('sound/foley/watermove (1).ogg','sound/foley/watermove (2).ogg'), 100, FALSE)
 				if(istype(oldLoc, type) && (get_dir(src, oldLoc) != SOUTH))
 					water_overlay.layer = ABOVE_MOB_LAYER
-					water_overlay.plane = GAME_PLANE_UPPER
+					water_overlay.plane = water_overlay.plane = GAME_PLANE_HIGHEST
 				else
 					spawn(6)
 						if(AM.loc == src)
 							water_overlay.layer = ABOVE_MOB_LAYER
-							water_overlay.plane = GAME_PLANE_UPPER
+							water_overlay.plane = GAME_PLANE_HIGHEST
 		if(!istype(L, /mob/living/carbon/human/species/skeleton))
 			return
 		if(!istype(src, /turf/open/water/sewer))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -592,7 +592,6 @@ GLOBAL_LIST_EMPTY(chosen_names)
 					dat += "High"
 			dat += "</a><br>"
 */
-//			dat += "<b>Ambient Occlusion:</b> <a href='?_src_=prefs;preference=ambientocclusion'>[ambientocclusion ? "Enabled" : "Disabled"]</a><br>"
 //			dat += "<b>Fit Viewport:</b> <a href='?_src_=prefs;preference=auto_fit_viewport'>[auto_fit_viewport ? "Auto" : "Manual"]</a><br>"
 //			if (CONFIG_GET(string/default_view) != CONFIG_GET(string/default_view_square))
 //				dat += "<b>Widescreen:</b> <a href='?_src_=prefs;preference=widescreenpref'>[widescreenpref ? "Enabled ([CONFIG_GET(string/default_view)])" : "Disabled ([CONFIG_GET(string/default_view_square)])"]</a><br>"
@@ -765,7 +764,9 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	// well.... one empty slot here for something I suppose lol
 	dat += "<table width='100%'>"
 	dat += "<tr>"
-	dat += "<td width='33%' align='left'></td>"
+	dat += "<td width='33%' align='left'>"
+	dat += "<b>Ambient Occlusion:</b> <a href='?_src_=prefs;preference=ambientocclusion'>[ambientocclusion ? "Enabled" : "Disabled"]</a><br>"
+	dat += "</td>"
 	dat += "<td width='33%' align='center'>"
 	var/mob/dead/new_player/N = user
 	if(istype(N))


### PR DESCRIPTION
## About The Pull Request
A port of a port: https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/4192

Adds toggleable ambient occlusion with drop shadows, ported from Twilight Axis.
(https://github.com/Twilight-Fortress-SS13/Twilight-Axis/pull/3)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<details><summary>With Ambient Occlusion enabled:</summary>
<img width="540" height="381" alt="Screenshot 2025-10-19 145337" src="https://github.com/user-attachments/assets/a04556ed-a0ae-43ea-a0db-5380c76588ef"
 /></details>
</summary>
<details><summary>With Ambient Occlusion disabled</summary>
<img width="539" height="396" alt="Screenshot 2025-10-19 145619" src="https://github.com/user-attachments/assets/008cac71-969d-4772-88e0-17ece2294d65" 
 /></details>
</summary>
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->


## Why It's Good For The Game
Makes this two decade old atmospheric simulator look a bit nicer, it can be turned off.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
