### PR TITLE
Adds wooden dildo to loadout

### DIFF
--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -712,6 +712,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Chain Leash"
 	path = /obj/item/leash/chain
 
+/datum/loadout_item/wood_dildo
+	name = "Wooden Dildo"
+	path = /obj/item/dildo/wood
+
 /datum/loadout_item/magic_recipes
 	name = "Guide to Arcyne"
 	path = /obj/item/recipe_book/magic


### PR DESCRIPTION
## About The Pull Request

Exactly what it says on the tin. It adds the wooden dildo to the loudout options, just below the collars and leashes

## Testing Evidence

<img width="512" height="356" alt="image" src="https://github.com/user-attachments/assets/91e94199-f5c5-4da4-b06b-d8843107157e" />


## Why It's Good For The Game

It's an RP item that most people *can* craft, but it takes time to do so. Let the girlies have their fun without cutting down their own tree.