### PR TITLE
Fixes heartfelt magos old age bonus spellpoints

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrants/heartfelt/retinue/heartfeltmagos.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrants/heartfelt/retinue/heartfeltmagos.dm
@@ -67,7 +67,6 @@
 		H.change_stat("speed", -1)
 		H.change_stat("intelligence", 1)
 		H.change_stat("perception", 1)
-	if(H.mind)
 		H?.mind.adjust_spellpoints(6)
 	if(ishumannorthern(H))
 		belt = /obj/item/storage/belt/rogue/leather/plaquegold


### PR DESCRIPTION
## About The Pull Request
Fixes the game giving an extra 6 spellpoints to the heartfelt magos when they **weren't** old.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="593" height="219" alt="image" src="https://github.com/user-attachments/assets/5c88c8f1-554e-4c69-8c93-6804f06d516c" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bugfix.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
