### PR TITLE
Fixes the Bracer Bug

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1277,7 +1277,6 @@ There are several things that need to be remembered:
 		update_body_parts(redraw = TRUE)
 		dna.species.handle_body(src)
 	update_hair()
-	update_inv_wrists()
 	// Note: wrists will update gloves in its own update
 
 	apply_overlay(SHIRT_LAYER)


### PR DESCRIPTION
- There's currently a bug that causes bracers to still appear on mobs after they've been removed.
- Deleting this single line of code fixes the bug and doesn't seem to cause any issues in my testing.
- Fixing this was a fucking nightmare. It took me over 8 hours to track down the one line of code causing it, which I finally did by finding the commit that introduced the bug and reverting chunks of code until it went away.
- Here's the commit in question, if you're curious. https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1179/commits/c1508958f28c1ef51623f9c99b9bd5ff0c2d7ae3