### PR TITLE
Makes the keep slightly harder to break into + gives servants a garden and councillors get bigger rooms.

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -28718,6 +28718,7 @@
 /area/rogue/indoors/town/garrison)
 "hWA" = (
 /obj/machinery/light/rogue/torchholder/c,
+/obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "hWN" = (
@@ -32907,9 +32908,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
-"jcY" = (
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/indoors/town)
 "jda" = (
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/ruinedwood/chevron,
@@ -81368,10 +81366,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
-"wsu" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/exposed/town/keep)
 "wsv" = (
 /mob/living/carbon/human/species/goblin/npc/ambush,
 /turf/open/floor/rogue/twig,
@@ -195460,7 +195454,7 @@ fAL
 xSV
 ylh
 ylh
-ylh
+urZ
 ylh
 ylh
 urZ
@@ -196363,7 +196357,7 @@ xSV
 mMx
 mMx
 mMx
-ylh
+urZ
 ylh
 ylh
 ylh
@@ -196813,7 +196807,7 @@ iad
 xAN
 ylh
 mMx
-ylh
+urZ
 fAL
 opX
 opX
@@ -197715,7 +197709,7 @@ opX
 opX
 opX
 xSV
-ylh
+urZ
 mMx
 ylh
 xAN
@@ -198621,7 +198615,7 @@ bNo
 mMx
 mMx
 mMx
-ylh
+urZ
 xAN
 dlD
 ogs
@@ -311162,13 +311156,13 @@ gyu
 gyu
 cDX
 hWA
-wsu
-rMf
+qer
+kAx
 vAw
 vAw
-rMf
+kAx
 izp
-rMf
+kAx
 phl
 phl
 phl
@@ -311619,7 +311613,7 @@ vAw
 vAw
 vAw
 vAw
-rMf
+kAx
 rMf
 phl
 jdu
@@ -312072,7 +312066,7 @@ vAw
 vAw
 vAw
 vAw
-rMf
+kAx
 kAi
 jdu
 phl
@@ -312501,17 +312495,17 @@ ebU
 ebU
 ebU
 aoe
-jcY
+aoe
 phl
 phl
 phl
-jcY
+aoe
+quW
 sNZ
 sNZ
+quW
 sNZ
-sNZ
-sNZ
-sNZ
+quW
 sNZ
 ibp
 phl
@@ -312959,10 +312953,10 @@ aoe
 aoe
 aoe
 aoe
+quW
 sNZ
 sNZ
-sNZ
-sNZ
+quW
 sNZ
 sNZ
 sNZ
@@ -313416,7 +313410,7 @@ rZO
 rZO
 rZO
 sNZ
-sNZ
+quW
 sNZ
 pLh
 phl


### PR DESCRIPTION
## About The Pull Request

Replaces most of the wood exterior keep walls with stone so now you can't just break it with a sword as easily. 

<img width="1920" height="2368" alt="image" src="https://github.com/user-attachments/assets/be2cf448-3fb8-48f2-8e0d-b5ac5ff8c479" />

Removes the gallows that were barely used and expands the area near the keep kitchens to give servants more room to grow crops instead of 8 dirt tiles on a path that knights walk over.

This also removes one of the easiest and most overlooked ways to get into the keep. 

<img width="480" height="704" alt="image" src="https://github.com/user-attachments/assets/ea85fc76-f745-4808-8b56-021a84e541c2" />

Expands the councillors rooms, no longer trapped in a 3x3 cube that resembles a broom closet despite being nobility.
Also gives them a small study area, was requested of me by a councillor main. 

<img width="640" height="704" alt="image" src="https://github.com/user-attachments/assets/5d29e8fa-27d0-4709-905f-ce2f1fe911d5" />


## Testing Evidence

<img width="316" height="324" alt="image" src="https://github.com/user-attachments/assets/70a983e1-9eef-40f3-a1c9-c71827116d1e" />


## Why It's Good For The Game

Thieves break into the keep constantly, this will hopefully help that a little (probably not by much). 