### PR TITLE
Requires Naledi Warscholars to wear a mask in order to use their unique class spells

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -1,6 +1,6 @@
 /datum/advclass/mercenary/warscholar
 	name = "Naledi Hierophant"
-	tutorial ="You are a Naledi Hierophant, a magician who studied under cloistered sages, well-versed in all manners of arcyne. You prioritize enhancing your teammates and distracting foes while staying in the backline."
+	tutorial ="You are a Naledi Hierophant, a magician who studied under cloistered sages, well-versed in all manners of arcyne. You prioritize enhancing your teammates and distracting foes while staying in the backline. Keep your face covered, or else the Djinni will siphon your magics and claim your soul."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/mercenary/warscholar
@@ -61,7 +61,7 @@
 	))
 	detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
 	detailcolor = naledicolors[detailcolor]
-	to_chat(H, span_warning("You are a Naledi Hierophant, a magician who studied under cloistered sages, well-versed in all manners of arcyne. You prioritize enhancing your teammates and distracting foes while staying in the backline."))
+	to_chat(H, span_warning("You are a Naledi Hierophant, a magician who studied under cloistered sages, well-versed in all manners of arcyne. You prioritize enhancing your teammates and distracting foes while staying in the backline. Keep your face covered, or else the Djinni will siphon your magics and claim your soul."))
 
 	if(H.age == AGE_OLD)
 		H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 5, TRUE)
@@ -102,7 +102,7 @@
 
 /datum/advclass/mercenary/warscholar/pontifex
 	name = "Naledi Pontifex"
-	tutorial = "You are a Naledi Pontifex, a warrior trained into a hybridized style of movement-controlling magic and hand-to-hand combat. Though your abilities in magical fields are lacking, you are far more dangerous than other magi in a straight fight. You manifest your calm, practiced skill into a killing intent that takes the shape of an arcyne blade."
+	tutorial = "You are a Naledi Pontifex, a warrior trained into a hybridized style of movement-controlling magic and hand-to-hand combat. Though your abilities in magical fields are lacking, you are far more dangerous than other magi in a straight fight. You manifest your calm, practiced skill into a killing intent that takes the shape of an arcyne blade. Keep your face covered, or else the Djinni will siphon your magics and claim your soul."
 	outfit = /datum/outfit/job/roguetown/mercenary/warscholar_pontifex
 
 	subclass_languages = list(
@@ -155,7 +155,7 @@
 	))
 	detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
 	detailcolor = naledicolors[detailcolor]
-	to_chat(H, span_warning("You are a Naledi Pontifex, a warrior trained into a hybridized style of movement-controlling magic and hand-to-hand combat. Though your abilities in magical fields are lacking, you are far more dangerous than other magi in a straight fight. You manifest your calm, practiced skill into a killing intent that takes the shape of an arcyne blade."))
+	to_chat(H, span_warning("You are a Naledi Pontifex, a warrior trained into a hybridized style of movement-controlling magic and hand-to-hand combat. Though your abilities in magical fields are lacking, you are far more dangerous than other magi in a straight fight. You manifest your calm, practiced skill into a killing intent that takes the shape of an arcyne blade. Keep your face covered, or else the Djinni will siphon your magics and claim your soul."))
 
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
@@ -189,7 +189,7 @@
 
 /datum/advclass/mercenary/warscholar/vizier
 	name = "Naledi Vizier"
-	tutorial = "You are a Naledi Vizier. Your research into miracles and holy incantations has lead you to esoteric magycks. Though psydonians have long struggled to channel their all-father's divinity, a combination of the saint's power may be similar enough."
+	tutorial = "You are a Naledi Vizier. Your research into miracles and holy incantations has lead you to esoteric magycks. Though Psydonites have long struggled to channel their all-father's divinity, a combination of the saint's power may be similar enough. Keep your face covered, or else the Djinni will siphon your magics and claim your soul."
 	outfit = /datum/outfit/job/roguetown/mercenary/warscholar_vizier
 
 	subclass_languages = list(
@@ -240,7 +240,7 @@
 	))
 	detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
 	detailcolor = naledicolors[detailcolor]
-	to_chat(H, span_warning("You are a Naledi Vizier. Your research into miracles and holy incantations has lead you to esoteric magycks. Though psydonians have long struggled to channel their all-father's divinity, a combination of the saint's power may be similar enough."))
+	to_chat(H, span_warning("You are a Naledi Vizier. Your research into miracles and holy incantations has lead you to esoteric magycks. Though Psydonites have long struggled to channel their all-father's divinity, a combination of the saint's power may be similar enough. Keep your face covered, or else the Djinni will siphon your magics and claim your soul."))
 
 	backl = /obj/item/rogueweapon/woodstaff/naledi
 	wrists = /obj/item/clothing/neck/roguetown/psicross/naledi

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -318,6 +318,7 @@
 	recharge_time = 10 SECONDS
 	miracle = TRUE
 	devotion_cost = 10
+	req_items = list(/obj/item/clothing/mask/rogue)
 
 /obj/effect/proc_holder/spell/invoked/regression/proc/get_most_damaged_limb(mob/living/carbon/C)
 	var/obj/item/bodypart/most_damaged_limb = null
@@ -376,7 +377,7 @@
 	movement_interrupt = FALSE
 //	chargedloop = /datum/looping_sound/invokeholy
 	chargedloop = null
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross, /obj/item/clothing/mask/rogue)
 	sound = list('sound/magic/convergence1.ogg','sound/magic/convergence2.ogg','sound/magic/convergence3.ogg','sound/magic/convergence4.ogg')
 	invocation_type = "none"
 	associated_skill = /datum/skill/magic/holy
@@ -428,6 +429,7 @@
 	var/blood = 0
 	miracle = TRUE
 	devotion_cost = 30
+	req_items = list(/obj/item/clothing/mask/rogue)
 
 /obj/effect/proc_holder/spell/invoked/stasis/cast(list/targets, mob/user = usr)
 	if(isliving(targets[1]))

--- a/modular_azurepeak/code/modules/spells/warscholar.dm
+++ b/modular_azurepeak/code/modules/spells/warscholar.dm
@@ -13,6 +13,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	hand_path = /obj/item/melee/touch_attack/rogueweapon/bladeofpsydon
+	req_items = list(/obj/item/clothing/mask/rogue)
 
 /obj/item/melee/touch_attack/rogueweapon/bladeofpsydon
 	name = "\improper arcyne push dagger"


### PR DESCRIPTION
## About The Pull Request

#1440 sought to force them to wear the Warscholar mask, but I felt that was too limiting. I think this is a decent compromise. It doesn't block all spells because I don't know how to do that.

It should work for every Roguetown mask. It doesn't work for zigs (despite being under the /mask/ path) since it's restricted to the /mask/rogue, but there may be a few edge-cases where non-mask items are still technically considered masks. Also, this only checks that you're wearing or holding a mask item, meaning that if the mask is in your hand, you can still cast the spells. If someone wants to suggest changes that prevent this, feel free.

I also edited the Warscholar description text to reflect the fact that they're meant to keep their faces covered.

## Testing Evidence

https://github.com/user-attachments/assets/15d19080-c12f-4b12-9ff9-8ed01640088e

I had to compress it to upload it so the text is hard to read, but it's just the "I'm missing something to cast this" message when you aren't wearing a mask.

## Why It's Good For The Game

Fits the lore about Naledi keeping their faces covered to protect themselves from Djinn. I don't really care that much about this, so feel free to deny it. I just wanted to offer an alternative to restricting them to the Warscholar facemask exclusively, since that's a unique and unreplacable item that basically bricks your role abilities if you lose it.
