### PR TITLE
Adds the Philosopher Lord, a spellcasting Duke

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -229,7 +229,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/maces = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/swords = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE, //Your only non-novice weapon skill, because you're a NERD who read books instead of studying the blade


### PR DESCRIPTION
## About The Pull Request

Adds the Philosopher Lord advclass for the Duke. They get T2 spells, 12 spellpoints (15 if old), and the Message spell for free. Skillswise they have Master reading (lol), Expert spellcasting skill, Journeyman alchemy, and only one weapon skill above Novice, which is Apprentice Knives. Other skills mostly taken from Merchant Lord. They also get Mage Armor and Intellectual but no reflexes or armor wearing.

## Testing Evidence

<img width="837" height="653" alt="image" src="https://github.com/user-attachments/assets/e4694987-ea25-4bb8-bdda-1257b4e4ba5a" />

## Why It's Good For The Game

We have the fighter duke, a grown up Daring Prince, the mercantile duke, a grown up Sheltered Aristocrat, and the inbred duke, a grown up Inbred Wastrel. This is a grown up Introverted Bookworm. They get shit physical combat, even compared to most mages (who'll have something like polearms), but in exchange they get spells. Only T2 though to keep them being **too** good or stepping on the toes of other classes. Not sure about the tuning on the spell points, might need to go up or down.
