### PR TITLE
Reworks (and fixes) accuracy

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -64,7 +64,7 @@
 	if(HAS_TRAIT(user, TRAIT_CURSE_RAVOX))
 		chance2hit -= 30
 
-	chance2hit = CLAMP(chance2hit, 5, 95)
+	chance2hit = CLAMP(chance2hit, 5, 93)
 
 	var/precision_roll = FALSE
 	var/accuracy_roll = FALSE


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Rolling to hit a limb only occurs once instead of twice. Buffs accuracy to aiming directly at a limb (instead of just aiming for a precise part in that limb)

Tweaks around accuracy a bit in general.

Now you roll once to hit a big limb, and roll again if you are aiming for a precise point on a limb (hand/eye/etc). Failing the first roll makes you hit chest, and if you succeed the first failing the second roll makes you hit the limb.

Increases the chance to hit slightly to hit directly big limbs when aiming for them.

Adds replaces the hard cap on perception at 15 with a soft cap, it will still help accuracy rolls just not as much. +3 to hit above 15 PER instead of 0 to hit above 15 PER (compared to +8 to hit for points below 15 PER)

Also rewrites the entire code to be less terrible and not be buggy.

Attempts to clarify accuracy rolls.

If you fail the accuracy roll, it'll say "Accuracy Fail!" and odds. It will hit the chest. 

If you aim for a hard target such as an eye you roll accuracy than precision. If you fail the precision roll than it'll say "Precision Fail!" and hit limb instead with odds. If you can come up with a better descriptor for these I'm open to suggestions.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="753" height="144" alt="Run again" src="https://github.com/user-attachments/assets/232636df-37d7-4fcc-a359-38cb29748231" />
<img width="500" height="386" alt="Precision fail" src="https://github.com/user-attachments/assets/0419c227-a801-4398-bdef-06b3d3de2710" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Overall accuracy has been reworked to not roll twice for hitting the target every time, if you are aiming at a limb you roll once with a higher roll.

If you are aiming for an extremity/hard target you roll once to hit the limb and roll again to hit the extremity, both at harder rolls.

This tweaks accuracy rolls quite a bit due to not rolling twice to hit the target now, before you rolled twice and through a bit of arcane (and somewhat broken) code you hit the limb if you hit either roll. If you had 11 PER anyways, and if you had your "show roll setting" turned on (yes really)

It was kinda broken.

Overall aiming for harder to hit targets on the body will be risky and require high perception and skill or some other advantage (such as the target being knocked down), and a bit more punishing on failure.

This should help decrease the major meta of needing to have face protection at all times in order to fight, same with heavy gauntlets and boots. Hitting and aiming for limbs should be about as accurate as before, but aiming for hard targets will be relegated to lower chances without high skill or high perception (or probably both)