### PR TITLE
Chew on MMB

### DIFF
--- a/code/game/objects/items/rogueweapons/intents/mmb/bite.dm
+++ b/code/game/objects/items/rogueweapons/intents/mmb/bite.dm
@@ -34,9 +34,16 @@
 	if(HAS_TRAIT(user, TRAIT_NO_BITE))
 		to_chat(user, span_warning("I can't bite."))
 		return
-	user.changeNext_move(clickcd)
 	if(!user_species || (user_species && !user_species.headless))
 		user.face_atom(target)
+	if(iscarbon(user))
+		var/mob/living/carbon/carbon_user = user
+		if(carbon_user.mouth?.type == /obj/item/grabbing/bite)
+			var/obj/item/grabbing/bite/bitey = carbon_user.mouth
+			bitey.bitelimb(carbon_user)
+			. = ..()
+			return
+	user.changeNext_move(clickcd)
 	target.onbite(user)
 	. = ..()
 	return


### PR DESCRIPTION
## About The Pull Request

This PR is relatively simple, it lets you chew by clicking the target with MMB, instead of having to move your mouse over to the "chew" button on your mouth slot.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="244" height="320" alt="image" src="https://github.com/user-attachments/assets/fcdc39c9-2cbe-4b56-b34e-9b861303d460" />

Simplemobs can still bite you without issue

<img width="158" height="192" alt="image" src="https://github.com/user-attachments/assets/fa463202-2fa0-4668-b531-acc51ee6d240" />

Code also works with werewolves and normal humans.

I've also tested having your mouth covered and all of the other things that would disallow you from biting, a bit unneccesary, but I've tested it all the same. Forgot the screenshots though so... believe me? Please?

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

QoL, easier ways to bite people without having to look away from the battle into your inventory to actually chew someone.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
