### PR TITLE
Fixes goblin eyes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/other/goblin.dm
+++ b/code/modules/jobs/job_types/roguetown/other/goblin.dm
@@ -58,7 +58,7 @@
 		if(eyes)
 			eyes.Remove(H,1)
 			QDEL_NULL(eyes)
-		eyes = new /obj/item/organ/eyes/night_vision/zombie
+		eyes = new /obj/item/organ/eyes/night_vision/wild_goblin
 		eyes.Insert(H)
 		H.ambushable = FALSE
 		H.underwear = "Nude"

--- a/code/modules/mob/living/carbon/human/npc/goblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/goblin.dm
@@ -268,7 +268,7 @@
 	if(eyes)
 		eyes.Remove(src,1)
 		QDEL_NULL(eyes)
-	eyes = new /obj/item/organ/eyes/night_vision/nightmare
+	eyes = new /obj/item/organ/eyes/night_vision/wild_goblin
 	eyes.Insert(src)
 	src.underwear = "Nude"
 	if(src.charflaw)


### PR DESCRIPTION
## About The Pull Request
Makes it so goblins actually use their unique night vision eyes subtypes.

## Testing Evidence
It compiles.

## Why It's Good For The Game
Finally puts an end to people implanting goblin eyes into themselves, as has been intended for a while, since the proper subtype of goblin eyes poisons you if implanted.