### PR TITLE
Reflavors carpenter into Kunstmeister

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/carpenter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/carpenter.dm
@@ -1,62 +1,65 @@
 /datum/advclass/carpenter
-	name = "Carpenter"
-	tutorial = "A skilled carpenter, able to manipulate wood to suit their needs \
-	building forts and stores, carpenting floors, putting up crosses. You can do it all with enough logs"
+	name = "Kunstmeister"
+	tutorial = "You are a skilled artisan; Trained in various arts of your craft, be it stonework or woodwork, you are a useful service to the town in need of new homes to be built, or repairs from sieges."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
-	outfit = /datum/outfit/job/roguetown/adventurer/carpenter
+	outfit = /datum/outfit/job/roguetown/adventurer/kunstmeister
 	subclass_social_rank = SOCIAL_RANK_YEOMAN
 
 	category_tags = list(CTAG_PILGRIM, CTAG_TOWNER)
 	traits_applied = list(TRAIT_PEASANTMILITIA)
 
 	subclass_stats = list(
+		STATKEY_INT = 2,
 		STATKEY_END = 2,
-		STATKEY_STR = 1,
-		STATKEY_CON = 1,
-		STATKEY_INT = 1,
-		STATKEY_SPD = -1
+		STATKEY_STR = 2, // No extra fortune, doesn't make much of a difference in building
+		STATKEY_CON = 2, // they could reasonably shrug off a fall from a short distance, 
 	)
 
 	subclass_skills = list(
-		/datum/skill/combat/axes = SKILL_LEVEL_APPRENTICE, // They use hammers, sawes and axes all day.
+		/datum/skill/combat/axes = SKILL_LEVEL_APPRENTICE, // these skills can probably stay, they won't be combat viable
 		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE, 
-		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT, 
-		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN, 
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE, 
-		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN, // They work at great heights.
-		/datum/skill/craft/crafting = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/carpentry = SKILL_LEVEL_EXPERT,
-		/datum/skill/craft/masonry = SKILL_LEVEL_NOVICE,
-		/datum/skill/craft/engineering = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/traps = SKILL_LEVEL_NOVICE,
 		/datum/skill/labor/lumberjacking = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/labor/mining = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT, 
+		/datum/skill/craft/crafting = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/carpentry = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/masonry = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/engineering = SKILL_LEVEL_APPRENTICE, // the actual architect can have better engineering, not needed here
+		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE, // why could they swim so well?
+		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT, // it has always annoyed me that you couldn't climb the stone walls you made yourself
+		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/ceramics = SKILL_LEVEL_APPRENTICE, // needed to work with glass, 
 	)
-
-/datum/outfit/job/roguetown/adventurer/carpenter/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/adventurer/kunstmeister/pre_equip(mob/living/carbon/human/H)
 	..()
-	head = /obj/item/clothing/head/roguetown/hatfur
-	if(prob(50))
-		head = /obj/item/clothing/head/roguetown/hatblu
-	armor = /obj/item/clothing/suit/roguetown/armor/workervest
+
+	head = /obj/item/clothing/head/roguetown/hatfur // more fitting hat
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest
+	cloak = /obj/item/clothing/cloak/apron/waist/bar
 	pants = /obj/item/clothing/under/roguetown/trou
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/random
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	belt = /obj/item/storage/belt/rogue/leather
-	beltr = /obj/item/storage/belt/rogue/pouch/coins/mid
-	beltl = /obj/item/rogueweapon/hammer/steel
+	beltr = /obj/item/flashlight/flare/torch/lantern
+	beltl = /obj/item/rogueweapon/pick // give them an iron pickaxe for balance reasons
+	backr = /obj/item/rogueweapon/stoneaxe/woodcut/steel/woodcutter // woodcutter already gets a woodcutting axe, this should be fine to stay
 	backl = /obj/item/storage/backpack/rogue/backpack
 	backpack_contents = list(
+						/obj/item/rogueweapon/hammer/steel = 1,
+						/obj/item/rogueweapon/handsaw = 1,
+						/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
+						/obj/item/rogueweapon/chisel = 1,
+						/obj/item/flashlight/flare/torch = 1,
 						/obj/item/flint = 1,
 						/obj/item/rogueweapon/huntingknife = 1,
-						/obj/item/flashlight/flare/torch = 1,
 						/obj/item/rogueweapon/handsaw = 1,
-						/obj/item/dye_brush = 1,
+						/obj/item/dye_brush = 1, // does this even have a use?
+						/obj/item/recipe_book/engineering = 1,
 						/obj/item/recipe_book/builder = 1,
 						/obj/item/recipe_book/survival = 1,
-						/obj/item/rogueweapon/scabbard/sheath = 1,
 						)
+	ADD_TRAIT(H, TRAIT_MASTER_CARPENTER, TRAIT_GENERIC) // makes it not ass to get planks for building
+	ADD_TRAIT(H, TRAIT_MASTER_MASON, TRAIT_GENERIC)	// likewise here


### PR DESCRIPTION
## About The Pull Request

Gives the town carpenter some guild architect skill adjacent skills including two notable skills that being master carpenter and master mason, allowing them to get multiple planks from one small log and multiple stone bricks from a single stone

A Kunstmeister is a germanic job that is roughly about what we would consider today an 'Engineer' they were a master in the arts of multiple professions and often worked clerical jobs in the medieval age, that being they were a master in a few skilled trades such as stonework, mining or carpentry and likely blacksmithing too, this is the most equivalent job to what our architect is, we already have a german name for a servant class, why not a towner class.

## Testing Evidence

Compiled on local host, spawned in checking my backpack and it contained no guild key, was given an iron pickaxe properly
<img width="625" height="526" alt="image" src="https://github.com/user-attachments/assets/e5bc62cb-4ecc-4456-bcb1-b427d699d118" />
<img width="624" height="584" alt="image" src="https://github.com/user-attachments/assets/454551f1-a23c-43fb-b5c1-2550995b8570" />


## Why It's Good For The Game

This should allow for players to have skills similar to that of the guild architech while not being as good as the architect in certain aspects, notably with lesser quality equipment and _no guild key_

From experience trying to build anything while only getting a single plank from one small log is a complete pain in the ass and what would take a skilled player about an hour to make a simple house as an architect would take a once again skilled player the entire round to build something pretty small, this should help improve server creativity without having to take up a valuable guild slot!