### PR TITLE
Balancejacks Intellectual and Breaks All Game Balance

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -125,7 +125,7 @@
 /datum/virtue/utility/linguist
 	name = "Intellectual"
 	desc = "I've spent my life surrounded by various books or sophisticated foreigners, be it through travel or other fortunes beset on my life. I've picked up several tongues and wits, and keep a journal closeby. I can tell people's exact prowess."
-	custom_text = "Maximizes Assess benefits with a bonus of the target's Stats. Allows the choice of 3 languages to learn upon joining. +1 INT."
+	custom_text = "Maximizes Assess benefits with a bonus of the target's Stats. Allows the choice of 3 languages to learn upon joining."
 	added_traits = list(TRAIT_INTELLECTUAL)
 	added_skills = list(list(/datum/skill/misc/reading, 3, 6))
 	added_stashed_items = list(
@@ -135,7 +135,6 @@
 	)
 
 /datum/virtue/utility/linguist/apply_to_human(mob/living/carbon/human/recipient)
-	recipient.change_stat("intelligence", 1)
 	addtimer(CALLBACK(src, .proc/linguist_apply, recipient), 50)
 
 /datum/virtue/utility/linguist/proc/linguist_apply(mob/living/carbon/human/recipient)


### PR DESCRIPTION
## About The Pull Request
Removes the +1 INT stat bonus from intellectual. One line change.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It's a one line change I apologize.....
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This virtue has no downsides yet many, many, upsides. I considered replacing the +1 INT with the GOODWRITER trait that archivists get but then I looked and realized you're already getting so much. +3 to Reading skill(this takes you to legendary if you're at journeyman!) and 3 extra languages (Something most people don't even care about and probably use to pick Otavan to listen in on the inquisition only). Not to mention being able to QUICKLY assess your enemies from range and see their stats/skills. This virtue is too good in its current state.

TL;DR: Free +1 INT (most desired) with no downsides (And +3 reading!)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
