### PR TITLE
Blacksmith / Artificer Apprentice Virtue Changes

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -210,6 +210,7 @@
 	added_skills = list(list(/datum/skill/craft/crafting, 2, 2),
 						list(/datum/skill/craft/carpentry, 2, 2),
 						list(/datum/skill/craft/masonry, 2, 2),
+						list(/datum/skill/craft/blacksmithing, 2, 2),
 						list(/datum/skill/craft/engineering, 2, 2),
 						list(/datum/skill/craft/smelting, 2, 2),
 						list(/datum/skill/misc/ceramics, 2, 2)


### PR DESCRIPTION
## About The Pull Request
- Engineering to Blacksmith apprentice.
- Blacksmith to Artificer apprentice.

## Testing Evidence
Trust me bro it's a 2 line change. Also, it compiled.

## Why It's Good For The Game
Someone pointed this out on the discord and I answered. Blacksmiths already get engineering, but the virtue doesn't give it to you. And you need it to make things like locks.

Apparently having basic blacksmith would be nice on artificer too. This does not include armor/weapon smithing. If you want that, choose blacksmith apprentice.