### PR TITLE
You can now sleep in armor bound to your body

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -628,9 +628,9 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 				var/armor_blocked = FALSE
 				if(ishuman(src) && stat == CONSCIOUS)
 					var/mob/living/carbon/human/H = src
-					if(H.head && H.head.armor?.blunt > 70 && !(HAS_TRAIT(head.armor, TRAIT_NODROP)))
+					if(H.head && H.head.armor?.blunt > 70 && !(HAS_TRAIT(H.head.armor, TRAIT_NODROP)))
 						armor_blocked = TRUE
-					if(H.wear_armor && (H.wear_armor.armor_class in list(ARMOR_CLASS_HEAVY, ARMOR_CLASS_MEDIUM)) && !(HAS_TRAIT(wear_armor, TRAIT_NODROP)))
+					if(H.wear_armor && (H.wear_armor.armor_class in list(ARMOR_CLASS_HEAVY, ARMOR_CLASS_MEDIUM)) && !(HAS_TRAIT(H.wear_armor, TRAIT_NODROP)))
 						armor_blocked = TRUE
 					if(armor_blocked && !fallingas)
 						to_chat(src, span_warning("I can't sleep like this. My armor is burdening me."))


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Any armor that possesses the NO_DROP trait no longer blocks sleeping in it (without abusing sleep verb to bypass this)

Aka all heretical armors from rituals for now.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="2528" height="1004" alt="Armor" src="https://github.com/user-attachments/assets/965c3083-945b-4a9d-96c8-7d7417727034" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

if you couldn't use sleep verb you'd be physically unable to go to sleep with heavy armor that's  bound to you.

Lore reason, its because its made out of your Lux (its very comfortable we swear) so its more of a bubbly soft compound than hard steel to you. Attached to your body, stuck and unable to be removed forever and ever.

One step away from removing the sleep verb entirely with no problematic consequences.
