### PR TITLE
noc guard now requires T2 meld instead of T1

### DIFF
--- a/code/datums/magic_items/_ritual.dm/summons.dm
+++ b/code/datums/magic_items/_ritual.dm/summons.dm
@@ -47,7 +47,7 @@
 	desc = "summons a noc guard"
 	blacklisted = FALSE
 	tier = 2
-	required_atoms = list(/obj/item/reagent_containers/food/snacks/grown/manabloom = 1, /obj/item/magic/obsidian = 1, /obj/item/magic/melded/t1 = 1)
+	required_atoms = list(/obj/item/reagent_containers/food/snacks/grown/manabloom = 1, /obj/item/magic/obsidian = 1, /obj/item/magic/melded/t2 = 1)
 	mob_to_summon = /mob/living/simple_animal/hostile/retaliate/rogue/arcane/noc_guard
 
 /datum/runeritual/summoning/imp


### PR DESCRIPTION
## About The Pull Request

noc guard now requires T2 meld instead of T1

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

idk i havent played on SR since end of august so cant tell

<img width="1177" height="278" alt="image" src="https://github.com/user-attachments/assets/3cf7807c-e91b-408c-9849-5d208305ceef" />

