### PR TITLE
Fixes the descriptions of Wild-Kin and Doll races to properly reflect their actual stat changes

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -10,7 +10,7 @@
 	making them rather predictable. Despite this, the way each wild-kin approaches their bizarre physiology and psychology varies, \
 	creating a diverse race of people who may not even empathise with one another. And whilst Dendor is considered the main culprit for Wild-kin, there are those created through other means, \
 	akin to Noc's stolen knowledge that created lupians and other abstract experimentation or circumstance.<br> \
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 CON | +1 END</b></span> </br> \
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 CON | +1 PER</b></span> </br> \
 	<span style='color: #cc0f0f;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>(Wild-kin are not a template race to play your own custom race. If you play a wild-kin, \
 	you are expected to roleplay to the setting and the race's lore.)</b></span> </br>"
 	default_color = "444"


### PR DESCRIPTION
## About The Pull Request

Wildkin have +1 PER and +1 CON in game. Their description says they have +1 CON and +1 END. This fixes that.

Dolls have -2 STR, +1 SPD and +2 INT in game, but their description says they have **-1 STR,** +1 SPD and +2 INT

## Testing Evidence

None needed

## Why It's Good For The Game

People building characters now accurately know what stats they're getting when picking a species.

I'm fine with the opposite being done, changing wildkin to have END instead of PER and giving the dolls a smaller strength malus, but 
1) Wildkin having perception makes more sense than them having endurance, they have on average better smell, hearing or both over humans.
2) I didn't want to balancejak Dolls. If someone wants to have them buffed just let me know.
