### PR TITLE
Fixes Martyr Sword

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -573,6 +573,10 @@
 		added_def = 0,\
 	)
 
+/obj/item/rogueweapon/sword/long/martyr/Initialize()
+	AddComponent(/datum/component/martyrweapon)
+	..()
+
 /obj/item/rogueweapon/sword/long/martyr/attack_hand(mob/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user


### PR DESCRIPTION
## About The Pull Request
Fixes the martyr sword components (e.g the oath mechanics) not working at all, which was broken by the silver rework.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="557" height="399" alt="image" src="https://github.com/user-attachments/assets/44320c73-5daf-4235-85c3-e83e32b81434" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The silver rework on Azure had this extra code added after the blessed component initialization. This part was not ported alongside the rest of the silver rework, breaking the martyr sword entirely. Woe.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
