### PR TITLE
[TESTMERGE ONLY] more grungly optimizations

### DIFF
--- a/code/controllers/subsystem/rogue/crediticons.dm
+++ b/code/controllers/subsystem/rogue/crediticons.dm
@@ -6,6 +6,7 @@ SUBSYSTEM_DEF(crediticons)
 	priority = 1
 	var/list/processing = list()
 	var/list/currentrun = list()
+	can_fire = FALSE
 
 /datum/controller/subsystem/crediticons/fire(resumed = 0)
 	if (!resumed)


### PR DESCRIPTION
## About The Pull Request

- disables crediticons subsystem. this nukes the end-of-round head scroll (which breaks more than half the time anyway) in exchange for removing a fairly large source of lag when lots of new characters join the round. crediticons is **expensive as FUCK** and its really low priority meant that it'd often immediately hit overrun, spend all of its budget, then pause either forever for the rest of the round or introduce high spikes of TIDI at a later date when the MC tried to catch it back up during lulls.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

faster speed gooderer
