### PR TITLE
Removes duplicate equipment from Marshal, gives Sergeant a horn

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
@@ -121,6 +121,7 @@
 		/obj/item/rope/chain = 1,
 		/obj/item/storage/keyring/guardsergeant = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,
+		/obj/item/signal_horn = 1,
 	)
 	H.adjust_blindness(-3)
 	//triage fix - loadout is busted, needs fix. See https://github.com/Scarlet-Reach/Scarlet-Reach/issues/1226

--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -42,7 +42,6 @@
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	id = /obj/item/scomstone/garrison
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/signal_horn = 1)
 
 	H.verbs |= /mob/proc/haltyell
 	H.verbs |= list(/mob/living/carbon/human/proc/request_outlaw, /mob/living/carbon/human/proc/request_law, /mob/living/carbon/human/proc/request_law_removal, /mob/living/carbon/human/proc/request_purge)
@@ -87,6 +86,7 @@
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
 	beltl = /obj/item/storage/keyring/sheriff
 	head = /obj/item/clothing/head/roguetown/chaperon/noble/bailiff
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/signal_horn = 1)
 
 /datum/advclass/marshal/kcommander
 	name = "Knight Commander"
@@ -126,6 +126,7 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
 	beltl = /obj/item/storage/keyring/sheriff
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/signal_horn = 1)
 
 /mob/living/carbon/human/proc/request_law()
 	set name = "Request Law"


### PR DESCRIPTION
## About The Pull Request

Fixes the issue with Marshal causing them to spawn with two horns and two daggers. Also gives the Sergeant a horn in their backpack.

## Testing Evidence

I forgot to grab screenshots, but I tested both and they spawn as expected now, with one signal horn (and only one dagger for Marshal)

## Why It's Good For The Game

Bug fix is self-explanatory. Sergeant getting a horn is for a few reasons. Firstly, it's what I usually see done with the Marshal's spare horn currently; intended or not the garrison has been making use of its two horns. Secondly, it's a natural thing for a combat leadership role to have, especially the kind that's supposed to be leading from the front. It lets them get reinforcements more reliably than trying to scream their location into their scomstone. I would give one to KC too if that role itself wasn't on the chopping block.
