### PR TITLE
Fixes blunt intent damage, clamps dullness to fix edge case

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -240,7 +240,7 @@
 		return newforce
 	var/dullness_ratio = 1
 	if(I.max_blade_int && I.sharpness != IS_BLUNT)
-		dullness_ratio = I.blade_int / I.max_blade_int
+		dullness_ratio = clamp(I.blade_int / I.max_blade_int, 0.05, 1)
 	var/cont = FALSE
 	var/used_str = user.STASTR
 	if(iscarbon(user))


### PR DESCRIPTION
## About The Pull Request
Fixes some stuff.

## Testing Evidence
It compiles.

## Why It's Good For The Game
Makes blunt less useless by fixing a broken part of the code. Smash now deals more damage than strike as intended.
Makes it so your weapon no longer reverts to dealing full damage the moment it hits 0% sharpness.
