### PR TITLE
Lazy restoration of surgical clamps bleed rate reduction (in theory)

### DIFF
--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -5,6 +5,8 @@
 	var/list/obj/item/embedded_objects = list()
 	/// Bandage, if this ever hard dels thats fucking silly lol
 	var/obj/item/bandage
+	/// Cached bitflag of our last get_surgery_flags call. Used pretty much exclusively to swiftly check bleed rate calls.
+	var/cached_surgery_flags = 0
 
 /// Checks if we have any embedded objects whatsoever
 /obj/item/bodypart/proc/has_embedded_objects()
@@ -118,10 +120,9 @@
 		bleed_rate *= grab.bleed_suppressing
 	bleed_rate = max(round(bleed_rate, 0.1), 0)
 	
-	// temporarily disabling below because it is niche use and a LOT of performance drain
-	/*var/surgery_flags = get_surgery_flags()
-	if(surgery_flags & SURGERY_CLAMPED)
-		return min(bleed_rate, 0.5)*/
+	if(cached_surgery_flags & SURGERY_CLAMPED)
+		return min(bleed_rate, 0.5)
+
 	return bleed_rate
 
 /// Called after a bodypart is attacked so that wounds and critical effects can be applied
@@ -495,6 +496,8 @@
 			owner.clear_alert("embeddedobject")
 			SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "embedded")
 		update_disabled()
+	if (embedder.embedding?.clamp_limbs)
+		get_surgery_flags() // hacky workaround that ensures cached clamp flag status updates properly
 	return TRUE
 
 /obj/item/bodypart/proc/try_bandage(obj/item/new_bandage)
@@ -572,6 +575,7 @@
 /// Returns surgery flags applicable to this bodypart
 /obj/item/bodypart/proc/get_surgery_flags()
 	// oh sweet mother of christ what the FUCK is this. this is called EVERY TIME BLEED RATE IS CHECKED.
+	// why do we BUILD THIS every time instead of applying the appropriate flags??? i'm SO CONFUSED.
 	var/returned_flags = NONE
 	if(can_bloody_wound())
 		returned_flags |= SURGERY_BLOODY
@@ -614,4 +618,6 @@
 		returned_flags |= SURGERY_DRILLED
 	if(skeletonized)
 		returned_flags |= SURGERY_INCISED | SURGERY_RETRACTED | SURGERY_DRILLED //ehh... we have access to whatever organ is there
+	
+	cached_surgery_flags = returned_flags
 	return returned_flags


### PR DESCRIPTION
## About The Pull Request

Part of my bleed opts involved not calling an incredibly expensive bodyparts proc that constructed and returned a bitflag used for surgeries. This had the unfortunate side effect of nuking the bleed reduction that clamped limbs are supposed to have, so people are dying in surgery a lot more from bleeding now.

This restores that functionality in a little effort as humanly possible without absolutely cratering the performance gains we get. It is **bad** code.

I can't be bothered to do any more than this at the moment and that includes testing this thoroughly. Worst case scenario is it won't do shit.

## Testing Evidence

<img width="504" height="173" alt="image" src="https://github.com/user-attachments/assets/6e31daa6-2619-458a-9731-33b678e0b10e" />

## Why It's Good For The Game

helps apothecaries not murder people during surgery
