### PR TITLE
Changes Featherstep enchantment

### DIFF
--- a/code/datums/magic_items/superior_items/superior.dm
+++ b/code/datums/magic_items/superior_items/superior.dm
@@ -37,7 +37,7 @@
 	else
 		active_item = TRUE
 		ADD_TRAIT(user, TRAIT_LIGHT_STEP, "[type]")
-		ADD_TRAIT(user, TRAIT_LEAPER, "[type]")
+		ADD_TRAIT(user, TRAIT_NOFALLDAMAGE1, "[type]")
 		to_chat(user, span_notice("I feel much more nimble!"))
 
 


### PR DESCRIPTION
## About The Pull Request
Makes the Featherstep enchantment give the Acrobatic virtue, rather than +1 Speed.

## Testing Evidence
Awawa.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
People keep getting a billion Featherstep-enchanted items and stacking them. It's not an active enchantment, so it can stack at the moment. This makes it so there is no incentive to stack it by trading the speed bonus for a trait.
