### PR TITLE
Add Arcane Warden subclass

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -206,7 +206,7 @@
 /datum/advclass/warden/arcane
 	name = "Arcane Warden"
 	tutorial = "A magically talented individual who volunteered for the wardens. You might have been a foreigner or a witch looking to get in the town's good graces, or an apprentice who liked practical work more than study."
-	outfit = /datum/outfit/job/roguetown/warden/ranger
+	outfit = /datum/outfit/job/roguetown/warden/arcane
 	category_tags = list(CTAG_WARDEN)
 
 	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T2)
@@ -245,7 +245,7 @@
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE, // Same level as Advisor Hand, as requested in bounty
 	)
 
-/datum/outfit/job/roguetown/warden/ranger/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/warden/arcane/pre_equip(mob/living/carbon/human/H)
 	..()
 	neck = /obj/item/clothing/neck/roguetown/coif
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather


### PR DESCRIPTION
## About The Pull Request

Added a third warden subclass. Every change is noted in the code but notably

- Uses ranger as a base including armor
- gets hand-advisor level magic, with T2 Arcayne, 15 spell points and novice magic skill
- Trades 1 speed for 2 int
- combat skills are the worse of either subclass except knives (it has journeyman like ranger instead of apprentice like forester)
- has a wood staff and apprentice polearms
- has mana potion and alchemy book
- one more medicine than standard ranger
- apprentice alchemy
- expert literacy

Current bug: Warden helm/hood selection happens twice on every subclass now, but doesn't provide a second hood or helm so it's just annoying. Absolutely no idea how to fix.

## Testing Evidence

<img width="851" height="657" alt="Screenshot 2025-10-19 140257" src="https://github.com/user-attachments/assets/062127ea-d863-4ff5-9f5f-b6da45a83b23" />
<img width="329" height="354" alt="Screenshot 2025-10-19 140424" src="https://github.com/user-attachments/assets/d7827fbc-33ca-4c3c-9958-7c34cb97d630" />
<img width="1288" height="1060" alt="Screenshot 2025-10-19 140435" src="https://github.com/user-attachments/assets/974dcca0-e6fc-4747-b45b-10940b007c80" />


## Why It's Good For The Game

In response to a code bounty. Gives players more flexibility. More diversity in the Warden clubhouse.

Reworking the class is possible, maybe lowering some of the non-combat skills so they don't have expert tracking, swimming, climbing and athletics since mages are usually some kind of bookworm. Swapping journeyman knives for journeyman polearms? Lightening up their armor even further, maybe giving them a basic gambeson instead of a padded one. Going down in spellpoints is possible but maybe a bit painful since they don't have any other way of defending themselves. 

Potential issue is even apprentice alchemy getting a bit out of control surrounded by the forest and wardens, but they have to make a mortar/pestle and cauldron from scratch. Even if they did, their potion stash would be vulnerable to getting raided by antags and robbed off fallen wardens so it could create additional conflict. 