### PR TITLE
Apothecary buffs/powercreep round 2

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/physician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/physician.dm
@@ -53,7 +53,7 @@
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/sewing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/medicine = SKILL_LEVEL_LEGENDARY,

--- a/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
@@ -25,7 +25,7 @@
 
 /datum/advclass/apothecary
 	name = "Apothecary"
-	tutorial = "Working under the tutelage of the court physician, you still remain a mere talented apprentice in the medical arts. \
+	tutorial = "Working under the tutelage of the court physician, you still remain a mere apprentice in the medical arts. \
 	Woe is the one who has to suffer your hand holding the scalpel when your master is out."
 	outfit = /datum/outfit/job/roguetown/apothecary/basic
 	category_tags = list(CTAG_APOTH)
@@ -36,13 +36,13 @@
 	)
 
 	subclass_skills = list(
-		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/polearms = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/medicine = SKILL_LEVEL_MASTER,
+		/datum/skill/misc/medicine = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/sewing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
 		/datum/skill/labor/farming = SKILL_LEVEL_APPRENTICE,


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Gives Apothecaries Apprentice Farming. So they can farm alchemy things and see seed herb identities. Or, well, its in line with farming alchemy things.
Gives Apothecaries Expert Alchemy. So they can actually do more alchemy things than mages (or most often, the same level as mages and witches, as they get expert alchemy. Less than the dedicated potion makers...)

Gives Court Physician +3 PER. Why? Because like, Apothecaries get +2 PER, why does Court Physician get nothing. Perception is important for alchemy and theoretically surgery anyways.
Gives Court Physician Journeyman Farming. See above.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

They're rather under equipped for their jobs... Really underequipped compared to roles like acolyte. It seems like no one has touched this role in 10 years when every other role is getting buffed up with all sorts of skills...

One dose of powercreep please.