### PR TITLE
[TESTMERGE ONLY] Improve lobbyrefresh subsystem speed by 95%~

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -100,7 +100,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 	for (var/job_name in ready_players_by_job)
 		var/list/job_players = ready_players_by_job[job_name]
-		job_list += "<B>[job_name]</B> ([job_players.len]) - [job_players.Join(", ")]"
+		job_list += "<B>[job_name]</B> ([job_players.len]) - [job_players.Join(", ")]<br>"
 	
 	sortTim(job_list, cmp = GLOBAL_PROC_REF(cmp_text_asc))
 


### PR DESCRIPTION
## About The Pull Request

Lobbyrefresh had like 560ms~ execution times at roundstart 120+ players because it was performing something like **30000**+ operations to generate a fucking list of people's ready-upped jobs. This reduces that to well below 1000 in most cases, and should therefore eliminate any chance of overrun slowing down game start under heavy load.

This has the consequence of disabling the old Grand Duke can pick their Hand thing (which I am anecdotally told didn't work anyway) and also changes the sorting to be alphabetical ascending instead of whatever the fuck it was before.

## Testing Evidence

I have not tested this w/ multiple clients yet, hence why it is a draft. TM this only if you're willing to test it live (do not do this

## Why It's Good For The Game

Faster game starts gooderer.
