### PR TITLE
[TESTMERGE ONLY] Re-enable static lighting only on actually static light sources

### DIFF
--- a/code/game/objects/lighting/_base_roguelight.dm
+++ b/code/game/objects/lighting/_base_roguelight.dm
@@ -5,6 +5,7 @@
 	fueluse = 60 MINUTES
 	bulb_colour = "#f9ad80"
 	bulb_power = 1
+	light_system = STATIC_LIGHT
 	var/datum/looping_sound/soundloop = null // = /datum/looping_sound/fireloop
 	pass_flags = LETPASSTHROW
 	flags_1 = NODECONSTRUCT_1


### PR DESCRIPTION
## About The Pull Request

Chaoko's holy work of defuckulating practically all of the mobile light sources means we can provisionally attempt to bring static lights back on things like wall candles, sconces, etc. This should reset the general appearance of the game's lighting back to 90% what it was before the optimizations, with hopefully only a little bit of overhead in the process.

Will need to see what kind of load this produces.

## Testing Evidence

Without static lighting (current game post-optimizations):

<img width="748" height="751" alt="dreamseeker_gy0ZZxeJwu" src="https://github.com/user-attachments/assets/2add3daf-927b-4fb7-923f-8f462f570144" />

With static lighting (what this PR re-adds):

<img width="736" height="781" alt="dreamseeker_ovECMK2uiJ" src="https://github.com/user-attachments/assets/8812f0f5-b3bf-4610-a53c-05f783cd47d3" />

## Why It's Good For The Game

The performance improvements from the light update were *really* important, but we have sacrificed quite a lot of sensical lighting to get there. This gets us a bit closer back to how things were while hopefully keeping most of the performance benefits.
