### PR TITLE
Fixes Bad Math in Buff Code

### DIFF
--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -67,7 +67,7 @@
 						break
 		else
 			if((owner.get_stat(S) + effectedstats[S]) > 20)	//We check for overflow as well.
-				effectedstats[S] = max(((owner.get_stat(S) + effectedstats[S]) - 20), 0)
+				effectedstats[S] = 20 - owner.get_stat(S)
 		owner.change_stat(S, effectedstats[S])
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
The buff code that protected from overflow (Stats above 20) had bad math that rounded all buffs to 1 instead of the max. 
(Example: 16 perception + hawk eyes = 21 perception. Ideally, this makes the buff give +4 perception to reach 20. Instead, it gave +1 perception).
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Before: 
<img width="433" height="97" alt="image" src="https://github.com/user-attachments/assets/787aed90-0e14-4a8b-9823-03166265af69" />
After: 
<img width="428" height="90" alt="image" src="https://github.com/user-attachments/assets/5c7846d6-5487-4089-8095-a704d1ffc3f2" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
bugfix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
