### PR TITLE
Surgery PR 2: Speeeeeeeed boooooooooost

### DIFF
--- a/code/modules/surgery/_surgery_step.dm
+++ b/code/modules/surgery/_surgery_step.dm
@@ -382,8 +382,11 @@
 		var/implement_type = tool_check(user, tool)
 		if(implement_type)
 			speed_mod *= implements_speed[implement_type] || 1
-	speed_mod *= get_location_modifier(target, user)
-
+	speed_mod *= get_location_speed_modifier(target, user)
+	if(target.stat == CONSCIOUS && !HAS_TRAIT(target, TRAIT_NOPAIN) && !target.has_status_effect(/datum/status_effect/buff/drunk))
+		to_chat(user, span_warning("It's hard to work with [target.p_them()] squirming around. Maybe I should give [target.p_them()] something for the pain?"))
+	else
+		speed_mod *= 0.8 //Painkillers make surgery 20% faster
 	return speed_mod
 
 /datum/surgery_step/proc/get_success_probability(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
@@ -392,11 +395,8 @@
 		var/implement_type = tool_check(user, tool)
 		if(implement_type)
 			success_prob *= (implements[implement_type]/100) || 1
-	success_prob *= get_location_modifier(target, user)
+	success_prob *= get_location_success_modifier(target, user)
 	success_prob *= get_skill_modifier(user, target, target_zone, tool, intent)
-	if(target.stat == CONSCIOUS && !HAS_TRAIT(target, TRAIT_NOPAIN) && !target.has_status_effect(/datum/status_effect/buff/drunk))
-		to_chat(user, span_warning("It's hard to work with [target.p_them()] squirming around. Maybe I should give [target.p_them()] something for the pain?"))
-		success_prob = max(success_prob - 20, 0) //Knock 'em out or give 'em painkillers. Flat 20% penalty if they're awake and squirming
 	return success_prob
 
 /datum/surgery_step/proc/get_skill_modifier(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
@@ -413,14 +413,27 @@
 		modifier += skill_maluses[skill_difference]
 	return max(modifier, 0)
 
-/datum/surgery_step/proc/get_location_modifier(mob/living/target)
+/datum/surgery_step/proc/get_location_success_modifier(mob/living/target)
 	var/is_lying = !(target.mobility_flags & MOBILITY_STAND)
 	if(!is_lying)
-		return 0.2 //I'm sorry but nah, we're gonna go ahead and make it REALLY hard to do surgery on somebody who isn't lying down
+		return 0.6
 	if(istype(target.buckled, /obj/structure/table/optable))
 		return 1.2
 	else if(istype(target.buckled, /obj/structure/bed))
-		return 0.9
+		return 1
 	else if(locate(/obj/structure/table) in get_turf(target))
-		return 0.7
-	return 0.5
+		return 0.9
+	return 0.8
+
+
+/datum/surgery_step/proc/get_location_speed_modifier(mob/living/target)
+	var/is_lying = !(target.mobility_flags & MOBILITY_STAND)
+	if(!is_lying)
+		return 3
+	if(istype(target.buckled, /obj/structure/table/optable))
+		return 0.5
+	else if(istype(target.buckled, /obj/structure/bed))
+		return 1
+	else if(locate(/obj/structure/table) in get_turf(target))
+		return 1.3
+	return 2


### PR DESCRIPTION
## About The Pull Request

Adjusts surgery logic and numbers in response to player feedback. Fixes a bug where surgery speed was WORSE the more favorable the conditions.

- Removes 20% increased failure chance when performing surgery without anasthesia. Instead, anasthesia increases surgery speed by 20%

- Rebalances surgery times based on conditions. Beds and operating tables are the fastest, standing is the slowest.

- Adjusted situational success probability modifiers.

- Corrected an issue where improving surgery conditions caused surgery to become slower, rather than faster.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="456" height="257" alt="image" src="https://github.com/user-attachments/assets/a7009647-bdeb-4504-a459-9b2e3cd27150" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Rounds off some rough edges from the last surgery PR. Makes things behave closer to how they're intended.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
