### PR TITLE
steel warhammer for footknight

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -212,7 +212,7 @@
 		if("Flail")
 			beltr = /obj/item/rogueweapon/flail/sflail
 		if ("Warhammer")
-			beltr = /obj/item/rogueweapon/mace/warhammer //Iron warhammer. This is one-handed and pairs well with shields. They can upgrade to steel in-round.
+			beltr = /obj/item/rogueweapon/mace/warhammer/steel
 		if("Sabre")
 			beltl = /obj/item/rogueweapon/scabbard/sword
 			l_hand = /obj/item/rogueweapon/sword/sabre


### PR DESCRIPTION
## About The Pull Request

giving footknight's warhammer option the steel hammer instead of the iron one.

## Testing Evidence

<img width="274" height="494" alt="Capture d&#39;écran 2025-11-24 184303" src="https://github.com/user-attachments/assets/1f19a68a-0e8a-4f89-8b5d-c8a2b6cbe259" />


## Why It's Good For The Game

The fact that footknight gets the same primary as footsoldier is a bit strange, i thought. people I discussed it with thought it was also strange. So, footknight gets the steel version, while footman gets the iron version.
