### PR TITLE
Yoroku Balancing - Be Like An Actual Ninja

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
@@ -139,7 +139,7 @@
 	backpack_contents = list(
 		/obj/item/flashlight/flare/torch = 1,
 		/obj/item/recipe_book/survival = 1,
-		/obj/item/reagent_containers/glass/bottle/rogue/strongpoison = 1,
+		/obj/item/reagent_containers/glass/bottle/rogue/berrypoison = 1,
 		)
 	belt = /obj/item/storage/belt/rogue/leather/knifebelt/black/kazengun
 	gloves = /obj/item/clothing/gloves/roguetown/eastgloves1


### PR DESCRIPTION
## About The Pull Request
This PR does the following to make Yoroku feel more like an actual ninja class instead of rogue+:
- Apprentice lockpicking (no lockpick ring).
- Apprentice bows (they do not start with one like thief does, go buy your own).
- Apprentice alchemy (to make bombs and identify poisons/reagents/make their own).
- Expert traps.
- Lightstep + keen ears trait.
- Adds a bottle of berrypoison to their satchel for killing their targets, or themselves if they're caught (and feeling edgy).

## Testing Evidence
<img width="1050" height="460" alt="ninjaproof" src="https://github.com/user-attachments/assets/6fe17c40-70d5-414c-be66-ab2d843f6aff" />

## Why It's Good For The Game
After messing around with Yoroku quite a bit in private testing, I have found it is pretty damn lackluster compared to the thief classes. A thief outclasses it in starting gear alone, not to mention traits and skills. Plus, it just didn't feel like a ninja at all... just a slightly better combat version of thief minus the rest of the good skills thief gets. This has been bothering me for ages ever since it came out so I finally got off my ass to do something about it.

Let's start with the top of the changelog and work down. First, ninjas need to be able to break into places at least to a degree for their work, and historically they also used bows. In these changes, they start with no equipment for these skills but have the training for balance reasons. Ninjas should also know a bit of alchemy, considering they work with poisons, bombs and the like in their career. This should let them create some, as well as smokebombs (if my upcoming PR goes well) as well as being able to identify and create traps.

Lightstep and keen ears are added to make them feel more like a spy. They're a ninja... that's their job. They need to be able to hear what is going on nearby for their client, and they should have the quick steps to match their sneaky getaway like any other rogue.

Berry poison is just a weak poison to dip a dagger in to weaken a target if they need to, or to drink if they can do so in time and save their honor.
