### PR TITLE
Priest gets legendary miracles

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -75,7 +75,7 @@ GLOBAL_LIST_EMPTY(heretical_players)
 		/datum/skill/craft/crafting = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/sewing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/labor/farming = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/magic/holy = SKILL_LEVEL_MASTER,
+		/datum/skill/magic/holy = SKILL_LEVEL_LEGENDARY,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 	)
 
@@ -107,8 +107,6 @@ GLOBAL_LIST_EMPTY(heretical_players)
 	)
 
 	H.cmode_music = 'sound/music/combat_holy.ogg'
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/magic/holy, 6, TRUE)
 
 	// Initialize the miracle set storage
 	if(H.mind)


### PR DESCRIPTION
## About The Pull Request
Removes the old age bonus for Priest which gave them +1 level to miracles and gives them legendary by default.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Can't test cuz someone fucked up some stuff and I can't compile, waaaa.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Astratan acolytes get an innate +1 bonus to their miracle skill due to being Astratan (the same way pestrans get +1 medical etcetc)- since all acolytes start at master, this means that an astratan priest is unironically on average a level below astratan acolytes if they aren't either old or have devotee as a virtue.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
