### PR TITLE
Sleep powder (zizobane) no longer works on tox_immune mobs

### DIFF
--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -503,8 +503,10 @@
 
 // TO DO: eventually rewrite drowsyness code to do this instead then it can be expanded
 // The reason why I haven't is because vampire lords have some special code for drowsyness I'll ave to get to...
+// this shit sucks ass and the person above should be fed feet first into a food processor for making this DOGSHIT
 /datum/reagent/sleep_powder/on_mob_metabolize(mob/living/carbon/M)
-	M.apply_status_effect(/datum/status_effect/debuff/knockout)
+	if (!HAS_TRAIT(M, TRAIT_TOXIMMUNE))
+		M.apply_status_effect(/datum/status_effect/debuff/knockout)
 	..()
 
 


### PR DESCRIPTION
## About The Pull Request

Yeah, so, you can zizobane vampires, apparently. Now you can't!

## Testing Evidence

<img width="496" height="129" alt="image" src="https://github.com/user-attachments/assets/6a730e7e-d9c1-4b7e-98c9-e7c75ce5a4be" />

## Why It's Good For The Game

Obviously.
