### PR TITLE
Total Harpy Annihilation: Fixes fly up/fly down being too fast

### DIFF
--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -199,7 +199,7 @@
 		if(C.flying)
 			var/turf/open/transparent/openspace/turf_above = get_step_multiz(C, UP)
 			if(C.canZMove(UP, turf_above))
-				if(do_after(C, 3))
+				if(do_after(C, 3 SECONDS)) // excuse me this was fucking 3 (aka 300ms) before???
 					var/athletics_skill = max(C.get_skill_level(/datum/skill/misc/athletics), SKILL_LEVEL_NOVICE)
 					var/stamina_cost_final = round((10 - athletics_skill), 1)
 					C.stamina_add(stamina_cost_final)
@@ -246,7 +246,7 @@
 		if(C.flying)
 			var/turf/open/transparent/openspace/turf_below = get_step_multiz(C, DOWN)
 			if(C.canZMove(DOWN, turf_below))
-				if(do_after(C, 3))
+				if(do_after(C, 3 SECONDS))
 					var/athletics_skill = max(C.get_skill_level(/datum/skill/misc/athletics), SKILL_LEVEL_NOVICE)
 					var/stamina_cost_final = round((10 - athletics_skill), 1)
 					C.stamina_add(stamina_cost_final)


### PR DESCRIPTION
## About The Pull Request

do_afters work with deciseconds. This means that 1 second is the value 10, and 3 seconds are the value 30.

The fly up/down harpy counter was using the value **3** instead of the macro **3 SECONDS**. This means that harpies were able to shift up and down a z-level in **300ms** instead of **3 seconds.**

## Testing Evidence

<img width="462" height="160" alt="image" src="https://github.com/user-attachments/assets/0fe324c0-37ba-4543-8cdb-38a32f83cc27" />

## Why It's Good For The Game

This should make them significantly less annoying in just about every regard. There is no way a paltry 300ms delay was intentional. We can look at adjusting it down to 2 seconds or 1.5 seconds if this is too slow, but it's a good starting point.