### PR TITLE
shrine added to wedding areas

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1170,8 +1170,8 @@
 	if(user.mind)
 		if(user.mind.assigned_role == "Priest" || user.mind.assigned_role == "Priestess")
 			if(istype(W, /obj/item/reagent_containers/food/snacks/grown/apple))
-				if(!istype(get_area(user), /area/rogue/indoors/town/church/chapel))
-					to_chat(user, span_warning("I need to do this in the chapel."))
+				if(!(istype(get_area(user), /area/rogue/indoors/town/church/chapel) || istype(get_area(user), /area/rogue/outdoors/rtfield/eora)))
+					to_chat(user, span_warning("I need to perform this ritual somewhere more sacred."))
 					return FALSE
 				var/marriage = FALSE
 				var/obj/item/reagent_containers/food/snacks/grown/apple/A = W


### PR DESCRIPTION
## About The Pull Request

Priests now can wed people at the eoran shrine

## Testing Evidence

<img width="443" height="78" alt="image" src="https://github.com/user-attachments/assets/643a5a6c-c5e1-4af5-b26e-4e2366efcde4" />

## Why It's Good For The Game

People should be able to marry in Eora's shrine, a goddess whose domains are life and love.
Today I was going to wed two people as the priest at the shrine and it was a total failure, we had to do the whole thing again.