### PR TITLE
Adds a second great furnace to the smithy and an extra iron bar + steel bar in each smithy chest

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -22949,6 +22949,7 @@
 /obj/item/ingot/steel,
 /obj/item/ingot/steel,
 /obj/item/ingot/steel,
+/obj/item/ingot/steel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "gaW" = (
@@ -67089,11 +67090,6 @@
 "rBR" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter)
-"rBY" = (
-/turf/open/floor/rogue/metal{
-	icon_state = "plating2"
-	},
-/area/rogue/indoors/town/dwarfin)
 "rCa" = (
 /turf/closed/mineral/rogue/salt,
 /area/rogue/under/cave)
@@ -82497,6 +82493,7 @@
 /area/rogue/indoors/town/tavern)
 "vyk" = (
 /obj/structure/closet/crate/chest/crate,
+/obj/item/ingot/iron,
 /obj/item/ingot/iron,
 /obj/item/ingot/iron,
 /obj/item/ingot/iron,
@@ -174864,7 +174861,7 @@ vGa
 hse
 vGa
 vGa
-rBY
+qgf
 cgC
 bXm
 urZ


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Adds an additional great furnace to the smithy.

Adds an extra iron bar and steel bar in each iron/steel chest in the smithy, for a total of 2 extra steel bars and 2 extra iron bars to start the round with.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="601" height="495" alt="Furnace" src="https://github.com/user-attachments/assets/9ee5f395-e427-46ef-97ca-4faad4de62f5" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

The smithy is very, very overwhelmed with only a single great furnace, they can't keep up with the utter hoards of people with only a single great furnace and often only a single blacksmith on duty.

Guildsman is basically a super over worked role and basically runs on fumes and having to perfectly optimize and micromanage a single great furnace to keep up with the demand is rather brutal.

If steel and iron were ever properly changed this could be undone but for now making the role less stressful and taxing to play is the most ideal solution to the role no one really wants to play.

I added an extra starting iron/steel bar as well as a treat to the poor blacksmith mains.
