### PR TITLE
Dual Wielder to Pestran Templars

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -359,6 +359,7 @@
 		if("Plaguebringer Sickles")
 			H.put_in_hands(new /obj/item/rogueweapon/huntingknife/idagger/steel/pestrasickle(H), TRUE)
 			H.put_in_hands(new /obj/item/rogueweapon/huntingknife/idagger/steel/pestrasickle(H), TRUE)
+			ADD_TRAIT(H, TRAIT_DUALWIELDER, TRAIT_GENERIC)
 			H.adjust_skillrank_up_to(/datum/skill/combat/knives, 4, TRUE) // actually makes them usable for the templar. (fixed to no longer have legendary skill templars)
 		if("Forgefiend")
 			H.put_in_hands(new /obj/item/rogueweapon/sword/long/malumflamm(H), TRUE)


### PR DESCRIPTION
## About The Pull Request

Adds dual wielder to Pestran Templars IF they choose the sickles.

## Testing Evidence

<img width="964" height="478" alt="image" src="https://github.com/user-attachments/assets/3e8a9c1d-f786-4bd3-89b7-a40f60b77854" />
<img width="791" height="79" alt="image" src="https://github.com/user-attachments/assets/36193af4-3d45-439c-acaf-4efbd0337581" />
<img width="447" height="79" alt="image" src="https://github.com/user-attachments/assets/d8220468-e45a-4b6e-8893-1a64e29192b4" />


## Why It's Good For The Game

Right now there is almost no point in giving Pestran templars **two** plaguebringer sickles without inherent dual wielder along with the sickles. Them having to use the shield + sickle combo is a little absurd when they choose the sickles.
This also aims to provide them maybeee... more combat prowess given that their only offensive miracle has a charge time as well. In addition, provides more character diversity.

This is my first PR ever but it is a one line change so I think it should be fine.
Feel free to point out my mistakes.