### PR TITLE
Caps overfill from red potions to 600 blood, tweaks lesser health to not be stronger than normal health potions

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -597,3 +597,8 @@ Medical defines
 #define ARTERY_LIMB_BLEEDRATE 20	//This is used as a reference point for dynamic wounds, so it's better off as a define.
 #define CONSTITUTION_BLEEDRATE_MOD 0.1	//How much slower we'll be bleeding for every CON point. 0.1 = 10% slower.
 #define CONSTITUTION_BLEEDRATE_CAP 15	//The CON value up to which we get a bleedrate reduction.
+
+/*
+	Red Potion defines
+*/
+#define BLOOD_VOLUME_POTION_MAX 600

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -18,9 +18,9 @@
 /datum/reagent/medicine/minorhealthpot/on_mob_life(mob/living/carbon/M) // Heals half as much as health potion, but not wounds.
 	var/list/wCount = M.get_wounds()
 	if(M.blood_volume < BLOOD_VOLUME_NORMAL) //can not overfill
-		M.blood_volume = min(M.blood_volume+20, BLOOD_VOLUME_MAXIMUM)
+		M.blood_volume = min(M.blood_volume+5, BLOOD_VOLUME_NORMAL)
 	if(wCount.len > 0)
-		M.heal_wounds(10)
+		M.heal_wounds(3)
 		M.update_damage_overlays()
 		if(prob(10))
 			to_chat(M, span_nicegreen("I feel my wounds mending."))
@@ -29,7 +29,6 @@
 			M.reagents.remove_reagent(R.type,1)
 	M.adjustBruteLoss(-1, 0)
 	M.adjustFireLoss(-1, 0)
-	M.adjustToxLoss(-1, 0)
 	M.adjustOxyLoss(-1.5, 0)
 	M.adjustCloneLoss(-1, 0)
 	for(var/obj/item/organ/organny in M.internal_organs)
@@ -68,11 +67,11 @@
 /datum/reagent/medicine/healthpot/on_mob_life(mob/living/carbon/M)
 	var/list/wCount = M.get_wounds()
 	if(M.blood_volume < BLOOD_VOLUME_NORMAL)
-		M.blood_volume = min(M.blood_volume+10, BLOOD_VOLUME_MAXIMUM) //Each sip restores 10%~ of your total blood, given every person has a max of 560 blood.
+		M.blood_volume = min(M.blood_volume+10, BLOOD_VOLUME_POTION_MAX) //Each sip restores 10%~ of your total blood, given every person has a max of 560 blood.
 		//Yes this is the same amount that water recovers, but this is the 'normal' health potion.
 	else
 		//can overfill you with blood, but at a slower rate
-		M.blood_volume = min(M.blood_volume+5, BLOOD_VOLUME_MAXIMUM)
+		M.blood_volume = min(M.blood_volume+5, BLOOD_VOLUME_POTION_MAX)
 	if(wCount.len > 0)
 		//some peeps dislike the church, this allows an alternative thats not a doctor or sleep.
 		M.heal_wounds(8)
@@ -98,9 +97,9 @@
 /datum/reagent/medicine/stronghealth/on_mob_life(mob/living/carbon/M)
 	var/list/wCount = M.get_wounds()
 	if(M.blood_volume < BLOOD_VOLUME_NORMAL)
-		M.blood_volume = min(M.blood_volume+20, BLOOD_VOLUME_MAXIMUM) //+100 blood per sip, 960 blood per bottle. Still enough to fill up your blood twice over.
+		M.blood_volume = min(M.blood_volume+20, BLOOD_VOLUME_POTION_MAX) //+100 blood per sip, 960 blood per bottle. Still enough to fill up your blood twice over.
 	else
-		M.blood_volume = min(M.blood_volume+10, BLOOD_VOLUME_MAXIMUM)
+		M.blood_volume = min(M.blood_volume+10, BLOOD_VOLUME_POTION_MAX)
 	if(wCount.len > 0)
 		M.heal_wounds(12) //Less wound healing. Two sips will fix an artery, but only barely. 
 		M.update_damage_overlays()


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Caps blood volume maximum overfilled by health potions to 600 blood instead of 1120 blood (560 is normal blood volume)

Removes toxin healing from lesser health potions, decreases wound healing from 10 to 3 to make sense. 

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="1487" height="871" alt="Blood volume" src="https://github.com/user-attachments/assets/5b482773-beec-46ac-be04-992719193ba4" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Blood Overfill: Not very good for the game for someone to be able to stack an absurd amount of blood in them with ease, some amount is okay so we give a buffer for it to exist. They're healing potions, not infinite blood forever potions.

Lesser potions: For some reason they were just better than normal health potions in wound healing and also gave toxic healing, I do believe the last time potions were nerfed they were entirely overlooked, so they're just nerfed to be weaker than other health potions.
