### PR TITLE
Composter Optimizations

### DIFF
--- a/code/modules/farming/composter.dm
+++ b/code/modules/farming/composter.dm
@@ -12,6 +12,7 @@
 	var/unflipped_compost = 0
 	var/flipped_compost = 0
 	var/ready_compost = 0
+	var/processing = FALSE
 
 /obj/structure/composter/halffull
 	ready_compost = MAXIMUM_TOTAL_COMPOST * 0.5
@@ -33,7 +34,6 @@
 	update_overlays()
 
 /obj/structure/composter/Initialize()
-	START_PROCESSING(SSprocessing, src)
 	update_icon()
 	. = ..()
 
@@ -50,6 +50,8 @@
 	flipped_compost -= compost_to_process
 	unflipped_compost += compost_to_process * 0.25
 	ready_compost += compost_to_process * 0.75
+	maybe_stop_processing()
+
 
 /obj/structure/composter/proc/get_total_compost()
 	return unflipped_compost + flipped_compost + ready_compost
@@ -73,6 +75,7 @@
 	var/flip_amount = unflipped_compost
 	unflipped_compost -= flip_amount
 	flipped_compost += flip_amount
+	maybe_start_processing()
 	update_icon()
 
 /obj/structure/composter/proc/try_handle_adding_compost(obj/item/attacking_item, mob/user, batch_process)
@@ -92,7 +95,6 @@
 		if(!batch_process)
 			to_chat(user, span_notice("I add \the [attacking_item] to \the [src]"))
 		qdel(attacking_item)
-		update_icon()
 		return TRUE
 	return FALSE
 
@@ -131,8 +133,10 @@
 			attacking_item.update_icon()
 		else
 			to_chat(user, span_warning("There's nothing in [attacking_item] that can be composted."))
+		update_icon()
 		return TRUE
 	if(try_handle_adding_compost(attacking_item, user, params))
+		update_icon()
 		return
 	. = ..()
 
@@ -177,6 +181,20 @@
 		. += "post_compost_mid"
 	else if (total_processed >= COMPOST_PER_PRODUCED_ITEM)
 		. += "post_compost_low"
+
+/obj/structure/composter/proc/maybe_start_processing()
+	// Start processing if there is any flipped compost to process
+	if(!processing && flipped_compost > 0)
+		START_PROCESSING(SSprocessing, src)
+		processing = TRUE
+		update_overlays()
+
+/obj/structure/composter/proc/maybe_stop_processing()
+	// Stop processing if there is no flipped compost left
+	if(processing && flipped_compost <= 0)
+		STOP_PROCESSING(SSprocessing, src)
+		processing = FALSE
+		update_overlays()
 
 /obj/item/compost
 	name = "compost"


### PR DESCRIPTION
## About The Pull Request

Reduces the number of unnecessary icon and overlay updates performed by composters.

Composters will not be processed when they do not have flipped compost inside them, and are removed from processing once flipped compost is ready, reducing the amount of unnecessary calculations and icon refreshes performed every game server tick.

Dumping a bag into a composter will now only redraw icons and overlays once, instead of doing it for every item added.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Composting
<img width="387" height="318" alt="image" src="https://github.com/user-attachments/assets/1ab85ac8-a4eb-4f1e-a58d-2e15f6e246dd" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Composters are unusually expensive for what they do. Reducing icon updating and not processing unnecessarily should help a lot.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
