### PR TITLE
Permits foreigners to use the Meister with extra tax

### DIFF
--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -1,7 +1,7 @@
 #define RURAL_TAX 50 // Free money. A small safety pool for lowpop mostly
 #define TREASURY_TICK_AMOUNT 6 MINUTES
 #define EXPORT_ANNOUNCE_THRESHOLD 100
-#define FOREIGNER_TAX_SURCHARGE 0.05 //Amount extra that non-noble foreigners are charged as tax
+#define FOREIGNER_TAX_MULTIPLIER 1.5 //Amount that the tax rate is multiplied by for foreigners
 
 /proc/send_ooc_note(msg, name, job)
 	var/list/names_to = list()
@@ -170,7 +170,7 @@ SUBSYSTEM_DEF(treasury)
 		if(HAS_TRAIT(character, TRAIT_NOBLE))
 			bank_accounts[character] += amt
 		else if(HAS_TRAIT(character, TRAIT_OUTLANDER) && !HAS_TRAIT(character, TRAIT_INQUISITION)) //Outsiders who aren't inquisition get taxed extra
-			taxed_amount = round(amt * (tax_value + FOREIGNER_TAX_SURCHARGE))
+			taxed_amount = round(amt * tax_value * FOREIGNER_TAX_MULTIPLIER)
 			amt -= taxed_amount
 			bank_accounts[character] += amt
 		else

--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -165,7 +165,7 @@
 
 /obj/structure/roguemachine/atm/examine(mob/user)
 	. += ..()
-	. += span_info("The current tax rate on deposits is [SStreasury.tax_value * 100] percent. Nobles exempt. Non-noble foreigners pay extra.")
+	. += span_info("The current tax rate on deposits is [SStreasury.tax_value * 100] percent. Nobles exempt. Non-noble foreigners are taxed at a 50% higher rate.")
 
 
 /obj/structure/roguemachine/atm/proc/drill(obj/structure/roguemachine/atm)


### PR DESCRIPTION
## About The Pull Request

Comments out the code making foreigners unable to use the Meister. Now they can, but if they aren't a noble or part of the Inquisition they get taxed at 150% the rate of normal people (e.g. if the tax rate is 20% they are charged 30%)

## Testing Evidence

See later comment for test of current code.

## Why It's Good For The Game

Prohibiting foreigners from using the Meister doesn't really do anything positive for the game. It locks them out of being able to fill the stockpile for money, requires them to find a place to stash larger amounts of cash (walking to and from your money box is not good gameplay), and is generally a nuisance. Furthermore, it doesn't make much sense in-character, as the Duke can only collect taxes when people use the Meister. This means that foreigners just don't get taxed, any tax-enforcement laws can't really apply to them (can't demand people put their money in the Meister if they're literally incapable). This change makes it so that they can use it, but there's still a penalty to being foreign in the form of an extra tax, currently at 5%.