### PR TITLE
Small Surgery Tweak

### DIFF
--- a/code/modules/surgery/surgeries/healing.dm
+++ b/code/modules/surgery/surgeries/healing.dm
@@ -13,8 +13,8 @@
 	name = "Repair body"
 	implements = list(
 		TOOL_SUTURE = 80,
-		TOOL_HEMOSTAT = 60,
-		TOOL_IMPROVISED_HEMOSTAT = 50,
+		TOOL_HEMOSTAT = 80,
+		TOOL_IMPROVISED_HEMOSTAT = 60,
 		TOOL_SCREWDRIVER = 50,
 	)
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
@@ -24,8 +24,8 @@
 	repeating = TRUE
 	repeatingonfail = TRUE
 	surgery_flags = SURGERY_BLOODY | SURGERY_CLAMPED
-	skill_min = SKILL_LEVEL_JOURNEYMAN
-	skill_median = SKILL_LEVEL_EXPERT
+	skill_min = SKILL_LEVEL_APPRENTICE
+	skill_median = SKILL_LEVEL_APPRENTICE
 	success_sound = 'sound/surgery/retractor2.ogg'
 	failure_sound = 'sound/surgery/organ2.ogg'
 	/// How much brute damage we heal per completion


### PR DESCRIPTION
## About The Pull Request

Makes forceps the correct tool for damage tending surgeries.

Also reduces the skill modifiers on damage tending to make them easier at all skill levels.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="451" height="75" alt="image" src="https://github.com/user-attachments/assets/582751d8-a8f7-41af-acb0-0a6083c76c79" />

On a bed with expert skill using forceps. Intentional fail so it will show the odds.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Everybody uses forceps, the AP guide to surgery says to use forceps. People would rather keep hammering away screaming that the game is broken than try a different tool.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
