### PR TITLE
Replaces the wretch berserker helmet with something that doesn't have a broken sprite

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -36,7 +36,7 @@
 	)
 
 /datum/outfit/job/roguetown/wretch/berserker/pre_equip(mob/living/carbon/human/H)
-	head = /obj/item/clothing/head/roguetown/helmet/heavy/grag
+	head = /obj/item/clothing/head/roguetown/helmet/kettle
 	mask = /obj/item/clothing/mask/rogue/wildguard
 	cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
 	wrists = /obj/item/clothing/wrists/roguetown/bracers


### PR DESCRIPTION
## About The Pull Request

Replaces the berserker wretch's 'vicious spiked star' with a kettle helmet until someone decides to fix the sprite.

## Testing Evidence

<img width="446" height="452" alt="image" src="https://github.com/user-attachments/assets/6ca14363-c64f-4cf0-92be-398c70947ebd" />
<img width="1200" height="697" alt="image" src="https://github.com/user-attachments/assets/201e54b1-5233-442a-a978-9d06c71c6c52" />


## Why It's Good For The Game

I'm tired of ahelping each time I spawn as a berserker for a functional hat, items shouldn't have broken sprites, it's been busted long enough that it necessitates a hot fix until someone goes in and figures out what's wrong with it. 
