### PR TITLE
Fixes the bug where Goblins go blind 

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -182,7 +182,7 @@
 
 /obj/item/organ/eyes/night_vision/wild_goblin/on_life()
 	. = ..()
-	if (!isgoblinp(owner))
+	if (!isgoblinp(owner) && !istype(owner, /mob/living/carbon/human/species/goblin))
 		if (prob(50))
 			owner.adjustToxLoss(5)
 			applyOrganDamage(10)


### PR DESCRIPTION
- Basically, the goblin eyes code check for "!isgoblinp" for if it should poison the owner or not.  This is from an unused race which is not used by our NPCs or Goblin siegers.
- This caused goblins to be poisoned and die over the course of a round. This was especially bad for besiegers
- This PR adds a check for the goblin mob we use, and if the owner is a goblin, it doesn't poison them. This fixes the issue.
- Screenshot attached. As you can see i am not getting the burning eyes poison messages
<img width="2612" height="1449" alt="image_2025-11-23_223331883" src="https://github.com/user-attachments/assets/99460540-c28a-4360-8f81-b6f0bffe6968" />
