### PR TITLE
Adds Unusual Origin

### DIFF
--- a/modular_azurepeak/virtues/origin.dm
+++ b/modular_azurepeak/virtues/origin.dm
@@ -249,6 +249,11 @@
 			recipient.dna.species.skin_tone_wording = "Custom"
 			var/datum/virtue/virtue_chosen = virtue_choices[result]
 			apply_virtue(recipient, virtue_chosen)
+		else
+			var/chosen_virtue = new recipient.dna.species.origin_default
+			apply_virtue(recipient, chosen_virtue)
+			to_chat(recipient, "Denied foreign origin! Resetting to default. Triumph cost refunded!")
+			recipient.adjust_triumphs(3)
 	else
 		var/chosen_virtue = new recipient.dna.species.origin_default
 		apply_virtue(recipient, chosen_virtue)


### PR DESCRIPTION
## About The Pull Request

Adds an origin that allows you to choose regions normally restricted to your race.
Costs 3 triumphs per use.

<img width="632" height="123" alt="image" src="https://github.com/user-attachments/assets/19025590-41c0-4ad4-a899-c082cfa0c25b" />

Also changed some description formatting.

## Testing Evidence

<img width="1369" height="615" alt="image" src="https://github.com/user-attachments/assets/6931e2b3-eab1-4f27-aa3b-445b2d41c3f3" />

## Why It's Good For The Game

Players have told me they want to play things that don't align perfectly to the restrictions we have set up for origins, like a naledi goblin. So this is the solution I worked out!
