### PR TITLE
Allows Wildkin to be from Gronn

### DIFF
--- a/modular_azurepeak/virtues/origin.dm
+++ b/modular_azurepeak/virtues/origin.dm
@@ -66,7 +66,7 @@
 
 /datum/virtue/origin/racial/gronn
 	name = "Gronnic"
-	desc = "I originate from the brisk grasslands of G5ronn, a tribal confederation of northmen and half-orcs nestled in the Skol River Valley. Gronnic culture is fierce, martial and vengeful, and blood feuds still split the clans to this day.<br>"
+	desc = "I originate from the brisk grasslands of Gronn, a tribal confederation of northmen and half-orcs nestled in the Skol River Valley. Gronnic culture is fierce, martial and vengeful, and blood feuds still split the clans to this day.<br>"
 	races = list(/datum/species/halforc,
 				/datum/species/goblinp,
 				/datum/species/human/northern,


### PR DESCRIPTION
## About The Pull Request
Allows wildkin to be from Gronn, which they were not allowed to be from for some reason.

## Testing Evidence

<img width="315" height="163" alt="image" src="https://github.com/user-attachments/assets/e59e1261-307d-4f7b-9c9c-0710fb9fe15b" />

## Why It's Good For The Game

Lets me play my wildkin who I have been roleplaying as from Gronn for over a year correctly without sinking 3 triumphs a round. 
Wildkin are pretty ubiquitous and are more 'wild' than halfkin are so it's not a huge stretch that they'd be in the cold north war country.  