### PR TITLE
Keybinding of 'DELETE' key

### DIFF
--- a/code/_globalvars/lists/client.dm
+++ b/code/_globalvars/lists/client.dm
@@ -13,7 +13,7 @@ GLOBAL_LIST_INIT(_kbMap, list(
 	"INSERT" = "Insert",
 	"HOME" = "Northwest",
 	"PAGEUP" = "Northeast",
-	"DEL" = "Delete",
+	"DELETE" = "Delete",
 	"END" = "Southwest",
 	"PAGEDOWN" = "Southeast",
 	" " = "Space",


### PR DESCRIPTION
## About The Pull Request

Fixes #1339 
Now the Delete key can be bound to anything you'd like for those players that want that amount of flexibility, under the keybinds menu.

## Testing Evidence

<img width="384" height="192" alt="StrongKeybindFix" src="https://github.com/user-attachments/assets/5d85a4d8-2286-4c1a-9453-d18d06c5480f" />
Proof you are able to properly bind the Delete key.

<img width="289" height="347" alt="AimedOriginal" src="https://github.com/user-attachments/assets/b2f6dbbf-7b70-46e1-b0db-9744f519b12a" />
Starting with Aimed as my start point.
<img width="281" height="327" alt="StrongIntentFix" src="https://github.com/user-attachments/assets/727c6d11-7d2f-40a5-902c-eb2c51a6c757" />
After hitting the 'DELETE' key on my keyboard, it switched to Strong intent as intended.


## Why It's Good For The Game

As stated earlier, seems this was just an overlooked error that now allows the Delete key to be used as a keybind for whatever the player desires.
