### PR TITLE
Changed the Astratan Templar Helmet.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -230,7 +230,7 @@
 	switch(H.patron?.type)
 		if(/datum/patron/divine/astrata)
 			wrists = /obj/item/clothing/neck/roguetown/psicross/astrata
-			head = /obj/item/clothing/head/roguetown/helmet/heavy/astratan
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/astratahelm
 			cloak = /obj/item/clothing/cloak/templar/astratan
 		if(/datum/patron/divine/abyssor)
 			wrists = /obj/item/clothing/neck/roguetown/psicross/abyssor
@@ -324,7 +324,7 @@
 			H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
 		if("Longsword")
 			H.put_in_hands(new /obj/item/rogueweapon/sword/long(H), TRUE)
-			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)	
+			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 		if("Flail")
 			H.put_in_hands(new /obj/item/rogueweapon/flail(H), TRUE)
 			H.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)


### PR DESCRIPTION
## About The Pull Request

The Astratan Bucket helmet, unfortunately, is ugly as sin - and we have a fancier, nicer-looking one capable  of being forged. Adventurer paladins can keep the ugly bucket helmet, whereas the town's Templars will spawn with a helm that looks as cool as all the others.

## Testing Evidence
Templar:
<img width="1021" height="424" alt="dreamseeker_2025-11-07_00-42-29" src="https://github.com/user-attachments/assets/84401710-9a6e-48f8-88cb-6f75f567b360" />
Adventurer Paladin:
<img width="998" height="273" alt="dreamseeker_2025-11-07_00-43-26" src="https://github.com/user-attachments/assets/4b29f3cb-9b7f-4269-a0eb-13308c6be1b5" />

## Why It's Good For The Game

The bucket helmet is ugly. The sleek Astratan helm is cool. Simple as.