### PR TITLE
Fix/Tweak: bluestam regeneration while buckled to chairs and benches

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -9,6 +9,7 @@
 	resistance_flags = NONE
 	max_integrity = 250
 	integrity_failure = 0.1
+	sleepy = 0.5
 	var/buildstacktype
 	var/buildstackamount = 1
 	var/item_chair = /obj/item/chair // if null it can't be picked up

--- a/code/game/objects/structures/beds_chairs/roguechair.dm
+++ b/code/game/objects/structures/beds_chairs/roguechair.dm
@@ -159,7 +159,6 @@
 	max_integrity = 100
 	destroy_sound = 'sound/combat/hits/onwood/destroyfurniture.ogg'
 	attacked_sound = "woodimpact"
-	sleepy = 0.35
 
 /obj/item/chair/rogue/getonmobprop(tag)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Currently, wall leaning calls energy_add(5) every handle_sleep(), while chairs do not restore blue at all and benches add 3,5 energy. Sounds like a bug to me.

This PR sets var/sleepy = 0.5 at ``obj/structure/chair`` level, effectively making all chairs, benches and so on restore 5 energy every handle_sleep() fire, on par with wall leaning. 

## Testing Evidence

<img width="1412" height="422" alt="image" src="https://github.com/user-attachments/assets/c7508e48-71df-451a-aa38-c45eda6dcf57" />

## Why It's Good For The Game

Chairs should restore blue stam bar, chairs should restore it at least as good as wall leaning.
I think I need those bugs gone.
