### PR TITLE
Spell Runes are transparent to mouse + 128 Alpha

### DIFF
--- a/code/game/objects/items/rogueweapons/intent_alert.dm
+++ b/code/game/objects/items/rogueweapons/intent_alert.dm
@@ -6,3 +6,5 @@
 	pixel_y = 32
 	layer = ABOVE_ALL_MOB_LAYER
 	plane = 100
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	alpha = 128


### PR DESCRIPTION
## About The Pull Request
https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/4201
Set mouse opacity to false on spell runes.

## Testing Evidence
<img width="153" height="177" alt="Screenshot 2025-10-25 154042" src="https://github.com/user-attachments/assets/865a49f9-611a-4519-b332-d8cdf9c3316d" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Set mouse opacity to false on spell runes.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
