### PR TITLE
Ports decashield for da martyr.

### DIFF
--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -231,7 +231,6 @@
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silver
 
-
 /obj/item/rogueweapon/shield/tower/metal/psy/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\
@@ -242,6 +241,36 @@
 		added_int = 100,\
 		added_def = 1,\
 	)
+
+/obj/item/rogueweapon/shield/tower/metal/holysee
+	name = "decablessed shield"
+	desc = "Protection of the Ten upon the wielder. A final, staunch line against the darkness. For it's not what is before the shield-carrier that matters, but the home behind them."
+	icon_state = "gsshield"
+	var/swapped = FALSE
+	flags_1 = CONDUCT_1
+	sellprice = 30
+
+/obj/item/rogueweapon/shield/tower/metal/holysee/MiddleClick(mob/user, params)
+	. = ..()
+	swapped = !swapped
+	update_icon()
+
+/obj/item/rogueweapon/shield/tower/metal/holysee/update_icon()
+	. = ..()
+	if(swapped)
+		icon_state = "gsshielddark"
+	else
+		icon_state = "gsshield"
+
+
+/obj/item/rogueweapon/shield/tower/getonmobprop(tag)
+	. = ..()
+	if(tag)
+		switch(tag)
+			if("gen")
+				return list("shrink" = 0.6,"sx" = -5,"sy" = -1,"nx" = 6,"ny" = -1,"wx" = 0,"wy" = -2,"ex" = 0,"ey" = -2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0)
+			if("onback")
+				return list("shrink" = 0.6,"sx" = 1,"sy" = 4,"nx" = 1,"ny" = 2,"wx" = 3,"wy" = 3,"ex" = 0,"ey" = 2,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 8,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
 
 /obj/item/rogueweapon/shield/tower/metal/alloy
 	name = "decrepit shield"

--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -514,6 +514,7 @@
 	beltr = /obj/item/storage/keyring/priest
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/rich
 	backr = /obj/item/storage/backpack/rogue/satchel
+	backl = /obj/item/rogueweapon/shield/tower/metal/holysee
 	gloves = /obj/item/clothing/gloves/roguetown/chain
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	neck = /obj/item/clothing/neck/roguetown/bevor


### PR DESCRIPTION
## About The Pull Request
Ports the following azure PR which utilizes the unused sprites for holy see shields into a kite-shield level shield and also gives it to the martyr.
https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3556

It's effectively a kite shield which can be swapped between 2 icon states (via mmb), an astrata and a noc themed shield!
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1072" height="586" alt="image" src="https://github.com/user-attachments/assets/e90c3520-f83e-4f05-b278-4e6c2fde9b2d" />
<img width="1918" height="1014" alt="image" src="https://github.com/user-attachments/assets/48edbcef-af14-4eaf-9309-eddfb45f5332" />
(On mob sprite doesn't update immediately, you gotta holster it/do something that updates mob state or w/e)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It's a cool shield and the martyr sword is effective as a one handed weapon + the martyr has journeyman shields. They should get a shield!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
