### PR TITLE
readds combat music verb and run mode verb

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -519,3 +519,47 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		policytext += "No related rules found."
 
 	usr << browse(policytext.Join(""),"window=policy")
+
+/client/verb/runm()
+	set name = "Run Mode"
+	set desc = "Changes if you run continually or if you stop running when you turn."
+	set category = "Options"
+	prefs.toggles ^= RUN_MODE
+	if(prefs.toggles & RUN_MODE)
+		to_chat(usr, "Running changed (no turning)")
+	else
+		to_chat(usr, "Running changed (turning)")
+
+/client/verb/combat_music() // if you touch this, touch the option in game preferences too
+	set name = "Combat Mode Music"
+	set category = "Options"
+	set desc = ""
+	if(!isliving(mob))
+		to_chat(src, span_warning("You're not alive yet. Set this in your Game Preferences instead."))
+		return
+	var/mob/living/L = mob
+	var/track_select = tgui_input_list(src, "To you, the Signal sounds like:", "COMBAT MUSIC", GLOB.cmode_tracks_by_name, L.cmode_music_override_name)
+	if(track_select)
+		if(!isliving(mob)) // mob might've changed between then and now
+			return
+		L = mob
+		var/datum/combat_music/combat_music
+		combat_music = GLOB.cmode_tracks_by_name[track_select]
+		to_chat(src, span_notice("Selected track: <b>[track_select]</b>."))
+		if(combat_music.desc)
+			to_chat(src, "<i>[combat_music.desc]</i>")
+		if(combat_music.credits)
+			to_chat(src, span_info("Song name: <b>[combat_music.credits]</b>"))
+		// also change it for Werewolf & Wildshape transformations, else it'd be annoying to keep changing this (lol)
+		var/mob/living/carbon/human/H
+		var/mob/living/S
+		if(ishuman(mob))
+			H = mob
+			if(isliving(H.stored_mob))
+				S = H.stored_mob
+		L.cmode_music_override = combat_music.musicpath
+		L.cmode_music_override_name = combat_music.name
+		if(S)
+			S.cmode_music_override = combat_music.musicpath
+			S.cmode_music_override_name = combat_music.name
+	return


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Readds combat music verb and run mode verb that were deleted by the tgui rework

gives the combat music verb a similar look to the prefs one

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="2047" height="1284" alt="switcharoo" src="https://github.com/user-attachments/assets/1b3c836f-7abe-4938-9a4d-11076bf35fed" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Lets people change their overriden combat music again while in game, and whether they want to stop running when they change directions.
