### PR TITLE
Allows Certain Headwraps / Scarfs on Neck Slot

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -2184,6 +2184,7 @@
 	desc = "A thick hood that covers one's entire head, should they desire, or merely acts as a scarf otherwise. Made with spell-laced fabric to provide some protection against daemons and mortals alike."
 	max_integrity = 100
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_TWIST)
+	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK|ITEM_SLOT_NECK
 	armor = ARMOR_HEAD_PSYDON
 	icon_state = "deserthood"
 	item_state = "deserthood"


### PR DESCRIPTION
## About The Pull Request
Allows the following items to be worn on the neck, like leather hoods or chainmail, gorgets, whatever.
- Scarf
- Hijab
- Hierophant Pashima
- Kazengunese Headwrap

## Testing Evidence
<img width="1148" height="472" alt="Scarfs" src="https://github.com/user-attachments/assets/df3cf9fd-ee09-4a1e-be79-bcf5c88e0d26" />

## Why It's Good For The Game
I wanted to be able to wear a hijab/scarf/etc while ALSO wearing something on my head slot like a hat and a crown or flower in my mask slot. This lets players sacrifice neck armor to do that for the sake of fashion, and it makes sense that they would go on the neck slot regardless. One can also make use of headwrap layers and do a multicolored style headwrap which is kinda neat! Even if they stacked both the Kazengun headwrap and hierophant pashima, it still would not be as good as wearing chainmail or something anyway. So this PR is for fashion's sake.

Yes, you can wear the regular scarf in your mouth slot too but if you're a smoker you gotta remove your scarf just to smoke and that's also really annoying. It bugs me. Now I can have that slot open too.
