### PR TITLE
unclamps minimum glide size

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -180,7 +180,7 @@
 
 	if((direct & (direct - 1)) && mob.loc == n) //moved diagonally successfully
 		add_delay *= 2
-	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay))
+	mob.set_glide_size(MOVEMENT_ADJUSTED_GLIDE_SIZE(add_delay, 1)) // TODO: jck this into the movement loop somehow so we can derive a delta time.
 	move_delay += add_delay
 	if(.) // If mob is null here, we deserve the runtime
 		if(mob.throwing)


### PR DESCRIPTION
## About The Pull Request
see title. Basically makes it so that the minimum glide is not 4 anymore.  for some reason someone clamped minimum glide size to 4 on a "dude just trust me" basis and everyone ate that up. Then byond actually added real camera interpolation in 511 or 512, rendering it completely pointless to have.

This can be improved yet further by piping in some kind of delta factor but I honestly can't figure out what to use.

This should make moving faster and moving slower look less fucking weird during normal scenarios, and if I can find a good time delta (I MIGHT JUST GENUINELY USE THE STRAIGHT UP TIDI) it should soften laggy scenario visuals just a little. It's still gonna feel laggy, but it will look less dogshit

## Testing Evidence
https://streamable.com/iqebiz
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
makes the game look a little less weird when you're slowed down.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
