### PR TITLE
Longjump Race Rebalancing

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -786,6 +786,8 @@
 			if(H.dna.species.name != dna.species.name)
 				if(dna.species.stress_examine)//some species don't have a stress desc
 					. += dna.species.stress_desc
+				if(istype(src.dna.species, /datum/species/moth))
+					. += span_red("Bug-eyes... <a href='?src=[REF(src)];mothtip=1'>Wings are valuable, though</a>.")
 
 	if((user != src) && isliving(user))
 		var/mob/living/L = user

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -184,6 +184,9 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 			if(social_rank < examiner_rank)
 				to_chat(usr, span_notice("This person is <EM>[rank_name]</EM>, they are my lesser."))
 
+	if(href_list["mothtip"])
+		to_chat(usr, span_notice("Can cut wings off the back of their <B>chest</B> down the <B>middle</B> using a <B>knife</B>."))
+
 	if(href_list["undiesthing"]) //canUseTopic check for this is handled by mob/Topic()
 		if(!get_location_accessible(src, BODY_ZONE_PRECISE_GROIN, skipundies = TRUE))
 			to_chat(usr, span_warning("I can't reach that! Something is covering it."))

--- a/code/modules/mob/living/carbon/human/species_types/species/moth.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/moth.dm
@@ -14,7 +14,7 @@
 	The sole settlement in Effluvia, Mercuriam. It is here that Pestra's arts are honored; \
 	only the educated are allowed to pass its bronze gates. Denied fluvians must eke out a primitive life in the rotting wilds of Effluvia.<br>\
 	According to the fluvians of Mercuriam, their god, Pestra, has not yet been born. She lies in a nascent cocoon, bestowing wisdom from a time to come.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 SPD | -1 CON</b></span> </br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>+1 SPD</b></span> </br>\
 	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>Long Jump | Can Eat Clothes</b></span>"
 
 	species_traits = list(EYECOLOR,LIPS,MUTCOLORS,HAIR)
@@ -39,7 +39,7 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1), \
 		)
-	race_bonus = list(STAT_SPEED = 1, STAT_CONSTITUTION = -1)
+	race_bonus = list(STAT_SPEED = 1)
 	enflamed_icon = "widefire"
 	attack_verb = "slash"
 	attack_sound = 'sound/blank.ogg'


### PR DESCRIPTION
## About The Pull Request

People have informed me that -1 CON for an extra jump tile isn't a worthwhile trade to most people, and may be putting them off from playing fluvian. 
This removes the CON malus, but adds a new stress text to fluvians. It tells the examiner that fluvian wings are valuable and clicking on it gives a short guide on how to cut them off. 

I believe this is more of a reasonable counterbalance to the extra jump tile.

<img width="277" height="255" alt="image" src="https://github.com/user-attachments/assets/f68132d0-cbce-4da3-b8d2-f54a5926c213" />

<img width="546" height="26" alt="image" src="https://github.com/user-attachments/assets/4e6c0c7b-e6a7-4c92-97a1-753e8bd5dafa" />

## Testing Evidence

<img width="866" height="705" alt="image" src="https://github.com/user-attachments/assets/f97d29b3-8546-4142-a892-e8992a6cba0e" />


## Why It's Good For The Game

Should make the race's benefits more equally weigh with its negatives.
