### PR TITLE
Force spell recharge recalculation during revert_cast

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -539,6 +539,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			charge_counter++
 		if("holdervar")
 			adjust_var(user, holder_var_type, -holder_var_amount)
+	START_PROCESSING(SSfastprocess, src)
 	if(action)
 		action.UpdateButtonIcon()
 


### PR DESCRIPTION
## About The Pull Request

I think this might be what's causing spells to get stuck in the shadow realm sometimes and in wholly unreliable circumstances.

## Testing Evidence

Compiles, ran around casting spells for a bit, seems to all work okay.

## Why It's Good For The Game

people not having spells randomly softlocking themselves is good