### PR TITLE
bevor upscale - the most useless armor item (but the most drippy) actually gets a use

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -227,7 +227,7 @@
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/steel
 	resistance_flags = FIRE_PROOF
-	slot_flags = ITEM_SLOT_NECK
+	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_MASK
 	body_parts_covered = NECK|MOUTH|NOSE
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST)
 	adjustable = CAN_CADJUST
@@ -296,8 +296,8 @@
 		add_overlay(pic)
 
 /obj/item/clothing/neck/roguetown/fencerguard/Initialize()
-	. = ..()		
-	update_icon()		
+	. = ..()
+	update_icon()
 
 /obj/item/clothing/neck/roguetown/gorget/forlorncollar
 	name = "forlorn collar"
@@ -367,7 +367,7 @@
 	if(slot == SLOT_NECK)
 		mob_overlay_icon = initial(mob_overlay_icon)
 		sleeved = initial(sleeved)
-	
+
 	return TRUE
 
 /obj/item/clothing/neck/roguetown/psicross/attack_right(mob/user)


### PR DESCRIPTION
## About The Pull Request

lets you put bevors on the mask slot, might be pending a additional balance pass to reduce their integrity as a downside to this; also kind of brings the bevor in line with a similar alternative, the steel mempo which isn't nearly as drippy but is basically a bevor equippable on the mask slot, so yeah

semi related to this https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1546 - as instead of people wearing coifs as masks it'll probably result in people wearing bevors to fill in the gap, maybe wearing a coif as their gorget substitute
but that in turn opens necks to peeling - which may or may not go away with the combat rework pr, so who knows if this will annihilate balance, i just want to in truth, wear a bevor for the drip, while wearing something that isn't the fucking bevor on my neck slot because holy shit the bevor is really just a worse gorget

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

i promise i tested a one line change it works as intended with no visual oddities

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

okay so as it is there's basically no reason to wear a bevor other than if you're

A: wearing the visored sallet, which is basically inferior to a fullfaced helmet in every facet
B: wearing it for the drip, which is probably why you're wearing the visored sallet
this is a visored sallet upscale PR in disguise

otherwise, the bevor is basically just a peelable gorget as the nose and mouth protection rarely comes into play as everyone who's aiming for facial features is aiming eyes to bypass fullface coifs, and the protection that the bevor provides means that even `if` someone is aiming for facial features, they're probably doing it with a poking weapon that has enough AP to act like the bevor isn't even there

wearing it on your mask slot compared to an actual mask substitutes eye protection for an extra neck layer, which I'd argue eye protection is more important - but still a fair tradeoff for people who don't want to get standing decapitated as easily
obviously you can also wear two bevors but why the fuck would you do that, wear a gorget, dumbass

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
