### PR TITLE
zizoid excommunicado vagrant fix

### DIFF
--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/excommunicado.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/excommunicado.dm
@@ -58,6 +58,8 @@
 		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_SOUL_EXAMINE, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_GRAVEROBBER, TRAIT_GENERIC)
+		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/minion_order)
+		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/gravemark)
 	if(H.patron?.type == /datum/patron/inhumen/baotha)
 		H.adjust_skillrank(/datum/skill/misc/music, 2, TRUE)
 		H.adjust_skillrank(/datum/skill/craft/alchemy, 2, TRUE)


### PR DESCRIPTION
## About The Pull Request
gives zizoid excommunicated vagrants gravemark and minion order

## Testing Evidence
lowkey didn't test it but its just 2 lines of code, surely this doesn't break anything :clueless:

## Why It's Good For The Game
since they can summon skeletons they're supposed to have it