### PR TITLE
Fixes weapon sharpness decay rate from parrying

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -403,7 +403,6 @@
 						if(used_weapon == offhand)
 							intdam = INTEG_PARRY_DECAY_NOSHARP
 						used_weapon.take_damage(intdam, BRUTE, used_weapon.d_type)
-						used_weapon.remove_bintegrity(SHARPNESS_ONHIT_DECAY, user)
 					return TRUE
 				else
 					return FALSE


### PR DESCRIPTION
## About The Pull Request

The proc to reduce weapon sharpness from parrying was being called twice due to a bug introduced in #739. This removes the duplicate proc call, cutting the rate of weapon sharpness reduction in half.

## Testing Evidence

<img width="466" height="169" alt="image" src="https://github.com/user-attachments/assets/fa4ef0ba-bf2c-4299-99a8-d94d8789cecb" />

## Why It's Good For The Game

Bugfix.
