### PR TITLE
Adds Dynamic Wounds to Necra's Vow

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -554,7 +554,7 @@
 	if(owner.blood_volume < BLOOD_VOLUME_NORMAL)
 		owner.blood_volume = min(owner.blood_volume + (healing_on_tick + 10), BLOOD_VOLUME_NORMAL)
 	if(wCount.len > 0)
-		owner.heal_wounds(healing_on_tick, list(/datum/wound/slash, /datum/wound/puncture, /datum/wound/bite, /datum/wound/bruise))
+		owner.heal_wounds(healing_on_tick, list(/datum/wound/slash, /datum/wound/puncture, /datum/wound/bite, /datum/wound/bruise, /datum/wound/dynamic))
 		owner.update_damage_overlays()
 	owner.adjustBruteLoss(-healing_on_tick, 0)
 	owner.adjustFireLoss(-healing_on_tick, 0)


### PR DESCRIPTION
## About The Pull Request

Updates Necra's Vow to work with omniwounds. Fixes a bug where wounds would not be healed by the passive regeneration of Necra's Vow.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="191" height="144" alt="image" src="https://github.com/user-attachments/assets/3cf55662-e930-47bf-9f2d-468fbff43708" />
<img width="144" height="144" alt="image" src="https://github.com/user-attachments/assets/849c2a6c-32dd-4597-a940-847f540617ba" />
<img width="612" height="204" alt="image" src="https://github.com/user-attachments/assets/6a3e6750-1e68-407b-8141-ca58ffbf8403" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Bugfix. Necra's Vow heals a specific list of wounds, and this list does not appear to have been updated for Omniwounds.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
