### PR TITLE
Allows middle aged to be squire, any age to be clerk and shophand

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -10,7 +10,7 @@
 		/datum/species/lamia,
 	)
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_ages = list(AGE_ADULT)
+	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	advclass_cat_rolls = list(CTAG_SQUIRE = 20)
 	job_traits = list(TRAIT_SQUIRE_REPAIR)
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/clerk.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/clerk.dm
@@ -7,7 +7,6 @@
 	spawn_positions = 1
 	allowed_races = RACES_APPOINTED_OUTCASTS_UP
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_ages = list(AGE_ADULT)
 
 	tutorial = "Clerk, tax-collector, blessed fool. You help the Steward with anything they need and perform their tasks when they are unavailable. Although you aren't a noble, it's not the worst position. The caveat? If money is misplaced or goes missing, a noble could probably weasel out of the stockades as punishment. You? Eh...well, Etrusca is lovely this time of year."
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
@@ -6,7 +6,6 @@
 	total_positions = 1
 	spawn_positions = 1
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_ages = list(AGE_ADULT)
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "You work the largest store in the Reach by grace of the Merchant who has shackled you to this drudgery. The work of stocking shelves and taking inventory for your employer is mind-numbing and repetitive--but at least you have a roof over your head and comfortable surroundings. With time, perhaps you will one day be more than a glorified servant."
 	outfit = /datum/outfit/job/roguetown/shophand


### PR DESCRIPTION
## About The Pull Request
In the wake of the whole discussion surrounding middle-aged veterans, a friend and I talked about middle-aged squires, and found out there's a couple of other odd age restrictions that feel out-of-place now. This allows any age character to play clerk or shophand (did you know [the oldest clerk was 85 and died in 1902 after working for 57 years](https://www.nytimes.com/1902/12/01/archives/oldest-pension-clerk-dead.html)?) and allows middle-aged characters to squire. I think it'd be too far / unsuitable for _old_ characters to squire, but given we allow unholy creations of the gods like dark elves to do it, having a squire that's past their prime and stuck in their position sounds alright.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1395" height="563" alt="ia8z4qXYSo" src="https://github.com/user-attachments/assets/df3e7f4b-09c3-4eb1-9096-3ad035be6d39" />
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
There are people who prefer to play older characters but do not feel they have the experience or seniority to play central roles in some of the areas they're restricted to (having to play merchant if they want to work in the shop, having to play steward if they want to help the stewardry, etc.) and other roles don't work this way (knight, the blacksmiths, the inn, etc.)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
