### PR TITLE
Adds Prestidigitation to Noc Acolyte Utility

### DIFF
--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -126,6 +126,9 @@
 			if(!user.mind?.has_spell(/obj/effect/proc_holder/spell/invoked/diagnose/secular))
 				var/secular_diagnose = new /obj/effect/proc_holder/spell/invoked/diagnose/secular
 				user.mind?.AddSpell(secular_diagnose)
+			if(!user.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
+				var/prestidigitation = new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation
+				user.mind?.AddSpell(prestidigitation)
 			add_spells(user, utility_bundle, choice_count = 2)
 		if("Offense")
 			add_spells(user, offensive_bundle, grant_all = TRUE)


### PR DESCRIPTION
## About The Pull Request
See title.

## Testing Evidence
<img width="339" height="461" alt="NocChangeProof" src="https://github.com/user-attachments/assets/322cf2f4-371d-4902-9200-28171e60ff0b" />

## Why It's Good For The Game
It is the BASIC mage's spell and it is probably the most utility out of all the damn utility spells. Why they didn't get this basic spell which adds immense QoL to their kit (cleaning and light), I have no damn clue. It bugged me and so I added it. Now I don't have to waste a virtue to get it when you can't even select spells with points from said virtue because of how Noc acolyte spell picking works.
