### PR TITLE
fluted cuirass down to torso coverage

### DIFF
--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -914,7 +914,7 @@
 	icon_state = "flutedcuirass"
 	desc = "A sturdy steel cuirass with tassets. Supposedly protective, though maybe not against crossbow bolts."
 
-	body_parts_covered = COVERAGE_ALL_BUT_ARMS
+	body_parts_covered = COVERAGE_TORSO
 	max_integrity = 350
 
 /obj/item/clothing/suit/roguetown/armor/plate/half/fluted/ornate


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

nerfs fluted cuirass down to only having torso coverage.

Its still an upgrade on normal cuirass, giving you +50 more integrity and torso (chest+groin+vitals) coverage compared to only vest coverage (which doesn't protect groin)

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->


Fluted cuirass doesn't really have any reason to protect legs, its not flexible or long at all compared to long scalemail that can cover down the legs, and its not full plate either.

This gives more of a reason for scalemail to exist as the definitive, flexible medium armor coverage that protects legs.

Yes, this is painful. Frankly, armor needs a lot of work to be less durable overall, but this is one step of that painful healing process. Light armor and heavy armor should be significantly looked at as well. Especially fluted plate and some specific light armor variants...