### PR TITLE
Heretic irremovable armor rites give mending

### DIFF
--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -535,7 +535,6 @@ var/forgerites = list("Ritual of Blessed Reforgance")
 		loc.visible_message(span_cult("Great hooks come from the rune, embedding into [target]'s ankles, pulling them onto the rune. Then, into their wrists. Their lux is torn from their chest, and reforms into armor. "))
 		target.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/mending)
 		to_chat(target, span_notice("A new understanding fills my mind... I can mend that which breaks."))
-
 	spawn(20)
 		playsound(loc, 'sound/combat/hits/onmetal/grille (2).ogg', 50)
 		target.equipOutfit(/datum/outfit/job/roguetown/darksteelrite)


### PR DESCRIPTION
## About The Pull Request

Rites that give  irremovable cursed Armor also gives the target the mending spell.

## Testing Evidence

<img width="2560" height="1427" alt="image" src="https://github.com/user-attachments/assets/89097655-b251-4955-b195-321b072bfc7b" />
## Why It's Good For The Game

Not being able to remove/repair your plate makes this intentionally overpowered antag armor useless for anything except a final, suicidal last stand. This change aims to make it viable beyond that by giving it some sustainability.