### PR TITLE
Resident virtue removes the Outlander trait

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -86,6 +86,9 @@
 
 	if(mapswitch == 0)
 		return
+	if(HAS_TRAIT(recipient, TRAIT_OUTLANDER))
+		to_chat(recipient, "You may have originated from another land, but you have lived here long enough and become a true citizen.")
+		REMOVE_TRAIT(recipient, TRAIT_OUTLANDER, JOB_TRAIT)
 	if(recipient.mind?.assigned_role == "Adventurer" || recipient.mind?.assigned_role == "Mercenary" || recipient.mind?.assigned_role == "Court Agent")
 		// Find tavern area for spawning
 		var/area/spawn_area


### PR DESCRIPTION
## About The Pull Request

Having the Resident virtue will now remove the Outlander trait if you would normally have it.

## Testing Evidence

<img width="595" height="410" alt="image" src="https://github.com/user-attachments/assets/f108d4ea-0ced-4a02-8bcd-c6fdb4e86fd1" />

## Why It's Good For The Game

Resident virtue represents that you're a part of the town, with a home and everything, despite your class origins. Prior to my changing of the Meister to permit foreigner accounts, one of its major benefits was that unlike other outlanders, you actually had an account. This allows them to use that account without the extra taxes. Additionally, it means that you're not a foreigner for purposes of the laws that dukes often make regarding such, which makes sense given that you literally live in town and have your own home.