### PR TITLE
Fix global wound regeneration

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -36,12 +36,12 @@
 		handle_blood()
 		//passively heal even wounds with no passive healing
 
-	var/heal_amount = 1 + (blood_volume > BLOOD_VOLUME_SURVIVE ? 0.6 : 0)
-	// apparently this means NPCs should heal their wounds slowly over time,
-	// with a 60% bonus if they're not completely bled out.
-	// this is a strict replacement for two whole-ass block iteration things that did the same thing (or nothing at all)
-	heal_wounds(heal_amount)
-	
+		var/heal_amount = 1 + (blood_volume > BLOOD_VOLUME_SURVIVE ? 0.6 : 0)
+		// apparently this means NPCs should heal their wounds slowly over time,
+		// with a 60% bonus if they're not completely bled out.
+		// this is a strict replacement for two whole-ass block iteration things that did the same thing (or nothing at all)
+		heal_wounds(heal_amount)
+		
 	if (QDELETED(src)) // diseases can qdel the mob via transformations
 		return
 


### PR DESCRIPTION
## About The Pull Request

[This comment covers this best.](https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1386#issuecomment-3506601603)

TLDR: simple mob wound regeneration was applying to everyone when it shouldn't have (including human mobs). Wounds should be significantly more dangerous now over long periods of time.

## Testing Evidence

<img width="462" height="140" alt="image" src="https://github.com/user-attachments/assets/72587c74-37ee-4beb-9a02-993ecbe6d6e3" />

## Why It's Good For The Game

People probably shouldn't be regenerating like Psydonites all the time by default.
