### PR TITLE
[BUG] Armbrustschutze starts with no medium armor trait but can spawn with one

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -184,6 +184,7 @@
 	switch(armor_choice)
 		if("Light Brigandine")
 			armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light	// find a smithy to fix it
+			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 		if("Studded Leather Vest")
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/studded		// or maintain it yourself!
 	//General gear regardless of class.


### PR DESCRIPTION
## About The Pull Request

Fixes #1416 

## Testing Evidence

<img width="1273" height="925" alt="image" src="https://github.com/user-attachments/assets/0ee30540-6f0d-4025-8042-d5a332d36303" />

The trait is only given if you pick the **Light Brigadine** armor when spawning, otherwise you are not given the trait.
## Why It's Good For The Game

fixes an oversight/bug
