### PR TITLE
Lobotomizes Sawbones&Enforces the 1 slot comment

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
@@ -16,7 +16,7 @@
 		TRAIT_DECEIVING_MEEKNESS
 	)
 	subclass_stats = list(
-		STATKEY_INT = 2,
+		STATKEY_INT = 3,
 		STATKEY_SPD = 3,
 		STATKEY_LCK = 3,
 		STATKEY_CON = 1,


### PR DESCRIPTION
## About The Pull Request

As the title says,
For some reason, in the Sawbones slot list, there's two while the comment demands one as,
`	maximum_possible_slots = 2 // We only want one of these because of master in swords. `
So I'm enforcing that by removing the additional slot and turning that into a 1.

Also reduces Sawbones INT from 4 to 2, and gives them 1 CON/END. They retain master swords since they're a 1-slot job. 
A human sawbones with intellectual starts with a whopping 16 int before statpacks. They can still feint, but they're not the '0% for thee, 90% for me' anymore. They'll still be menaces after the necklace, but that' their little treat.

## Testing Evidence

it's a one line change and it doesn't explode the game.

## Why It's Good For The Game

I LOVE BALANCEJAKKING BANDITS
I LOVE BALANCEJAKKING BANDITS
I LOVE BALANCEJAKKING BANDITS