### PR TITLE
Revert "Refactors Spell transferring during transformation"

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -109,9 +109,6 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 
 	var/list/special_people = list()
 
-	// Spell persistence system for transformations
-	var/list/stored_transformation_spells	// Preserves spells across forms
-	var/can_store_spells = FALSE			// Trait to enable spell storage
 	// Priest miracle set switching
 	var/list/stored_miracle_sets				// Associative: god_name = devotion_datum
 	var/active_miracle_set						// Currently active god name
@@ -709,9 +706,6 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 	if(!S)
 		return
 	spell_list += S
-	// Automatically enable spell storage for transformation spells
-	if(istype(S, /obj/effect/proc_holder/spell/targeted/shapeshift) || istype(S, /obj/effect/proc_holder/spell/targeted/wildshape))
-		enable_spell_storage()
 	S.action.Grant(current)
 
 /datum/mind/proc/check_learnspell()
@@ -904,53 +898,6 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 /datum/mind/proc/get_special_person_colour(mob/M)
 	if (special_people[M.real_name])
 		return special_people[M.real_name]
-
-/datum/mind/proc/enable_spell_storage()
-	can_store_spells = TRUE
-
-/datum/mind/proc/store_spell_list()
-	if(!can_store_spells)
-		return null
-	if(!spell_list || !length(spell_list))
-		return list()
-	// Return a copy of the spell_list (the actual spell objects, not types)
-	return spell_list.Copy()
-
-/datum/mind/proc/restore_spell_list(list/stored_spells, list/always_keep_types)
-	if(!current)
-		return FALSE
-	
-	// Remove all current spell actions
-	for(var/obj/effect/proc_holder/spell/S in spell_list)
-		S.action?.Remove(current)
-	
-	// Build new spell list
-	var/list/new_spell_list = list()
-	var/list/present_types = list()
-	
-	// Add spells that should always be kept (by type)
-	if(always_keep_types && length(always_keep_types))
-		for(var/obj/effect/proc_holder/spell/S in spell_list)
-			if(S.type in always_keep_types)
-				new_spell_list += S
-				present_types[S.type] = TRUE
-	
-	// Add stored spells (actual spell objects)
-	if(stored_spells && length(stored_spells))
-		for(var/obj/effect/proc_holder/spell/S in stored_spells)
-			if(present_types[S.type])
-				continue
-			new_spell_list += S
-			present_types[S.type] = TRUE
-	
-	// Update spell_list
-	spell_list = new_spell_list
-	
-	// Grant all actions for the new spell list
-	for(var/obj/effect/proc_holder/spell/S in spell_list)
-		S.action?.Grant(current)
-	
-	return TRUE
 
 /proc/handle_special_items_retrieval(mob/user, atom/host_object)
 	// Attempts to retrieve an item from a player's stash, and applies any base colors, where preferable.

--- a/code/game/objects/shapeshift_holder.dm
+++ b/code/game/objects/shapeshift_holder.dm
@@ -15,9 +15,6 @@
 		CRASH("shapeshift holder created outside mob/living")
 	stored = caster
 	if(stored.mind)
-		// Store spell list before transferring mind
-		if(stored.mind.can_store_spells)
-			stored.mind.stored_transformation_spells = stored.mind.store_spell_list()
 		stored.mind.transfer_to(shape)
 	stored.forceMove(src)
 	stored.notransform = TRUE
@@ -86,10 +83,6 @@
 
 	if(shape && shape.mind)
 		shape.mind?.transfer_to(stored)
-		// Restore spell list after mind transfer (use stored.mind since mind has transferred)
-		if(stored.mind && stored.mind.can_store_spells && stored.mind.stored_transformation_spells)
-			stored.mind.restore_spell_list(stored.mind.stored_transformation_spells)
-			stored.mind.stored_transformation_spells = null
 	if(death)
 		stored.death()
 	else if(stored && source.convert_damage)

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
@@ -33,13 +33,7 @@
 	W.stored_language.copy_known_languages_from(src)
 	W.stored_skills = ensure_skills().known_skills.Copy()
 	W.stored_experience = ensure_skills().skill_experience.Copy()
-
-	// Store spell list using new system if enabled
-	if(mind && mind.can_store_spells)
-		mind.stored_transformation_spells = mind.store_spell_list()
-	else
-		W.stored_spells = mind.spell_list.Copy() // Fallback for non-storage-enabled minds
-
+	W.stored_spells = mind.spell_list.Copy()
 	W.voice_color = voice_color
 	W.cmode_music_override = cmode_music_override
 	W.cmode_music_override_name = cmode_music_override_name
@@ -84,25 +78,11 @@
 	skills?.known_skills = WA.stored_skills.Copy()
 	skills?.skill_experience = WA.stored_experience.Copy()
 
-	// Restore spells using new system if storage was enabled
-	if(W.mind && W.mind.can_store_spells && W.mind.stored_transformation_spells)
-		// Remove T2 miracles granted during wildshape, keep transformation spells
-		var/list/always_keep = list(
-			/obj/effect/proc_holder/spell/targeted/wildshape
-		)
-		W.mind.restore_spell_list(W.mind.stored_transformation_spells, always_keep)
-		W.mind.stored_transformation_spells = null
-	else
-		// Fallback: old buggy logic for non-storage-enabled minds
-		// Remove spells that weren't in the original list
-		for(var/obj/effect/proc_holder/spell/wildspell in W.mind.spell_list)
-			var/found = FALSE
-			for(var/obj/effect/proc_holder/spell/originspell in WA.stored_spells)
-				if(wildspell == originspell)
-					found = TRUE
-					break
-			if(!found)
-				W.mind.RemoveSpell(wildspell)
+	//Compares the list of spells we had before transformation with those we do now. If there are any that don't match, we remove them
+	for(var/obj/effect/proc_holder/spell/self/originspell in WA.stored_spells)
+		for(var/obj/effect/proc_holder/spell/self/wildspell in W.mind.spell_list)
+			if(wildspell != originspell)
+				W.RemoveSpell(wildspell)
 
 	W.regenerate_icons()
 

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -82,7 +82,6 @@
 	associated_skill = /datum/skill/magic/holy
 	invocation = "Treefather light the way."
 	invocation_type = "whisper" //can be none, whisper, emote and shout
-	miracle = TRUE
 	devotion_cost = 30
 	miracle = TRUE
 

--- a/code/modules/spells/spell_types/wildshape.dm
+++ b/code/modules/spells/spell_types/wildshape.dm
@@ -62,15 +62,6 @@
 	if(src.mind)
 		src.adjust_skillrank(/datum/skill/magic/holy, 3, TRUE) //Any dendorite using this should be a holy magic user
 
-		// Remove existing devotion-based miracles before adding T2 miracles
-		// BUT keep the wildshape spell itself so we can transform back
-		if(src.mind.can_store_spells)
-			// Remove all miracle spells from current list EXCEPT wildshape spell
-			for(var/obj/effect/proc_holder/spell/S in src.mind.spell_list)
-				if(S.miracle && !istype(S, /obj/effect/proc_holder/spell/targeted/wildshape))
-					S.action?.Remove(src)
-					src.mind.spell_list -= S
-
 		var/datum/devotion/C = new /datum/devotion(src, src.patron) //If we don't do this, Dendorites can't be clerics and they can't revert back to their true forms
 		C.grant_miracles(src, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_MAJOR)	//Major regen as no matter the previous level, it gets reset on transform. More connection to dendor I guess? Can level up to T4.
 


### PR DESCRIPTION
Reverts Scarlet-Reach/Scarlet-Reach#1458

This currently breaks witch batform(by making them use druid shapeshift) and makes zadform spawn gibs. I'm not interested in fixing them at the moment due busywork irl and the fact that someone called me mean words on discord when I told them the issues were my fault.