### PR TITLE
No more Instant Werewolf-Deadite

### DIFF
--- a/code/game/objects/items/rogueweapons/intents/mmb/bite.dm
+++ b/code/game/objects/items/rogueweapons/intents/mmb/bite.dm
@@ -129,11 +129,13 @@
 			/*
 				ZOMBIE INFECTION VIA BITE
 			*/
-			var/datum/antagonist/zombie/zombie_antag = user.mind.has_antag_datum(/datum/antagonist/zombie)
-			if(zombie_antag && zombie_antag.has_turned)
-				zombie_antag.last_bite = world.time
-				if(bite_victim.zombie_infect_attempt())   // infect_attempt on bite
-					to_chat(user, span_danger("You feel your gift trickling from your mouth into [bite_victim]'s wound..."))
+			// Werewolves should only spread werewolf infection, not zombie infection
+			if(!istype(user.dna.species, /datum/species/werewolf))
+				var/datum/antagonist/zombie/zombie_antag = user.mind.has_antag_datum(/datum/antagonist/zombie)
+				if(zombie_antag && zombie_antag.has_turned)
+					zombie_antag.last_bite = world.time
+					if(bite_victim.zombie_infect_attempt())   // infect_attempt on bite
+						to_chat(user, span_danger("You feel your gift trickling from your mouth into [bite_victim]'s wound..."))
 	var/obj/item/grabbing/bite/B = new()
 	user.equip_to_slot_or_del(B, SLOT_MOUTH)
 	if(user.mouth == B)
@@ -267,11 +269,13 @@
 			/*
 				ZOMBIE CHEW. ZOMBIFICATION
 			*/
-			var/datum/antagonist/zombie/zombie_antag = user.mind.has_antag_datum(/datum/antagonist/zombie)
-			if(zombie_antag && zombie_antag.has_turned)
-				var/datum/antagonist/zombie/existing_zombie = C.mind?.has_antag_datum(/datum/antagonist/zombie) //If the bite target is a zombie
-				if(!existing_zombie && caused_wound.zombie_infect_attempt())   // infect_attempt on wound
-					to_chat(user, span_danger("You feel your gift trickling into [C]'s wound...")) //message to the zombie they infected the target
+			// Werewolves should only spread werewolf infection, not zombie infection
+			if(!istype(user.dna.species, /datum/species/werewolf))
+				var/datum/antagonist/zombie/zombie_antag = user.mind.has_antag_datum(/datum/antagonist/zombie)
+				if(zombie_antag && zombie_antag.has_turned)
+					var/datum/antagonist/zombie/existing_zombie = C.mind?.has_antag_datum(/datum/antagonist/zombie) //If the bite target is a zombie
+					if(!existing_zombie && caused_wound.zombie_infect_attempt())   // infect_attempt on wound
+						to_chat(user, span_danger("You feel your gift trickling into [C]'s wound...")) //message to the zombie they infected the target
 /*
 	Code below is for a zombie smashing the brains of unit. The code expects the brain to be part of the head which is not the case with AP. Kept for posterity in case it's used in an overhaul.
 */


### PR DESCRIPTION
## About The Pull Request

Fixes #213
A werewolf who was also a deadite could bite people in werewolf form and immediately turn them into deadites (necrosis/zombieism).
The bite code had no check to prevent zombie infection from being spread by werewolves. Even though werewolves in werewolf form have the /datum/species/werewolf species, the zombie infection code would still run as if they had a zombie antagonist datum.

Added a check if(!istype(user.dna.species, /datum/species/werewolf)) before the zombie infection code in bite.dm file.
Now werewolves will only spread werewolf infection through their bites, preventing the issue where a werewolf-deadite hybrid would turn bitten victims into deadites instead of werewolves, instantly. 

## Testing Evidence

Working on proofing it solo but should work as intended, may be difficult to test without other players.

## Why It's Good For The Game

This fixes a bug where a werewolf that is also a deadite, bypasses the deadite transformation time when they bite people. 
This makes it so werewolves only transmit werewolf infection when in werewolf form. 
