### PR TITLE
Golem only weapon change proposal

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -765,7 +765,7 @@
 /datum/anvil_recipe/weapons/bronze/golemknuckle
 	name = "Golem Knuckle"
 	req_bar = /obj/item/ingot/bronze
-    additional_items = list(/obj/item/ingot/bronze, /obj/item/ingot/bronze, /obj/item/ingot/steel)
+	additional_items = list(/obj/item/ingot/bronze, /obj/item/ingot/bronze, /obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/knuckles/bronzeknuckles/zizoconstruct
 	craftdiff = 4
 


### PR DESCRIPTION
## About The Pull Request

This PR makes so the Golem Knuckles that are usually a drop from the zizo constructs becomes a craftable recipe for the smiths.

## Testing Evidence

<img width="950" height="509" alt="image" src="https://github.com/user-attachments/assets/8927ed06-1e98-4a18-9041-4e68c4e21bc9" />
<img width="441" height="450" alt="image" src="https://github.com/user-attachments/assets/ed720366-c017-44df-b92a-ef576175a744" />
<img width="1084" height="82" alt="image" src="https://github.com/user-attachments/assets/4ead699a-b0fc-4e1a-a78e-00fe2b46690f" />


## Why It's Good For The Game

Well I know this is a usual loot but it has a few issues I wanted to address:

Firstly it's only worth 3 mammons so it won't ever get bought back to the merchant.

Anyone that doesn't have bleed immunity won't even be able to carry it so only way would be using a sack UNLESS you are a golem.

Golems are a VERY unique race with their own way to level up, own way to heal so might as well used content already in the game to give them a different unique weapon. Surely it's not SUPER good and that's on purpose, it's just flavourful.
