### PR TITLE
Fixes migration

### DIFF
--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -315,17 +315,30 @@ SUBSYSTEM_DEF(migrants)
 
 	for(var/client/client as anything in players)
 		var/base_priority = 0
-
-		// Standard role preference priority
+		var/triumph_bonus = 0
+		//Standard role preference priority
 		if(role_type in client.prefs.migrant.role_preferences)
-			base_priority = 100
+			base_priority = 1
+			triumph_bonus = get_triumph_selection_bonus(client, wave_type) //Only gains the Triumph Bonus if they want that role.
 
-		var/final_priority = base_priority + 100 * get_triumph_selection_bonus(client, wave_type)
+		var/final_priority = base_priority + triumph_bonus
 
 		if(final_priority > 0)
 			triumph_weighted[client] = final_priority
 
-	// Convert weighted list back to prioritized list
+	//Check if all triumph_weighted values are equal
+	var/all_equal = TRUE
+	var/first_val = -1
+
+	if(length(triumph_weighted))
+		first_val = triumph_weighted[1]
+		for(var/client/client in triumph_weighted)
+			// Check if anything is not equal to the first value in the list
+			if(triumph_weighted[client] != first_val)
+				all_equal = FALSE
+				break
+
+	//Convert weighted list to prioritized list
 	while(length(triumph_weighted))
 		var/client/highest = null
 		var/highest_priority = 0
@@ -339,8 +352,11 @@ SUBSYSTEM_DEF(migrants)
 			priority += highest
 			triumph_weighted -= highest
 
-	return priority
+	//Shuffle only if all have equal priority
+	if(all_equal)
+		priority = shuffle(priority)
 
+	return priority
 
 /datum/controller/subsystem/migrants/proc/can_be_role(client/player, role_type)
 	var/datum/migrant_role/role = MIGRANT_ROLE(role_type)


### PR DESCRIPTION
## About The Pull Request

Actually ports [this](https://github.com/Monkestation/Vanderlin/pull/3503) from Vanderlin. All credit goes to wgtjunior743!

> Fix the bug from this issue: (random migration job assignment) , the issue was happening because the triumph buff was being added even if the user didn't prioritize the role so they could roll squire and the squire would just roll knight.
> 
> Now by spending triumphs on a wave you can basically guarantee rolling a role you prioritize, for example if Jones spends 13 Triumphs, they can roll anything on the wave since the maximum someone can spend now is 12, that works for all the other roles as well.

## Testing Evidence
I even tested it with two clients!

<img width="601" height="420" alt="image" src="https://github.com/user-attachments/assets/0c048a8d-cf56-45b8-ae76-dda81bb43067" />


## Why It's Good For The Game

Uhhh I think I need those bugs gone