### PR TITLE
Whip buff

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/whip.dm
+++ b/code/game/objects/items/rogueweapons/melee/whip.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/roguetown/weapons/whips32.dmi'
 	sharpness = IS_BLUNT
 	//dropshrink = 0.75
-	wlength = WLENGTH_NORMAL
+	wlength = WLENGTH_GREAT
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BELT
 	associated_skill = /datum/skill/combat/whipsflails


### PR DESCRIPTION
## About The Pull Request
Makes whips able to hit all body parts instead of having the same reach as a sword. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I did this in bed. It's a one word change. 
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Whips are one of two. Two weapons that have a 3 reach intent. The other is a lance. Whips are underused, and the fact that they had a 3 reach and a 2 reach intent without being able to hit feet while weapons like great axes and any polearm in the game (the most meta weapons right now) could just felt criminal. 

I hope to help all my whip lovers slightly more with this change. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
