### PR TITLE
Lets people skill train up to apprentice in any combat skill against NPCs etc

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -367,7 +367,7 @@
 			if(weapon_parry == TRUE)
 				if(do_parry(used_weapon, drained, user)) //show message
 					if ((mobility_flags & MOBILITY_STAND))
-						var/skill_target = max(SKILL_LEVEL_EXPERT, attacker_skill)
+						var/skill_target = max(SKILL_LEVEL_JOURNEYMAN, attacker_skill)
 						if(!HAS_TRAIT(U, TRAIT_GOODTRAINER))
 							skill_target -= SKILL_LEVEL_NOVICE
 						if (can_train_combat_skill(src, used_weapon.associated_skill, skill_target))
@@ -384,7 +384,7 @@
 						else
 							attacker_skill_type = /datum/skill/combat/unarmed
 						if ((mobility_flags & MOBILITY_STAND))
-							var/skill_target = max(SKILL_LEVEL_EXPERT, defender_skill)
+							var/skill_target = max(SKILL_LEVEL_JOURNEYMAN, defender_skill)
 							if(!HAS_TRAIT(src, TRAIT_GOODTRAINER))
 								skill_target -= SKILL_LEVEL_NOVICE
 							if (can_train_combat_skill(U, attacker_skill_type, skill_target))
@@ -416,7 +416,7 @@
 			if(weapon_parry == FALSE)
 				if(do_unarmed_parry(drained, user))
 					if((mobility_flags & MOBILITY_STAND))
-						var/skill_target = max(SKILL_LEVEL_EXPERT, attacker_skill)
+						var/skill_target = max(SKILL_LEVEL_JOURNEYMAN, attacker_skill)
 						if(!HAS_TRAIT(U, TRAIT_GOODTRAINER))
 							skill_target -= SKILL_LEVEL_NOVICE
 						if(can_train_combat_skill(H, /datum/skill/combat/unarmed, skill_target))


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

People can now train up to Apprentice (or Journeyman if the target is a good trainer) in any combat skill without needing to fight someone with higher combat skills. In particular, this means less experienced characters can learn combat skill from fighting monsters and NPCs, as well as generally other people.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="545" height="158" alt="Test" src="https://github.com/user-attachments/assets/1af7f25e-4d09-4d7b-9e55-8da3c0dc4c86" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

The nerf made here is to prevent people from training up combat skills all the way to legendary or the like, but inadvertently made it so you are unable to train combat skills at all against anything but players, and only players with higher combat skills.

This, frankly, sucks if you don't start with combat skills. Its not fair at all for non-combat roles to be basically unable to learn any combat ability from going out on an adventure and fighting volves or some shit and only have the option to use a dummy to get to apprentice (which is fairly boring). This rectifies that.