### PR TITLE
Slight buffs to the Sleuth virtue & keybind for looking around

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -340,7 +340,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_LIGHT_STEP = span_info("My steps are light and swift. I make less noise while sneaking, and can sneak much quicker."),
 	TRAIT_NOMOOD = span_info("I feel no sorrow, no joy, and no stress."),
 	TRAIT_AZURENATIVE = span_info("I've grown up and lived all my lyfe in these lands. I can only trigger ambushes if I sprint through them."),
-	TRAIT_SLEUTH = span_info("I can spot my tracked Mark's trail without needing to approach it, and can spot them at a distance. I can track more frequently, and the act is not impaired by movement. I can examine tracks right away."),
+	TRAIT_SLEUTH = span_info("I can spot my tracked Mark's trail without needing to approach it, and can spot them at a distance. I can track more frequently, and the act is not impaired by movement. I can examine tracks right away, and others will not notice my efforts to search."),
 	TRAIT_HARDSHELL = span_info("The bulk of this armor prevents me from parrying effectively, but I can still move out of the way."),
 	TRAIT_MATTHIOS_EYES = span_notice("I have a sense for what the most valuable item someone has is."),
 	TRAIT_WOODWALKER = span_notice("I can climb trees quicker, and gain climbing experience twice as quickly. I can step on thorns and branches safely in the woods. I can get twice as many things from searching bushes, and I can stand on leaves in trees safely."),

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -267,6 +267,17 @@
 	else
 		return FALSE
 
+/datum/keybinding/living/search
+	hotkey_keys = list("ShiftG")
+	name = "search"
+	full_name = "Search"
+	description = "Search the area around you for hidden items or compartments."
+
+/datum/keybinding/living/search/down(client/user)
+	var/mob/living/L = user.mob
+	if (isliving(L))
+		L.look_around()
+
 //layer shifting
 
 /datum/keybinding/living/pixel_shift_layerup

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1864,7 +1864,7 @@
 	if(!can_look_up())
 		return
 	changeNext_move(HAS_TRAIT(src, TRAIT_SLEUTH) ? CLICK_CD_SLEUTH : CLICK_CD_TRACKING)
-	if(m_intent != MOVE_INTENT_SNEAK)
+	if(m_intent != MOVE_INTENT_SNEAK && !HAS_TRAIT(src, TRAIT_SLEUTH))
 		visible_message(span_info("[src] begins looking around."))
 	var/looktime = 50 - (STAPER * 2) - (get_skill_level(/datum/skill/misc/tracking) * 5)
 	looktime = clamp(looktime, 7, 50)


### PR DESCRIPTION
## About The Pull Request

Very straightforward:

- Added a keybinding called Search which performs the look around action that reveals traps and tracks.
- Sleuth-havers don't show look around attempts in chat, like they're always in sneak intent.

## Testing Evidence

<img width="476" height="153" alt="image" src="https://github.com/user-attachments/assets/b4d6f122-e5af-414f-875a-eddde3074374" />

## Why It's Good For The Game

Not very many people seem to pick Sleuth and it is probably because remembering to right click or shift click the stupid fucking eye is annoying.
