### PR TITLE
Revert "coif on face"

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -41,7 +41,7 @@
 	item_state = "coif"
 	max_integrity = 125
 	flags_inv = HIDEHAIR
-	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD|ITEM_SLOT_MASK
+	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD
 	blocksound = SOFTHIT
 	body_parts_covered = NECK|HAIR|EARS|HEAD
 	armor = ARMOR_LEATHER
@@ -62,7 +62,7 @@
 	item_state = "coif" // Lacks its own sprite/grey-sprite.
 	max_integrity = 100
 	flags_inv = HIDEHAIR
-	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD|ITEM_SLOT_MASK
+	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD
 	blocksound = SOFTHIT
 	body_parts_covered = NECK|HAIR|EARS|HEAD
 	armor = ARMOR_PADDED_BAD
@@ -97,7 +97,7 @@
 	flags_inv = HIDEHAIR
 	armor = ARMOR_MAILLE
 	resistance_flags = FIRE_PROOF
-	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD|ITEM_SLOT_MASK
+	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD
 	body_parts_covered = NECK|HAIR|EARS|HEAD
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT)
 	adjustable = CAN_CADJUST


### PR DESCRIPTION
## About The Pull Request

Reverts Scarlet-Reach/Scarlet-Reach#674

## Testing Evidence

reverts.

## Why It's Good For The Game

because the original pr cites

> Less skullcracks, less decaps, more armor for people to spend on which means more work for the smiths.

this isn't really a good reason nor is it a selling point to be able to stack essentially helmets.

<img width="356" height="80" alt="image" src="https://github.com/user-attachments/assets/38d5d951-ebbf-41f2-ad6b-1c1c159501d1" />

you can wear two of these, one on your neck and one on your mask slot, for a whopping 700 armor before even considering a helmet, covering...

<img width="370" height="28" alt="image" src="https://github.com/user-attachments/assets/d4557589-884d-43a0-972b-b1e994d201c5" />

please note that the integrity of an **armet** is only 325. the original pr is just armor powercreep




