### PR TITLE
Fixes runtime related to AI mob pathing

### DIFF
--- a/code/datums/ai/ai_movement/astar_movement.dm
+++ b/code/datums/ai/ai_movement/astar_movement.dm
@@ -13,6 +13,10 @@
 		COOLDOWN_START(controller, movement_cooldown, controller.movement_delay)
 
 		var/atom/movable/movable_pawn = controller.pawn
+		if (!movable_pawn) // if we don't have a pawn, cleanup and move on
+			stop_moving_towards(controller)
+			continue
+
 		if(!isturf(movable_pawn.loc)) //No moving if not on a turf
 			continue
 


### PR DESCRIPTION
## About The Pull Request

Sometimes astar controllers without pawns transiently continued to exist in moving_controllers and threw a series of runtimes. This just gracefully cleans them up and continues on like nothing ever happened.

## Testing Evidence

game runs, volf w/ astar controller bites my legs off as PSYDON intended

## Why It's Good For The Game

runtime fix good
