### PR TITLE
Containers do not autoclose on move

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -950,10 +950,6 @@
 			var/mob/living/L = pulledby
 			L.set_pull_offsets(src, pulledby.grab_state)
 
-//	if(active_storage && !(CanReach(active_storage.parent,view_only = TRUE)))
-	if(active_storage)
-		active_storage.close(src)
-
 	if(!(mobility_flags & MOBILITY_STAND) && !buckled && prob(getBruteLoss()*200/maxHealth))
 		makeTrail(newloc, T, old_direction)
 	//Hearthstone port - track creation hook.


### PR DESCRIPTION
## About The Pull Request

This PR makes it so things like belts/satchels do not automatically close when you move.
This does have the downside that inventory containers like wood bins will not close either, but you still need to be next to it to get anything from it. I think the good outweighs the bad.
## Testing Evidence

<img width="1267" height="957" alt="image" src="https://github.com/user-attachments/assets/b066953b-853b-4732-8bd4-231a8d158a69" />
## Why It's Good For The Game

Makes it easier to do inventory management. You can move while interacting with backpacks.