### PR TITLE
Return Shaman to Glory

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
@@ -80,7 +80,7 @@
 	subclass_stats = list(
 		STATKEY_STR = 3,
 		STATKEY_CON = 2,
-		STATKEY_END = 2,
+		STATKEY_END = 1,
 		STATKEY_SPD = 1,
 		STATKEY_INT = -1,
 		STATKEY_PER = -1


### PR DESCRIPTION
## About The Pull Request

Changes Shaman's traits back to their original glory and returns their original carbon copy stat-block of Berserker.

## Why It's Good For The Game

Shaman was supposed to be a Mercenary version of Berserker/Barbarian, turning them into a Dodge Expert Monk equivalent goes almost entirely against the core of the idea behind them which is grappling foes to the floor and chewing their guts out.

If concerns arise that a class/role has critical resistance and miracle access . . . just look at Inquisitor Disciple who many consider pretty sub-par and they get stacked CON+END in comparison to Shaman/Berserker.