### PR TITLE
[AP Port] Message QoL + Projections AP#4620

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/message.dm
+++ b/code/modules/spells/spell_types/wizard/utility/message.dm
@@ -87,7 +87,7 @@
 					to_chat(user, span_big("You whisper anonymously into [HL]'s mind: <font color=#[message_color]><i>\"[message]\"</i></font>"))
 				else
 					to_chat(HL, span_big("A brief vision suddenly flashes in my mind, originating from an unknown source: <font color=#[message_color]>\[<b>[message]</b>\]</font>"))
-					to_chat(user, span_big("You anonymously slip a brief vision into [HL]'s mind: <font color=#[message_color]>\[<b>[message]</b>\]</font>"))
+					to_chat(user, span_big("You slip a brief vision anonymously into [HL]'s mind: <font color=#[message_color]>\[<b>[message]</b>\]</font>"))
 
 			// Messages are whispered out loud, projections are just a silent murmur.
 			if(!is_projection)


### PR DESCRIPTION
[Original PR here](https://github.com/Azure-Peak/Azure-Peak/pull/4620)
All credit to [hazelrat](https://github.com/hazelrat)

## Testing Evidence
Ported evidence-
### Projection
<img width="535" height="205" alt="image" src="https://github.com/user-attachments/assets/7e079b31-4bc0-4a16-bf4f-e14efef28310" />

### Message
<img width="535" height="232" alt="image" src="https://github.com/user-attachments/assets/6da46ce0-a1a7-4ba2-856d-e9881fa77d05" />

> ## About The Pull Request
> This expands the message spell in the following ways:
> 
> * You may now either issue a message or a projection to the recipient of the spell. Projections are brief visions, comprising visuals, smells, feelings, and anything else that isn't a spoken sentence.
> * More feedback is implemented for the sender - you get a message confirming the success of the spell in addition to receiving the same noise as the recipient.
> * If not anonymous, messages appear in the text colour of the sender.
> 
> ## Testing Evidence
> <img alt="image" width="470" height="192" src="https://private-user-images.githubusercontent.com/83198434/517375082-2a4e434f-9648-48e6-b8a7-d3f1b0a47e6f.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjQxODQ0MDcsIm5iZiI6MTc2NDE4NDEwNywicGF0aCI6Ii84MzE5ODQzNC81MTczNzUwODItMmE0ZTQzNGYtOTY0OC00OGU2LWI4YTctZDNmMWIwYTQ3ZTZmLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTExMjYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMTI2VDE5MDgyN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTVmOGVkYmRkNjFhNWViYzg0OTE0NjlhY2FmZmI4YmQ0NmJiZWE4MjM4ZmM0OWMzNzI5OWZhNDJkNzNkMDFiY2ImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.Gyn-YC0Xzr18648_E-dPSPEI47fYtBgQ4cc8DPdqqEw"> <img alt="image" width="474" height="167" src="https://private-user-images.githubusercontent.com/83198434/517375484-6669a0fd-43dd-47fc-a96a-f0ef967db7f3.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjQxODQ0MDcsIm5iZiI6MTc2NDE4NDEwNywicGF0aCI6Ii84MzE5ODQzNC81MTczNzU0ODQtNjY2OWEwZmQtNDNkZC00N2ZjLWE5NmEtZjBlZjk2N2RiN2YzLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTExMjYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMTI2VDE5MDgyN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWNmOTNhNmI1NWNlZjUwNTY1ZjgwYjEwODg0ZTBiZjhkN2QzMjZkMzc4NmZiM2NhOTVlNzg5OThkN2U2NzA1NzcmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.k29dFNa7Dpx2F35pFRtWIUIo8OdnM1ZAMY7CvpmG-7w">
> ## Why It's Good For The Game
> Projections open up a lot of roleplay potential to the spell that isn't otherwise possible - there's a lot you can do with direct mind-to-mind communications that don't have to just be bound up in the format of dialogue. You can write prose! Obscure visions to interpret! Convince someone they're seeing the future! Get artsy!
> 
> Projections aren't whispered like messages are. This does theoretically open up the bad faith interaction of speaking normally into a projection just to avoid the message being whispered, but this is all adminlogged and it's a pretty particular scenario where it could be abused. Beyond that, the rest of this is just QoL.
