### PR TITLE
Disables the ability to bind T3 summons and above

### DIFF
--- a/code/datums/magic_items/mages_mechanics.dm/arcana_crafring.dm
+++ b/code/datums/magic_items/mages_mechanics.dm/arcana_crafring.dm
@@ -103,7 +103,7 @@
 	reqs = list(/obj/item/rope/chain/bindingshackles = 1,
 				/obj/item/magic/melded/t2 = 1)
 	craftdiff = 2
-
+/*
 /datum/crafting_recipe/roguetown/arcana/bindingt3
 	name = "binding shackles (T3)"
 	result = /obj/item/rope/chain/bindingshackles/t3
@@ -124,7 +124,7 @@
 	reqs = list(/obj/item/rope/chain/bindingshackles/t4 = 1,
 				/obj/item/magic/melded/t5 = 1)
 	craftdiff = 2
-
+*/
 /datum/crafting_recipe/roguetown/arcana/forge
 	name = "infernal forge"
 	req_table = FALSE


### PR DESCRIPTION
## About The Pull Request
What it says on the tin.

Just comments out the recipes for the T3/T4/T5 chains 
(not that it matters for T4 and T5, since you can't make them without the T3 I did it for consistency though.)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="626" height="239" alt="image" src="https://github.com/user-attachments/assets/c3a534e7-fdc1-4af9-9f74-4500d94c62a0" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
While it was always KNOWN that watchers are busted, I do not enjoy the fact that they are being abused. It is making every round a pain to interact with. Do other T3/T4/T5s need to be axed as well? No, but I guarantee you that people would just Dryad spam next, and believe me those 5x5 blocks of vines are actually more cancer than fireballs if done right.

The behemoth is the only one that's fair, but then the T4 version of it (the colossus) is completely ass (large sprite, ranged attack has bad feedback, shockwave is buggy and does not work- if it even fires). 

The T4 versions of Fairies and Fire are even worse. Sylphs spawn masses of kneestingers while the fiend spawns hellhounds and shoots greater fireballs. Are T4s harder to bind? Exponentially, yes they are. 

### However.
I would rather we rework fire damage into a usable state that actually feels better than binary damage that knocks you into crit in 2 shots.

I personally have only bound a watcher once, and it was to teach another mage how to do it, I do not know why you fucks would go out of your way to bind 5. This is not fun.

Ultimately this is a bandaid fix. I am not the one with the time and willingness to rework fire damage, but I recognize it's an issue. Fireballs, lightning bolts and what not are still cast by mages who can be easily punched into submission- Watchers with their 600 HP- Cannot.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
