### PR TITLE
Vampire transfix ability now accounts for compliance mode.

### DIFF
--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -1299,6 +1299,8 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 			return
 		if(L.cmode)
 			willroll += 10
+		if(L.compliance)
+			willroll = 0
 		var/found_psycross = FALSE
 		for(var/obj/item/clothing/neck/roguetown/psicross/silver/I in L.contents) //Subpath fix.
 			found_psycross = TRUE


### PR DESCRIPTION
## About The Pull Request
Transfix now checks for compliance mode and if so, makes it so that you will always lose the contest of wills against transfix.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="557" height="510" alt="image" src="https://github.com/user-attachments/assets/d1861041-cae0-481a-892f-2a648c1e7fd5" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Instant loss enjoyers rejoice!
If in: Submissive and breedable mode
Get: Hypnotized by even the shittiest blood sorcerer. (crimson curse cough)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
