### PR TITLE
Fixes  Inquisition silver bars (actually for reals this time)

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -1106,3 +1106,94 @@
 	created_item = /obj/item/rogueweapon/whip/psywhip_lesser
 	additional_items = list(/obj/item/natural/hide/cured, /obj/item/natural/hide/cured)
 	i_type = "Weapons"
+
+// BLESSED SILVER, BULLION VARIANTS
+/datum/anvil_recipe/weapons/psy/axe/inq
+	name = "Psydonian War Axe (+1 B. Silver, +1 Stick)"
+	req_bar = /obj/item/ingot/silverblessed/bullion
+	craftdiff = 3
+	created_item = /obj/item/rogueweapon/stoneaxe/battle/psyaxe
+	additional_items = list(/obj/item/ingot/silverblessed/bullion, /obj/item/grown/log/tree/stick)
+	i_type = "Weapons"
+
+/datum/anvil_recipe/weapons/psy/mace/inq
+	name = "Psydonian Mace (+1 B. Silver, +1 Stick)"
+	req_bar = /obj/item/ingot/silverblessed/bullion
+	craftdiff = 3
+	created_item = /obj/item/rogueweapon/mace/goden/psymace
+	additional_items = list(/obj/item/ingot/silverblessed/bullion, /obj/item/grown/log/tree/stick)
+	i_type = "Weapons"
+
+/datum/anvil_recipe/weapons/psy/spear/inq
+	name = "Psydonian Spear (+1 Small Log)"
+	req_bar = /obj/item/ingot/silverblessed/bullion
+	craftdiff = 3
+	created_item = /obj/item/rogueweapon/spear/psyspear
+	additional_items = list(/obj/item/grown/log/tree/small)
+	i_type = "Weapons"
+
+/datum/anvil_recipe/weapons/psy/dagger/inq
+	name = "Psydonian Dagger"
+	req_bar = /obj/item/ingot/silverblessed/bullion
+	craftdiff = 3
+	created_item = /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger
+	i_type = "Weapons"
+
+/datum/anvil_recipe/weapons/psy/shortsword/inq
+	name = "Psydonian Shortsword"
+	req_bar = /obj/item/ingot/silverblessed/bullion
+	craftdiff = 3
+	created_item = /obj/item/rogueweapon/sword/short/psy
+	i_type = "Weapons"
+
+/datum/anvil_recipe/weapons/psy/katar/inq
+	name = "Psydonian Katar"
+	req_bar = /obj/item/ingot/silverblessed/bullion
+	craftdiff = 3
+	created_item = /obj/item/rogueweapon/katar/psydon
+	i_type = "Weapons"
+
+/datum/anvil_recipe/weapons/psy/knuckles/inq
+	name = "Psydonian Knuckles"
+	req_bar = /obj/item/ingot/silverblessed/bullion
+	craftdiff = 3
+	created_item = /obj/item/rogueweapon/knuckles/psydon
+	i_type = "Weapons"
+
+/datum/anvil_recipe/weapons/psy/cudgel/inq
+	name = "Psydonian Handmace"
+	req_bar = /obj/item/ingot/silverblessed/bullion
+	craftdiff = 3
+	created_item = /obj/item/rogueweapon/mace/cudgel/psy
+	i_type = "Weapons"
+
+/datum/anvil_recipe/weapons/psy/halberd/inq
+	name = "Psydonian Halberd (+1 B. Silver, +1 Small Log)"
+	req_bar = /obj/item/ingot/silverblessed/bullion
+	craftdiff = 3
+	created_item = /obj/item/rogueweapon/halberd/psyhalberd
+	additional_items = list(/obj/item/ingot/silverblessed/bullion, /obj/item/grown/log/tree/small)
+	i_type = "Weapons"
+
+/datum/anvil_recipe/weapons/psy/gsword/inq
+	name = "Psydonian Greatsword (+1 B. Silver)"
+	req_bar = /obj/item/ingot/silverblessed/bullion
+	craftdiff = 3
+	created_item = /obj/item/rogueweapon/greatsword/psygsword
+	additional_items = list(/obj/item/ingot/silverblessed/bullion)
+	i_type = "Weapons"
+
+/datum/anvil_recipe/weapons/psy/sword/inq
+	name = "Psydonian Sword"
+	req_bar = /obj/item/ingot/silverblessed/bullion
+	craftdiff = 3
+	created_item = /obj/item/rogueweapon/sword/long/psysword
+	i_type = "Weapons"
+
+/datum/anvil_recipe/weapons/psy/whip/inq
+	name = "Psydonian Whip (+2 Cured Leather)"
+	req_bar = /obj/item/ingot/silverblessed/bullion
+	craftdiff = 3
+	created_item = /obj/item/rogueweapon/whip/psywhip_lesser
+	additional_items = list(/obj/item/natural/hide/cured, /obj/item/natural/hide/cured)
+	i_type = "Weapons"


### PR DESCRIPTION
## About The Pull Request
Just adds properly defined and copied smithing recipes for inquisitorial bars. actually fixing the issues #1354 and #1522 tried to fix. TEST YOUR PR's GOSH!!!
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiles. Spawned in and seen I could smith all psydonite weapons with both blessed and inquisitorial blessed bars.  
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bugs bad. Fixes bug. Thus is good.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
