### PR TITLE
Adds Basic Purchasable Tools to Merchantry

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/tools.dm
+++ b/code/modules/cargo/packsrogue/merchant/tools.dm
@@ -119,11 +119,6 @@
 	cost = 10
 	contains = list(/obj/item/rogueweapon/huntingknife/scissors,)
 
-/datum/supply_pack/rogue/tools/handsaw
-	name = "Handsaw"
-	cost = 10
-	contains = list(/obj/item/rogueweapon/handsaw = 1,)
-
 /datum/supply_pack/rogue/tools/chisel
 	name = "Chisel"
 	cost = 10
@@ -191,6 +186,11 @@
 	name = "Hammer"
 	cost = 35
 	contains = list(/obj/item/rogueweapon/hammer/iron)
+
+/datum/supply_pack/rogue/tools/tongs
+	name = "Tongs"
+	cost = 35
+	contains = list(/obj/item/rogueweapon/tongs)
 
 /datum/supply_pack/rogue/tools/fryingpan
 	name = "Frying Pan"


### PR DESCRIPTION
## About The Pull Request
You can buy from silverface / goldface now:
- Chisel
- Iron scissors
- Hunting Knife
- Tongs

## Testing Evidence
<img width="211" height="123" alt="Scissorproof" src="https://github.com/user-attachments/assets/b3643abe-7585-47ee-8e98-a52eb21aaade" />

## Why It's Good For The Game
Found it odd we had other tools there but not these. Scissors seem to be a hot item people want, and I have wanted on several occasions. It's just iron ones, not the fancy steel ones... go to the smith for that! But if you want to skip that long ass smith line for iron ones, here you go.

Let me know if the prices are too low. I made it the same as the hoe's modifier. I added the handsaw and chisel too since it was lacking those.