### PR TITLE
Gives Lunacy Embracer Journeyman Butchering

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
@@ -51,6 +51,7 @@
 		/datum/skill/craft/masonry = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/cooking = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/labor/butchering = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/labor/fishing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/magic/holy = SKILL_LEVEL_JOURNEYMAN,
 	)


### PR DESCRIPTION
## About The Pull Request
Gives Lunacy Embracer Journeyman Butchering.

## Testing Evidence
<img width="455" height="543" alt="image" src="https://github.com/user-attachments/assets/60b79f1f-369a-4157-bbe2-036359341cd0" />

## Why It's Good For The Game

Lunacy Embracer is flavored as a character that lives in the wilds, and lives OFF the wilds. It's hard to roleplay this sort of character when your character completely fucks up butchering three saigas in front of a city character they're trying to teach how to live in the wild. This changes helps fit the fantasy of the character while not causing any crazy balance consequences.
