### PR TITLE
Fixes headshot preview scaling in the character creator

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -517,7 +517,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			if(agevetted)
 				dat += "<br><b>Headshot:</b> <a href='?_src_=prefs;preference=headshot;task=input'>Change</a>"
 				if(headshot_link != null)
-					dat += "<br><img src='[headshot_link]' width='150px' height='175px'>"
+					dat += "<br><img src='[headshot_link]' width='150px' height='150px'>"
 				dat += "<br><b>NSFW Bodyshot:</b> <a href='?_src_=prefs;preference=nsfw_headshot;task=input'>Change</a>"
 				if(nsfw_headshot_link != null)
 					dat += "<br><img src='[nsfw_headshot_link]' width='125px' height='175px'>"


### PR DESCRIPTION
## About The Pull Request

The chargen headshot preview was scaling to 175x150, which is not 1:1. This fixes that.

## Testing Evidence
<img width="100" height="100" alt="jha2ofzeymw51" src="https://github.com/user-attachments/assets/13315286-41c9-41e7-8b2c-b63967439acf" />

<img width="263" height="280" alt="image" src="https://github.com/user-attachments/assets/d46b3612-ee2a-4468-82e5-ac7bd25fb692" /> <img width="212" height="274" alt="image" src="https://github.com/user-attachments/assets/5338a6cb-42d7-4247-83f4-fa3569ee8261" />

## Why It's Good For The Game

How the fuck has nobody fixed this yet?
