### PR TITLE
Labels the Hand's mailbox

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -56793,7 +56793,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "pfi" = (
-/obj/structure/roguemachine/mail/r,
+/obj/structure/roguemachine/mail/r{
+	mailtag = "Hand's Chambers"
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},


### PR DESCRIPTION
## About The Pull Request

Labels the mailbox in the Hand's room "Hand's Chambers"

## Testing Evidence

<img width="581" height="118" alt="image" src="https://github.com/user-attachments/assets/185995af-0efa-48eb-95fe-11bc3711c6fa" />

## Why It's Good For The Game

You can mail directly to mailboxes which is sometimes useful, but distinguishing the Hand's mailbox from the other ones in the Manor is a pain. This makes it not a pain.