### PR TITLE
Mending spell repairs coverage if integ is 100%

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/mending.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mending.dm
@@ -30,7 +30,6 @@
 			else
 				to_chat(user, span_info("[I] appears to be in perfect condition."))
 			return
-
 		var/repair_percent = 0.25
 		repair_percent *= I.max_integrity
 		I.obj_integrity = min(I.obj_integrity + repair_percent, I.max_integrity)
@@ -39,9 +38,6 @@
 		if(I.obj_broken && I.obj_integrity >= I.max_integrity)
 			I.obj_integrity = I.max_integrity
 			I.obj_fix()
-		else
-			to_chat(user, span_info("[I] appears to be in perfect condition."))
-			revert_cast()
 	else if(ishuman(targets[1]))
 		var/mob/living/carbon/human/H = targets[1]
 		if(H.construct)


### PR DESCRIPTION
## About The Pull Request

Mending spell will fix peeled coverage if the integ is already 100%.

## Testing Evidence
If below 100% mending will not fix coverage:
<img width="1226" height="682" alt="image" src="https://github.com/user-attachments/assets/df03d341-4e95-4e8d-aa72-3b4982a96201" />
If it's at 100% it will:
<img width="978" height="699" alt="image" src="https://github.com/user-attachments/assets/80a8c75b-32f9-4dfb-8abf-c4092bd21f45" />

## Why It's Good For The Game

It's what the spell is supposed to do.