### PR TITLE
Reverts coverage preventing mouthgrab silencing

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1373,7 +1373,7 @@
 	if(mouth?.muteinmouth)
 		return FALSE
 	for(var/obj/item/grabbing/grab in grabbedby)
-		if((grab.sublimb_grabbed == BODY_ZONE_PRECISE_MOUTH) && (get_location_accessible(src, BODY_ZONE_PRECISE_MOUTH)))
+		if((grab.sublimb_grabbed == BODY_ZONE_PRECISE_MOUTH)
 			return FALSE
 	if(istype(loc, /turf/open/water) && !(mobility_flags & MOBILITY_STAND))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

As per the title.

## Testing Evidence

Single-line change.

## Why It's Good For The Game

Fireballs are no longer broken, repulse exists, you have insta grab-breaks by virtue of someone PRing that prior. You can handle being muted by a grab you're likely going to break anyway. 
