### PR TITLE
Full plate for heavy knight subclass

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -151,7 +151,7 @@
 	var/armors = list(
 		"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
 		"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
-		"Full set of plate"	= /obj/item/clothing/suit/roguetown/armor/plate/full/fluted,
+		"Full set of plate"	= /obj/item/clothing/suit/roguetown/armor/plate/full,
 		"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
 		"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
 	)


### PR DESCRIPTION
## About The Pull Request

Added full plate as a selectable armor on spawn, for the heavy knight subclass.

## Testing Evidence

<img width="141" height="144" alt="Capture d&#39;écran 2025-11-03 132708" src="https://github.com/user-attachments/assets/3882e053-7c7d-4fca-b5b8-db0883efd5da" />
<img width="284" height="405" alt="Capture d&#39;écran 2025-11-03 132719" src="https://github.com/user-attachments/assets/f47ee201-2b23-4c8b-8cc9-5a20fd5b1e73" />
<img width="460" height="190" alt="Capture d&#39;écran 2025-11-03 132815" src="https://github.com/user-attachments/assets/9526ca0c-8f12-47c3-a57c-0ee93fe69fcf" />


## Why It's Good For The Game

I think it makes sense to give the opportunity to the 'heavy' knight class to be really heavy, considering they don't get riding skills, since they're too heavy to ride.
