### PR TITLE
Removes retreat health threshold from leyline lucans

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/leyline_lycan.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/leyline_lycan.dm
@@ -42,7 +42,7 @@
 	minimum_distance = 0
 	deaggroprob = 0
 	defprob = 35
-	retreat_health = 0.4
+	retreat_health = 0
 	food = 0
 	dodgetime = 30
 	aggressive = 1


### PR DESCRIPTION
## About The Pull Request

Problem: lucans start using the forbidden "Fvck off I'm outta here" strategy once their health drops below 0.4, getting somewhere *far away* and lost in the bog, pushing every leyline interaction beyond the boundaries of reason and coal.

## Testing Evidence

It compiled and worked.

<img width="783" height="636" alt="image" src="https://github.com/user-attachments/assets/713333d1-5484-4778-9d1a-e603780089cb" />

## Why It's Good For The Game

Mage gameplay loop is extremely *grindy*. To the point when it becomes utterly unbearable and abrasive. A little bit of QoL won't hurt, especially since leylines not only retreat, they *beeline away from you on hypersonic speeds* 