### PR TITLE
Flailing my way downtown part 2

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -36,6 +36,7 @@
 
 /datum/intent/flail/strike/matthiosflail
 	reach = 2
+	damfactor = 1.9
 
 /datum/intent/flail/strikerange
 	name = "ranged strike"
@@ -67,6 +68,7 @@
 
 /datum/intent/flail/strike/smash/matthiosflail
 	reach = 2
+	damfactor = 1.4
 
 /datum/intent/flail/strike/smash/militia
 	damfactor = 1.35
@@ -184,6 +186,8 @@
 	name = "Gilded Flail"
 	desc = "Weight of wealth in a deadly striking end."
 	icon_state = "matthiosflail"
+	force = 20
+	force_wielded = 50
 	sellprice = 250
 	smeltresult = /obj/item/ingot/steel
 	possible_item_intents = list(/datum/intent/flail/strike/matthiosflail)


### PR DESCRIPTION
## About The Pull Request

Done off the back of: https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1199

## Testing Evidence

<img width="591" height="228" alt="image" src="https://github.com/user-attachments/assets/9a2a5dcb-da07-4ca0-ab13-247438b1ea92" />

This is just a numberjak. There's no new code.

## Why It's Good For The Game

When the heretical armors and weapons were added, they were intentionally designed to be overpowered. But with the recent changes to swift journey the gilded flail is no longer the best flail. Swift Journey now has the same force and can be paired with a shield. The extra reach is of the gilded flail is nice but it’s not enough for it to not just be a side-grade.

This PR is meant to put the gilded flail back in it's rightful place as the objectively best flail.