### PR TITLE
removes hidden blunt nerf (blunt armor no longer decreases blunt integrity damage by a ton)

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -45,10 +45,6 @@
 		var/intdamage = damage
 		if(intdamfactor != 1)
 			intdamage *= intdamfactor
-		if(d_type == "blunt")
-			if(used.armor?.getRating("blunt") > 0)
-				var/bluntrating = used.armor.getRating("blunt")
-				intdamage -= intdamage * ((bluntrating / 2) / 100)	//Half of the blunt rating reduces blunt damage taken by %-age.
 		if(istype(used_weapon) && used_weapon.is_silver && ((used.smeltresult in list(/obj/item/ingot/aaslag, /obj/item/ingot/aalloy, /obj/item/ingot/purifiedaalloy)) || used.GetComponent(/datum/component/cursed_item)))
 			// Blessed silver delivers more int damage against "cursed" alloys, see component for multiplier values
 			var/datum/component/silverbless/bless = used_weapon.GetComponent(/datum/component/silverbless)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

someone decided to make blunt armor reduce blunt weapon integrity damage by 0.5*blunt armor value

This removes that.

no other damage type in the game does this, and theres no real justification for this, I'm pretty sure someone just has a hate boner for blunt weapons.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="573" height="161" alt="gaming" src="https://github.com/user-attachments/assets/97556b9a-e5b1-4f39-ad89-cda3c70094d6" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

You have blunt weapons with good force advertized with "1.25x" or "1.35x" integrity damage and then you immediately and quietly remove all the integrity damage given by any blunt weapons with a quiet nerf as every armor has at least semi-decent blunt armor and then on top of that make good blunt armor (such as the padded leather hood with 90 blunt) be basically invulnerable to blunt.

And sure, if every damage type had this value than it'd make sense but that's not even remotely true. Blunt already cannot penetrate armor due to a hidden -100 AP value, now it can't do any integrity damage against armor so it can't even break through armor to do damage, it doesn't get any more bonus force against armor... Its a joke. 

Blunt weapons don't get strong weapon defense values, they don't do damage to armor, they don't pen armor, they're essentially useless against anyone remotely armored. Who came up with this design. Let the mace smash plate armor in, let blunt has its niche.

Bleed is the main wound that does any damage anyways. Maybe if people start using blunt weapons we'll see less endless deaths as they're definitely less lethal than bleeding wounds.