### PR TITLE
[TM] Fixes Werewolves not being able to Howl

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -197,7 +197,7 @@
 	skills?.known_skills = WA.stored_skills.Copy()
 	skills?.skill_experience = WA.stored_experience.Copy()
 
-	W.RemoveSpell(new /obj/effect/proc_holder/spell/self/howl/call_of_the_moon)
+	W.RemoveSpell(new /obj/effect/proc_holder/spell/self/howl)
 	W.RemoveSpell(new /obj/effect/proc_holder/spell/self/claws)
 
 	W.regenerate_icons()


### PR DESCRIPTION
- Werewolves use the T4 Miracle version of Howl instead of the one in werewolf_spells like they're supposed to.
- This creates an issue where werewolves can't howl because they don't have devotion.
- Reverting them to using their howls fixes this. I don't know why it was changed to begin with.
- In my testing this fixed the devotion issue and didn't introduce any bugs. However, I was only able to test by myself so I can't tell if this causes any other issues.
- Because of this, a test merge should be done incase it causes any other problems.