### PR TITLE
Player Panel fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -48,7 +48,7 @@
 		H.become_blind("advsetup")
 
 /datum/advclass/wapprentice/associate
-	name = "Magicians Associate"
+	name = "Magician Associate"
 	tutorial = "You were once an apprentice, though through your studies and practice you've mastered the basics of the arcyne. You now spend your days working under your master, honing your skills so that you might one day be considered a true master yourself."
 	outfit = /datum/outfit/job/roguetown/wapprentice/associate
 	category_tags = list(CTAG_WAPPRENTICE)
@@ -148,7 +148,7 @@
 			H.cmode_music = 'sound/music/combat_cult.ogg'
 
 /datum/advclass/wapprentice/apprentice
-	name = "Magicians Apprentice"
+	name = "Magician Apprentice"
 	tutorial = "Your master once saw potential in you, although you are uncertain if they still do, given how rigorous and difficult your studies have been. The path to using magic is a treacherous and untamed one, and you are still decades away from calling yourself even a journeyman in the field. Listen and serve, and someday you will earn your hat."
 	outfit = /datum/outfit/job/roguetown/wapprentice/apprentice
 	category_tags = list(CTAG_WAPPRENTICE)


### PR DESCRIPTION
## About The Pull Request
Fixes an issue where admins couldn't open the player panel of a Magician's associate or Magician's Apprentice.

## Testing Evidence
<img width="702" height="121" alt="fix" src="https://github.com/user-attachments/assets/a32e08b0-87ae-4c3d-b647-8237429c9b23" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Admins needs to see the player panel of everyone.