### PR TITLE
Fixes Astratan's Gaze not taking skill level into account

### DIFF
--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -233,6 +233,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/buff/astrata_gaze
 	duration = 20 SECONDS
 	var/skill_level = 0
+	status_type = STATUS_EFFECT_REPLACE
 
 /datum/status_effect/buff/astrata_gaze/on_creation(mob/living/new_owner, slevel)
     // Only store skill level here
@@ -242,6 +243,7 @@
 /datum/status_effect/buff/astrata_gaze/on_apply()
 	// Reset base values because the miracle can 
 	// now actually be recast at high enough skill and during day time
+	// This is a safeguard because buff code makes my head hurt
     var/per_bonus = 0
     duration = 20 SECONDS
 


### PR DESCRIPTION
## About The Pull Request
Astratan Gaze was always meant to account for skill level in miracles but has never done so due to bad coding. I've fixed that, but this will introduce some balance concerns. Explained below.

Also my code sucks I hate working with BYOND and I think parent calls are stupid. Correct it if you see problems.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1354" height="793" alt="image" src="https://github.com/user-attachments/assets/533c35a7-f49a-4148-a333-9a3cd41ecfcf" />
<img width="1354" height="793" alt="image" src="https://github.com/user-attachments/assets/3aeb58e3-3d51-4607-9e04-8332a42b4d78" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
First, it's good for the game because bugfixes are good.

The miracle as it is right now has been capped at 40 seconds and +1 perception during daytime. Now that it's fixed, it gets +2 perception if you have at least apprentice miracle skills and multiplies the duration by the skill level consistently.

This means:
During daytime, the 360 view and +2 perception can be maintained for the whole duration of it with just Journeyman(3) miracle skill.
During night time, the 360 view and +1 perception can be maintained for the whole duration of it with Legendary(6) miracle skill.

Any one with Master or above miracle can now almost maintain this miracle indefinitely(only 20 sec cd during nighttime), assuming they have the devotion (it's cheap?) for it. This means they can parry or dodge even with their back turned if they are running away or fighting multiple people.

Honestly, I think it's better like this since it felt really useless and just a gimmick in its broken state, but I can understand there will be balance concerns. I think we should run it as it was intended first before we think about balancejaking it. I am not opposed to tweaking numbers.

Astratan templars and the priest with their Master Polearm skill just got a whole lot more terrifying, though.

DAY:
Apprentice: 80 s
Journeyman: 120 s (same as cooldown)
Expert: 160 s
Master: 200 s
Legendary : 240 s

NIGHT:
Apprentice: 40 s
Journeyman: 60 s
Expert: 80 s
Master: 100 s
Legendary 120 s (same as cooldown)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
