### PR TITLE
Fixes non-displayed wretch subclasses, misc fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/drunkard.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/drunkard.dm
@@ -8,7 +8,7 @@
 	subclass_social_rank = SOCIAL_RANK_DIRT
 
 	subclass_stats = list(
-		STATKEY_FOR = 2,
+		STATKEY_LCK = 2,
 		STATKEY_CON = 1,
 		STATKEY_STR = 1,
 		STATKEY_INT = -2

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/fisher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/fisher.dm
@@ -9,7 +9,7 @@
 
 	subclass_stats = list(
 		STATKEY_PER = 2,
-		STATKEY_FOR = 2,
+		STATKEY_LCK = 2,
 		STATKEY_SPD = 1
 	)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
@@ -9,6 +9,7 @@
 	)
 	outfit = /datum/outfit/job/roguetown/wretch/lunacyembracer
 	category_tags = list(CTAG_WRETCH)
+	extra_context = "Minimum PQ Required: 30"
 
 	traits_applied = list(
 		TRAIT_NUDIST,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/onimusha.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/onimusha.dm
@@ -13,7 +13,7 @@
 		STATKEY_CON = 3,
 		STATKEY_END = 2,
 		STATKEY_INT = -2,
-		STATKEY_FOR = -2
+		STATKEY_LCK = -2
 	)
 
 	subclass_skills = list(

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -36,13 +36,13 @@
 		/datum/advclass/wretch/deserter/maa,
 		/datum/advclass/wretch/berserker,
 		/datum/advclass/wretch/hedgemage,
-		/datum/advclass/wretch/lunacyembracer
+		/datum/advclass/wretch/lunacyembracer,
 		/datum/advclass/wretch/necromancer,
 		/datum/advclass/wretch/heretic,
 		/datum/advclass/wretch/heretic/wanderer,
-		/datum/advclass/wretch/onimusha
-		/datum/advclass/wretch/swordhunter
-		/datum/advclass/wretch/sohei
+		/datum/advclass/wretch/onimusha,
+		/datum/advclass/wretch/swordhunter,
+		/datum/advclass/wretch/sohei,
 		/datum/advclass/wretch/outlaw,
 		/datum/advclass/wretch/outlaw/marauder,
 		/datum/advclass/wretch/poacher,


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Adds the missing wretch subclasses to the character setup menu. Adds a note that LE requires 30 PQ

Replaces erroneously used "STATKEY_FOR" with "STATKEY_LCK" on 3 advanced classes yes really I don't know why it didn't break either.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="475" height="971" alt="PQ required" src="https://github.com/user-attachments/assets/4bf89260-7c37-49e8-839c-34ca57bf2950" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

fixes
