### PR TITLE
Allows Grenz Plumes on Mask slot

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -1942,6 +1942,8 @@
 	icon_state = "grenzelhat"
 	item_state = "grenzelhat"
 	icon = 'icons/roguetown/clothing/head.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/onmob/head.dmi'
+	alternate_worn_layer  = 8.9 //On top of helmet
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/stonekeep_merc.dmi'
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK
 	detail_tag = "_detail"


### PR DESCRIPTION
## About The Pull Request

FINALLY THE **GRENZ DRIP** NO MORE EXCUSES TO NOT WEAR THE HAT. FOR THE EMPIRE! GRENZELHOFT STANDS!

## Testing Evidence

<img width="653" height="440" alt="Screenshot 2025-11-05 075402" src="https://github.com/user-attachments/assets/db9677e1-0e61-4ec3-913c-9c6a2f26742d" />
<img width="1009" height="432" alt="Screenshot 2025-11-05 075405" src="https://github.com/user-attachments/assets/78e9f998-5055-4e53-8dda-febd607caf6d" />
<img width="981" height="422" alt="Screenshot 2025-11-05 075626" src="https://github.com/user-attachments/assets/6e557660-e184-43d6-87bd-374f8a3561ae" />

## Why It's Good For The Game

SCOT-- GRENZELHOFT FOREVER!!!
