### PR TITLE
Allows grenzelhoft hats to fit on the mask slot 

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -1959,6 +1959,7 @@
 	item_state = "grenzelhat"
 	icon = 'icons/roguetown/clothing/head.dmi'
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/stonekeep_merc.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/onmob/head.dmi' //Overrides slot icon behavior
 	slot_flags = ITEM_SLOT_HEAD
 	detail_tag = "_detail"
 	altdetail_tag = "_detailalt"
@@ -1972,6 +1973,8 @@
 	color = "#262927"
 	detail_color = "#FFFFFF"
 	altdetail_color = "#9c2525"
+	alternate_worn_layer  = 8.9 //On top of helmet
+	var/swapped = FALSE
 
 /obj/item/clothing/head/roguetown/grenzelhofthat/attack_right(mob/user)
 	..()
@@ -2002,7 +2005,24 @@
 			pic2.color = get_altdetail_color()
 		add_overlay(pic2)
 
-
+/obj/item/clothing/head/roguetown/grenzelhofthat/MiddleClick(mob/user, params)
+	..()
+	if(user.loc)
+		user.doUnEquip(src, TRUE, get_turf(user), silent = TRUE) // Forcibly unequips it.
+	else
+		return
+	swapped = !swapped
+	if(swapped)
+		slot_flags = ITEM_SLOT_MASK
+		armor = getArmor(0, 0, 0, 0, 0, 0)
+		prevent_crits = list()
+		desc = "Whether it's monsters or fair maidens, a true Grenzelhoftian slays both. This hat has had the hidden metallic cap underneath removed."
+	else
+		slot_flags = initial(slot_flags) // initial doesn't work for armor :sob:
+		armor = getArmor(70, 70, 50, 30, 0, 0) // Resets it back to ARMOR_SPELLSINGER (UPDATE THIS IF ANY BALANCEJACKS COME BY)
+		prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_TWIST)
+		desc = initial(desc)
+	user.visible_message("[user] adjusts [src]", "I adjust [src].", vision_distance = 1)
 
 /obj/item/clothing/head/roguetown/helmet/tricorn
 	slot_flags = ITEM_SLOT_HEAD


### PR DESCRIPTION
## About The Pull Request

Adds the ability to click MiddleMouse on a grenzelhoft plume hat, allowing it to fit on the mask slot. 

**Doing this removes the armor.**

You can revert it by middle clicking it again.

Changing the functionality (removing the metal cap) will cause it to drop to the ground.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="122" height="144" alt="image" src="https://github.com/user-attachments/assets/8b194140-bf8d-432c-99a5-c8a3b41ce0bc" />

<img width="714" height="626" alt="image" src="https://github.com/user-attachments/assets/ff2e8723-4b80-4725-bb65-a3ff1793d429" />

<img width="732" height="882" alt="image" src="https://github.com/user-attachments/assets/2c0070cc-fee2-4f2b-b680-7f3e447c8866" />




## Why It's Good For The Game

Drip. I don't even play grenzelhoft often, just something I heard people want.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
