### PR TITLE
Pestran Pocket Sand: leeches embed when thrown

### DIFF
--- a/code/modules/roguetown/roguejobs/fisher/leeches.dm
+++ b/code/modules/roguetown/roguejobs/fisher/leeches.dm
@@ -62,6 +62,7 @@
 		"embedded_pain_chance" = 0,
 		"embedded_fall_chance" = 0,
 		"embedded_bloodloss"= 0,
+		"embedded_ignore_throwspeed_threshold" = TRUE,
 	)
 	/// Consistent AKA no lore
 	var/consistent = FALSE


### PR DESCRIPTION
## About The Pull Request

Leeches now embed on targets when thrown at them, the voracious little freeks.

The intelligent and intrepid will find amusing ways to weaponize this.

Note: leeches currently do not affect NPCs. Don't get your hopes up.

## Testing Evidence

<img width="523" height="152" alt="image" src="https://github.com/user-attachments/assets/98d5701c-4f2b-4afb-83c9-d6884338b324" />

## Why It's Good For The Game

Consider fearing the Pestrans and fishers walking around with bags full of leeches. Gives people a new avenue of ridiculous combat shenanigans.
