### PR TITLE
Appeasing the linters: removal of relative pathed procs

### DIFF
--- a/code/datums/sexcon/sex_actions/deviant/tailjob.dm
+++ b/code/datums/sexcon/sex_actions/deviant/tailjob.dm
@@ -8,7 +8,7 @@
 		return FALSE
 	if(!target.getorganslot(ORGAN_SLOT_PENIS))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) && !islamia(user))
 		return FALSE
 	return TRUE
 
@@ -19,7 +19,7 @@
 		return FALSE
 	if(!target.getorganslot(ORGAN_SLOT_PENIS))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) && !islamia(user))
 		return FALSE
 	return TRUE
 

--- a/code/datums/sexcon/sex_actions/deviant/tailpegging_anal.dm
+++ b/code/datums/sexcon/sex_actions/deviant/tailpegging_anal.dm
@@ -7,7 +7,7 @@
 /datum/sex_action/tailpegging_anal/shows_on_menu(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user == target)
 		return FALSE
-	if((!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user)) || !target.sexcon.can_zodomize())
+	if((!user.getorganslot(ORGAN_SLOT_TAIL) && !islamia(user)) || !target.sexcon.can_zodomize())
 		return FALSE
 	return TRUE
 
@@ -16,7 +16,7 @@
 		return FALSE
 	if(!check_location_accessible(user, target, BODY_ZONE_PRECISE_GROIN, TRUE))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) && !islamia(user))
 		return FALSE
 	return TRUE
 

--- a/code/datums/sexcon/sex_actions/deviant/tailpegging_vaginal.dm
+++ b/code/datums/sexcon/sex_actions/deviant/tailpegging_vaginal.dm
@@ -9,7 +9,7 @@
 		return FALSE
 	if(!target.getorganslot(ORGAN_SLOT_VAGINA))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) && !islamia(user))
 		return FALSE
 	return TRUE
 
@@ -20,7 +20,7 @@
 		return FALSE
 	if(!target.getorganslot(ORGAN_SLOT_VAGINA))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) && !islamia(user))
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/items/rogueitems/bombs.dm
+++ b/code/game/objects/items/rogueitems/bombs.dm
@@ -264,9 +264,9 @@
 	throw_speed = 1
 
 	// Define a base explodes() proc that subtypes can override because its now explodes proc
-	proc/explodes()
-		STOP_PROCESSING(SSfastprocess, src)
-		qdel(src) // Delete the grenade after use boy (ALWAYS USE IT)
+/obj/item/impact_grenade/proc/explodes()
+	STOP_PROCESSING(SSfastprocess, src)
+	qdel(src) // Delete the grenade after use boy (ALWAYS USE IT)
 
 /obj/item/impact_grenade/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	..()
@@ -280,81 +280,81 @@
 	name = "Impact grenade"
 	desc = "Some substance, hidden under some paper and skin. This one sparks..."
 
-	explodes() 
-		STOP_PROCESSING(SSfastprocess, src)
-		var/turf/T = get_turf(src)
-		if(T)
-			explosion(T, heavy_impact_range = 1, light_impact_range = 2, flame_range = 2, smoke = TRUE, soundin = pick('sound/misc/explode/bottlebomb (1).ogg','sound/misc/explode/bottlebomb (2).ogg'))
-			qdel(src)
+/obj/item/impact_grenade/explosion/explodes() 
+	STOP_PROCESSING(SSfastprocess, src)
+	var/turf/T = get_turf(src)
+	if(T)
+		explosion(T, heavy_impact_range = 1, light_impact_range = 2, flame_range = 2, smoke = TRUE, soundin = pick('sound/misc/explode/bottlebomb (1).ogg','sound/misc/explode/bottlebomb (2).ogg'))
+		qdel(src)
 
 /obj/item/impact_grenade/smoke
 	name = "Impact grenade"
 	desc = "Some substance, hidden under some paper and skin. This one emits clouds of harmless smoke..."
 
-	explodes()
-		STOP_PROCESSING(SSfastprocess, src)
-		var/turf/T = get_turf(src)
-		playsound(T, 'sound/misc/explode/incendiary (1).ogg', 100)
-		for(T in view(1, T))
-			new /obj/effect/particle_effect/smoke(T)
-		qdel(src)
+/obj/item/impact_grenade/smoke/explodes()
+	STOP_PROCESSING(SSfastprocess, src)
+	var/turf/T = get_turf(src)
+	playsound(T, 'sound/misc/explode/incendiary (1).ogg', 100)
+	for(T in view(1, T))
+		new /obj/effect/particle_effect/smoke(T)
+	qdel(src)
 
 /obj/item/impact_grenade/poison_gas
 	name = "Impact grenade"
 	desc = "Some substance, hidden under some paper and skin. The smell of this one makes you to gasp..."
 
-	explodes() 
-		STOP_PROCESSING(SSfastprocess, src)
-		var/turf/T = get_turf(src)
-		playsound(T, 'sound/misc/explode/incendiary (1).ogg', 100)
-		for(T in view(2, T))
-			new /obj/effect/particle_effect/smoke/poison_gas(T)
-		qdel(src)
+/obj/item/impact_grenade/poison_gas/explodes() 
+	STOP_PROCESSING(SSfastprocess, src)
+	var/turf/T = get_turf(src)
+	playsound(T, 'sound/misc/explode/incendiary (1).ogg', 100)
+	for(T in view(2, T))
+		new /obj/effect/particle_effect/smoke/poison_gas(T)
+	qdel(src)
 
 /obj/item/impact_grenade/healing_gas
 	name = "impact grenade"
 	desc = "Some substance, hidden under some paper and skin. The smell of this one reminds you the taste of red..."
 
-	explodes() 
-		STOP_PROCESSING(SSfastprocess, src)
-		var/turf/T = get_turf(src)
-		playsound(T, 'sound/misc/explode/incendiary (1).ogg', 100)
-		for(T in view(2, T))
-			new /obj/effect/particle_effect/smoke/healing_gas(T)
-		qdel(src)
+/obj/item/impact_grenade/healing_gas/explodes() 
+	STOP_PROCESSING(SSfastprocess, src)
+	var/turf/T = get_turf(src)
+	playsound(T, 'sound/misc/explode/incendiary (1).ogg', 100)
+	for(T in view(2, T))
+		new /obj/effect/particle_effect/smoke/healing_gas(T)
+	qdel(src)
 
 /obj/item/impact_grenade/fire_gas
 	name = "impact grenade"
 	desc = "Some substance, hidden under some paper and skin. Smells like a chicken and burns your hand..."
 
-	explodes() 
-		STOP_PROCESSING(SSfastprocess, src)
-		var/turf/T = get_turf(src)
-		playsound(T, 'sound/misc/explode/incendiary (1).ogg', 100)
-		for(T in view(2, T))
-			new /obj/effect/particle_effect/smoke/fire_gas(T)
-		qdel(src)
+/obj/item/impact_grenade/fire_gas/explodes() 
+	STOP_PROCESSING(SSfastprocess, src)
+	var/turf/T = get_turf(src)
+	playsound(T, 'sound/misc/explode/incendiary (1).ogg', 100)
+	for(T in view(2, T))
+		new /obj/effect/particle_effect/smoke/fire_gas(T)
+	qdel(src)
 
 /obj/item/impact_grenade/blind_gas
 	name = "impact grenade"
 	desc = "Some substance, hidden under some paper and skin. The smell that comes from this one makes your eyes to cry."
 
-	explodes() 
-		STOP_PROCESSING(SSfastprocess, src)
-		var/turf/T = get_turf(src)
-		playsound(T, 'sound/misc/explode/incendiary (1).ogg', 100)
-		for(T in view(2, T))
-			new /obj/effect/particle_effect/smoke/blind_gas(T)
-		qdel(src)
+/obj/item/impact_grenade/blind_gas/explodes() 
+	STOP_PROCESSING(SSfastprocess, src)
+	var/turf/T = get_turf(src)
+	playsound(T, 'sound/misc/explode/incendiary (1).ogg', 100)
+	for(T in view(2, T))
+		new /obj/effect/particle_effect/smoke/blind_gas(T)
+	qdel(src)
 
 /obj/item/impact_grenade/mute_gas
 	name = "impact grenade"
 	desc = "Some substance, hidden under some paper and skin. Smell of this one makes your mind clean and not able to say a word."
 
-	explodes() 
-		STOP_PROCESSING(SSfastprocess, src)
-		var/turf/T = get_turf(src)
-		playsound(T, 'sound/misc/explode/incendiary (1).ogg', 100)
-		for(T in view(2, T))
-			new /obj/effect/particle_effect/smoke/mute_gas(T)
-		qdel(src)		
+/obj/item/impact_grenade/mute_gas/explodes() 
+	STOP_PROCESSING(SSfastprocess, src)
+	var/turf/T = get_turf(src)
+	playsound(T, 'sound/misc/explode/incendiary (1).ogg', 100)
+	for(T in view(2, T))
+		new /obj/effect/particle_effect/smoke/mute_gas(T)
+	qdel(src)		

--- a/code/game/objects/items/rogueitems/skillbooks.dm
+++ b/code/game/objects/items/rogueitems/skillbooks.dm
@@ -17,14 +17,15 @@
 
 	var/chosen_icon_state = null
 	var/list/authors = list()
-	proc/add_author(mob/living/carbon/human/H)
-		if(!H || !H.real_name)
-			return
-		var/author_job = H.advjob ? H.advjob : "Adventurer"
-		if(!(H.real_name in authors))
-			authors[H.real_name] = author_job
-		else if(authors[H.real_name] != author_job)
-			authors[H.real_name] = author_job
+
+/obj/item/skillbook/proc/add_author(mob/living/carbon/human/H)
+	if(!H || !H.real_name)
+		return
+	var/author_job = H.advjob ? H.advjob : "Adventurer"
+	if(!(H.real_name in authors))
+		authors[H.real_name] = author_job
+	else if(authors[H.real_name] != author_job)
+		authors[H.real_name] = author_job
 
 /obj/item/skillbook/proc/get_authors_text()
 	if(!authors || !authors.len)

--- a/code/modules/spells/roguetown/acolyte/churchgameloop/artefactsten.dm
+++ b/code/modules/spells/roguetown/acolyte/churchgameloop/artefactsten.dm
@@ -88,7 +88,7 @@ Malum's tool
 
 //shit made helper
 
-proc/_malum_recipe_requires_extras(datum/anvil_recipe/R)
+/proc/_malum_recipe_requires_extras(datum/anvil_recipe/R)
 	if(!R) return FALSE
 	if(ispath(R:needed_item)) return TRUE
 	var/ai = R:additional_items

--- a/code/modules/spells/roguetown/acolyte/churchgameloop/research.dm
+++ b/code/modules/spells/roguetown/acolyte/churchgameloop/research.dm
@@ -2,7 +2,6 @@
 // research.dm
 //=========================================================================
 
-#undef  MIRACLE_RADIAL_DMI
 #define MIRACLE_RADIAL_DMI 'icons/mob/actions/roguespells.dmi'
 
 #ifndef QUEST_COOLDOWN_DS
@@ -191,11 +190,11 @@ var/global/list/PATRON_ARTIFACTS = list(
 	desc = "A token blessed by a patron."
 	var/patron_name = ""
 
-	New(loc, p_name)
-		..()
-		if(istext(p_name))
-			patron_name = p_name
-			name = "Sacred Artefact of [p_name]"
+/obj/item/church_artefact/New(loc, p_name)
+	..()
+	if(istext(p_name))
+		patron_name = p_name
+		name = "Sacred Artefact of [p_name]"
 
 /obj/effect/proc_holder/spell/self/learnmiracle
 	name = "Miracles"
@@ -485,10 +484,11 @@ var/global/list/PATRON_ARTIFACTS = list(
 						html += "<tr><th align='left'>Artefact</th><th width='160'>Action</th></tr>"
 						for(var/T in art_list)
 							var/name_txt = "[T]"
-							var/tmp/obj/O = new T
+							var/obj/O = new T
 							if(O && length(O.name))
 								name_txt = O.name
-							if(O) qdel(O)
+							if(O) 
+								qdel(O)
 
 							html += "<tr><td>[html_attr(name_txt)]</td><td align='center'>"
 							if(HAS_TRAIT(H, TRAIT_CLERGY))

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -483,7 +483,7 @@
 	light_beam_distance = 3
 	light_object_power = 1
 
-	emp_act(severity)
+/obj/item/organ/eyes/t1/emp_act(severity)
 		return
 
 /obj/item/organ/eyes/t2

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -220,7 +220,7 @@
 	priority = 100 //it's an indicator you're dying, so it's very high priority
 	colour = "red"
 
-obj/item/organ/heart/t1
+/obj/item/organ/heart/t1
 	name = "completed heart"
 	icon_state = "heart"
 	desc = "The perfect art, it feels... Completed."


### PR DESCRIPTION
## About The Pull Request

Removes 21 warnings on compile, including ambiguous bitwise & operator (I can't help but wonder whether those sexcon acts even worked) and relatively pathed procs (!!!) 

## Testing Evidence

<img width="737" height="221" alt="image" src="https://github.com/user-attachments/assets/23bcb367-0015-429c-8a08-b3be86d3b85c" />

## Why It's Good For The Game

No user-facing changes. Removes this abomination, abhorrent and unnatural.

<img width="1303" height="828" alt="image" src="https://github.com/user-attachments/assets/2fa575c1-eced-4217-8465-d1cf4657a551" />