### PR TITLE
Knife Boot fix for Grenzelhoft

### DIFF
--- a/code/modules/cargo/packsrogue/Sellsword.dm
+++ b/code/modules/cargo/packsrogue/Sellsword.dm
@@ -27,7 +27,7 @@
 /datum/supply_pack/rogue/Sellsword/Grenzelshoes
 	name = "Grenzel Shoes"
 	cost = 15
-	contains = list(/obj/item/clothing/shoes/roguetown/grenzelhoft)
+	contains = list(/obj/item/clothing/shoes/roguetown/boots/grenzelhoft)
 
 /datum/supply_pack/rogue/Sellsword/coif/steel
 	name = "Steel Coif"

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -215,7 +215,7 @@
 	salvage_result = /obj/item/natural/hide/cured
 	sewrepair = TRUE
 
-/obj/item/clothing/shoes/roguetown/grenzelhoft
+/obj/item/clothing/shoes/roguetown/boots/grenzelhoft
 	name = "grenzelhoft boots"
 	icon_state = "grenzelboots"
 	item_state = "grenzelboots"

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -299,7 +299,7 @@
 			head = /obj/item/clothing/head/roguetown/grenzelhofthat
 			armor = /obj/item/clothing/suit/roguetown/armor/plate/half
 			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
-			shoes = /obj/item/clothing/shoes/roguetown/grenzelhoft
+			shoes = /obj/item/clothing/shoes/roguetown/boots/grenzelhoft
 			gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
 			beltl = /obj/item/rogueweapon/sword/short
 			beltr = /obj/item/storage/keyring/guardcastle

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -59,7 +59,7 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
 	head = /obj/item/clothing/head/roguetown/grenzelhofthat
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
-	shoes = /obj/item/clothing/shoes/roguetown/grenzelhoft
+	shoes = /obj/item/clothing/shoes/roguetown/boots/grenzelhoft
 	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backpack_contents = list(
@@ -122,7 +122,7 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
 	head = /obj/item/clothing/head/roguetown/grenzelhofthat
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
-	shoes = /obj/item/clothing/shoes/roguetown/grenzelhoft
+	shoes = /obj/item/clothing/shoes/roguetown/boots/grenzelhoft
 	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backpack_contents = list(
@@ -193,7 +193,7 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
 	head = /obj/item/clothing/head/roguetown/grenzelhofthat
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
-	shoes = /obj/item/clothing/shoes/roguetown/grenzelhoft
+	shoes = /obj/item/clothing/shoes/roguetown/boots/grenzelhoft
 	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backpack_contents = list(

--- a/code/modules/roguetown/roguecrafting/leather/leather_unique_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather_unique_recipes.dm
@@ -32,7 +32,7 @@
 
 /datum/crafting_recipe/roguetown/leather/unique/grenzelboots
 	name = "grenzelhoftian boots"
-	result = list(/obj/item/clothing/shoes/roguetown/grenzelhoft)
+	result = list(/obj/item/clothing/shoes/roguetown/boots/grenzelhoft)
 	reqs = list(/obj/item/natural/hide/cured = 1,
 	            /obj/item/reagent_containers/food/snacks/tallow = 1,
 				/obj/item/natural/fur = 1,


### PR DESCRIPTION
## About The Pull Request

Allows Knives to be slotted into Grenz Boots, since they weren't considered boots in code. Fixes this.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Oversight with Boots.
