### PR TITLE
Kashira & Ruma Hats

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/kashira.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/kashira.dm
@@ -35,6 +35,7 @@
 
 /datum/outfit/job/roguetown/mercenary/kashira/pre_equip(mob/living/carbon/human/H)
 	..()
+	head = /obj/item/clothing/head/roguetown/mentorhat
 	armor = /obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe
 	shirt = /obj/item/clothing/suit/roguetown/armor/skin_armor/easttats
 	cloak = /obj/item/clothing/cloak/eastcloak1

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/rumaclan.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/rumaclan.dm
@@ -33,6 +33,7 @@
 /datum/outfit/job/roguetown/mercenary/rumaclan/pre_equip(mob/living/carbon/human/H)
 	..()
 	to_chat(H, span_warning("You are relatively versed in the art of \"swinging a sword until enemy death.\" - You would gladly take up most jobs for money, or a chance to cut loose."))
+	head = /obj/item/clothing/head/roguetown/mentorhat
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/rogueweapon/scabbard/sword/kazengun/steel
 	beltl = /obj/item/rogueweapon/sword/sabre/mulyeog/rumahench


### PR DESCRIPTION
## About The Pull Request
Gives the Kazengun mercenary classes some extra armor, specifically the weak iron hat the adventurers get.

## Testing Evidence
<img width="631" height="514" alt="Clanproof" src="https://github.com/user-attachments/assets/234abcad-56e6-4c36-9f16-38ade26a340b" />

## Why It's Good For The Game
Requested by a friend, and the fact that these classes did not have a starter helmet. It looks drippy, has decent defensive stats but low durability. It will likely get replaced at the smithy later unless players choose to keep it for style points.
