### PR TITLE
Adds Bulk Bomb Recipes || Craftable Smokebombs

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -18,7 +18,7 @@
 	category = "Table"
 	result = list(/obj/item/bomb, /obj/item/bomb, /obj/item/bomb)
 	reqs = list(/obj/item/reagent_containers/glass/bottle = 3, /obj/item/ash = 6, /obj/item/rogueore/coal = 3, /obj/item/natural/cloth = 3)
-	craftdiff = 2
+	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/sbomb
 	name = "smoke bomb"
@@ -32,7 +32,7 @@
 	category = "Table"
 	result = list(/obj/item/smokebomb, /obj/item/smokebomb, /obj/item/smokebomb)
 	reqs = list(/obj/item/reagent_containers/glass/bottle = 3, /obj/item/ash = 6, /obj/item/reagent_containers/powder/salt = 3, /obj/item/natural/cloth = 3)
-	craftdiff = 2
+	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/ozium
 	name = "ozium"


### PR DESCRIPTION
## About The Pull Request
Yeah, you heard me. Craftable bulk bottle bomb recipes and you can now make smoke bombs! It's the same recipe as the bottle bomb, but it's salt instead of coal. Ever wondered why that fog was white?

## Testing Evidence
<img width="526" height="526" alt="boomproof" src="https://github.com/user-attachments/assets/2509f395-9873-47d2-b970-3738312196a3" />

## Why It's Good For The Game
We love committing crimes against humenity. Also, we really needed a way to make smokebombs.