### PR TITLE
Adds FLW to LOOC chat logs

### DIFF
--- a/modular_hearthstone/code/interface/LOOC.dm
+++ b/modular_hearthstone/code/interface/LOOC.dm
@@ -86,7 +86,7 @@
 		if(!M.client)
 			continue
 		if((C in GLOB.admins) && (C.prefs.chat_toggles & CHAT_ADMINLOOC))
-			added_text += " ([mob.ckey]) <A href='?_src_=holder;[HrefToken()];mute=[ckey];mute_type=[MUTE_LOOC]'><font color='[(muted & MUTE_LOOC)?"red":"blue"]'>\[MUTE\]</font></a>"
+			added_text += " ([mob.ckey]) [ADMIN_FLW(mob)] <A href='?_src_=holder;[HrefToken()];mute=[ckey];mute_type=[MUTE_LOOC]'><font color='[(muted & MUTE_LOOC)?"red":"blue"]'>\[MUTE\]</font></a>"
 			is_admin = 1
 		else if(isobserver(M))
 			continue


### PR DESCRIPTION
## About The Pull Request
Taken from: 
- (https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/4387)

Jannies can now follow LOOC messages

## Testing Evidence
<img width="174" height="29" alt="image" src="https://github.com/user-attachments/assets/fd7b27bb-3676-4be5-a45b-f099b37a420c" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
So I don't have to open up the player panel every time I want to follow someone salting in LOOC.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
