### PR TITLE
[TESTMERGE ONLY] Dirty Optimizations: makes farmers not lag the server for playing the game

### DIFF
--- a/code/modules/farming/soil.dm
+++ b/code/modules/farming/soil.dm
@@ -42,6 +42,8 @@
 	var/soil_decay_time = SOIL_DECAY_TIME
 	///The time remaining in which the soil was given special fertilizer, effect is similar to being blessed but with less beneficial effects
 	var/fertilized_time = 0
+	///Cached var to determine whether we need to call an icon update or not.
+	var/needs_icon_update = FALSE
 
 /obj/structure/soil/Crossed(atom/movable/AM)
 	. = ..()
@@ -289,6 +291,7 @@
 	if(plant && plant_dead)
 		plant_dead = FALSE
 		plant_health = 10.0
+		update_icon()
 	// If low on nutrition, Dendor provides
 	if(nutrition < 30)
 		adjust_nutrition(max(30 - nutrition, 0))
@@ -303,25 +306,33 @@
 	fertilized_time = 60 MINUTES //Keeps the plant fertilized for a good while
 
 /obj/structure/soil/proc/adjust_water(adjust_amount)
+	var/pre_water = water
 	water = clamp(water + adjust_amount, 0, MAX_PLANT_WATER)
-	update_icon()
+	if (adjust_amount && pre_water != water)
+		needs_icon_update = TRUE
 
 /obj/structure/soil/proc/adjust_nutrition(adjust_amount)
+	var/pre_nutrition = nutrition
 	nutrition = clamp(nutrition + adjust_amount, 0, MAX_PLANT_NUTRITION)
-	update_icon()
+	if (adjust_amount && pre_nutrition != nutrition)
+		needs_icon_update = TRUE
 
 /obj/structure/soil/proc/adjust_weeds(adjust_amount)
+	var/pre_weeds = weeds
 	weeds = clamp(weeds + adjust_amount, 0, MAX_PLANT_WEEDS)
-	update_icon()
+	if (adjust_amount && pre_weeds != weeds)
+		needs_icon_update = TRUE
 
 /obj/structure/soil/proc/adjust_plant_health(adjust_amount)
 	if(!plant || plant_dead)
 		return
+	var/pre_plant_health = plant_health
 	plant_health = clamp(plant_health + adjust_amount, 0, MAX_PLANT_HEALTH)
 	if(plant_health <= 0)
 		plant_dead = TRUE
 		produce_ready = FALSE
-	update_icon()
+	if (adjust_amount && pre_plant_health != plant_health)
+		needs_icon_update = TRUE
 
 /obj/structure/soil/Initialize()
 	START_PROCESSING(SSprocessing, src)
@@ -338,9 +349,11 @@
 	process_weeds(dt)
 	process_plant(dt)
 	process_soil(dt)
-	update_icon()
 	if(soil_decay_time <= 0)
 		decay_soil()
+	if (plant && needs_icon_update) // only call icon updates if we really need to (aka if we've requested an icon update and if we have a plant)
+		update_icon()
+		needs_icon_update = FALSE
 
 /obj/structure/soil/weather_act_on(weather_trait, severity)
 	if(weather_trait != PARTICLEWEATHER_RAIN)
@@ -581,11 +594,13 @@
 	if(!matured)
 		if(growth_time >= plant.maturation_time)
 			matured = TRUE
+			needs_icon_update = TRUE
 	else
 		produce_time += added_growth
 		if(produce_time >= plant.produce_time)
 			produce_time -= plant.produce_time
 			produce_ready = TRUE
+			needs_icon_update = TRUE
 
 
 #define SOIL_WATER_DECAY_RATE 0.5 / (1 MINUTES)


### PR DESCRIPTION
## About The Pull Request

Soil plots were calling potentially **5+** icon updates every second **per plot**. The average combination of an innkeeper, servant and maybe 1 soilson character were imposing tick rates of beyond 40ms on SSprocessing, which is comparable to the improved mobs subsystem processing over 250 mobs.

Yeah.

This gets total operations per tick down by like 99% by removing a shit ton of repeated icon update calls (every time any plant stat needed to be adjusted, it was calling 1 update minimum, and this was cascading into several checks). Players should notice nothing different.

## Testing Evidence

<img width="439" height="46" alt="image" src="https://github.com/user-attachments/assets/64a9a62e-e6ef-4ae5-95b2-93b47f6d2b1e" />

## Why It's Good For The Game

game run gooderer