### PR TITLE
Fixes drag&drop spell behavior

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -223,8 +223,7 @@
 	if(tcompare)
 		var/atom/target_atom = object
 		if(istype(target_atom) && tcompare != mob && (mob.atkswinging == "middle" || (mob.atkswinging && object != tcompare)))
-			if(mob.atkswinging == "middle" || (mob.atkswinging && object != tcompare))
-				target_atom.Click(location, control, params)
+			target_atom.Click(location, control, params)
 		tcompare = null
 
 //	mouse_pointer_icon = 'icons/effects/mousemice/human.dmi'


### PR DESCRIPTION
## About The Pull Request

This shit has been abrasive enough to raise me from my grave.
The problem is simple and hides in here, notice the ``object != tcompare`` (tcompare is the object we clicked initially on in /client/MouseDown()

```	if(tcompare)
		if(object)
			if(isatom(object) && object != tcompare && mob.atkswinging && tcompare != mob)
				var/atom/N = object
				N.Click(location, control, params)
		tcompare = null

```

The solution is to do the if ``mob.atkswinging == "middle"`` check since middle swings are required for chargeup, otherwise it works as before. (Adjacent() check was a wrong solution as it turns out)
## Testing Evidence

Melee, ranged and spells seem to work. Spells seem to work even after mousedrag on mob.

https://github.com/user-attachments/assets/746cf4f8-9733-45d3-97d6-0e9e9922278a

## Why It's Good For The Game

Uhh I think I need spells to feel less like I'm wiping my ass with sandpaper