### PR TITLE
Slight Spear Hunter Balancing

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
@@ -68,6 +68,7 @@
 	tutorial = "You are a hunter. With your bow you hunt the fauna of the glade, skinning what you kill and cooking any meat left over. The job is dangerous but important in the circulation of clothing and light armor."
 	outfit = /datum/outfit/job/roguetown/adventurer/hunter_spear
 
+	traits_applied = list(TRAIT_OUTDOORSMAN, TRAIT_WOODSMAN)	
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_CON = 1,
@@ -98,6 +99,7 @@
 /datum/outfit/job/roguetown/adventurer/hunter_spear/pre_equip(mob/living/carbon/human/H)
 	..()
 	to_chat(H, span_warning("You are a hunter who specializes in spears, excelling in strength and endurance."))
+	head = /obj/item/clothing/head/roguetown/helmet/leather
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
@@ -108,7 +110,7 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/storage/meatbag
 	beltl = /obj/item/flashlight/flare/torch/lantern
-	l_hand = /obj/item/rogueweapon/spear
+	l_hand = /obj/item/rogueweapon/spear/boar
 	backpack_contents = list(
 				/obj/item/flint = 1,
 				/obj/item/bait = 1,


### PR DESCRIPTION
## About The Pull Request
- Removes DE from towner spear hunter.
- Gives them a leather helmet and boar spear in exchange.

## Testing Evidence
Ignore the darksight / etc that's from Noc's bonus. They just have woodsman and outdoorsman now.
<img width="692" height="566" alt="Spearmanproof" src="https://github.com/user-attachments/assets/cfde4a53-a98f-46f6-8431-064c8a3a754b" />

## Why It's Good For The Game
Might be controversial to some but as someone who has played this class a lot in testing fighting mobs because it's probably the most well rounded combat class amongst towners and even adventurers, they don't need the DE. It's just a nice class overall, but it's already too good to justify having DE. There are other reasons too, let me tell you.

Why? Because they don't need to use the bow unless you train it later in game (which isn't necessary when you got a cool spear), whereas the bow-hunter needs that since their starter kit is more lacking. Also, spear hunter gets no speed bonuses, whereas you do with bow hunter to take advantage of dodge rolls. I would rather PARRY with my spear than dodge as a spear hunter, and make use of my defense bonus. Even if you take the swift statpack, having at most 13 speed with your outdoors bonus is pretty meh with DE. I mean, it will let you dodge a lot but you're also losing out on other things like the arcane potential virtue's basic T1 spells (can't get those with DE) which is a really nice thing to have as a towner.

And speaking of defense bonuses from my point earlier, I gave them a basic leather helmet and a boar spear (just a cooler spear with only +1 more def) instead of the basic spear, as it felt more specialized for their role as a hunter and it just looks nice.

Hopefully this will make players decide if they want that nice DE roguish setup as a bow hunter or be what the spear hunter was intended to be which was a stronger, slightly more durable hunter in sacrifice of extra mobility.