### PR TITLE
oxyloss fix (so people don't get perpetually stuck in critical condition)

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -165,7 +165,7 @@
 			if(blood_volume <= BLOOD_VOLUME_BAD)
 				adjustOxyLoss(blood_volume <= BLOOD_VOLUME_SURVIVE ? 3 : 1)
 			else if((blood_volume > BLOOD_VOLUME_SURVIVE) || HAS_TRAIT(src, TRAIT_BLOODLOSS_IMMUNE))
-				if(getOxyLoss() && (health + oxyloss) >= 0)
+				if(getOxyLoss() && (health + getOxyLoss()) >= 0)
 					adjustOxyLoss(-1.6)
 
 	//Bleeding out


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Fixed a bug where if your health was below 0 and you either were bloodloss immune or had enough blood to survive you would heal oxyloss despite taking oxyloss damage from being below 0 health. Resulting in people not dying in critical condition and not healing either.

Yeah so it just checks to see if you are in critical and then doesn't heal oxyloss while in critical condition.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Skeletons and other bleed immune mobs/anyone with enough blood no longer stuck in perpetual critical condition unless they sleep abuse. This mandates the use of CPR in order to heal people out of critical condition as well outside of certain scenarios.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
