### PR TITLE
Balances mole and mire crawler wildshape

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/wildshape/dendormole.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/dendormole.dm
@@ -13,7 +13,7 @@
 /mob/living/carbon/human/species/wildshape/dendormole/gain_inherent_skills()
 	. = ..()
 	if(src.mind)
-		src.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
+		src.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE) //We don't want this thing wrestling people.
 		src.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
 		src.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 		src.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
@@ -40,15 +40,12 @@
 		TRAIT_STRONGBITE,
 		TRAIT_STEELHEARTED,
 		TRAIT_BREADY, //Ambusher
-		TRAIT_ORGAN_EATER,
 		TRAIT_WILD_EATER,
 		TRAIT_HARDDISMEMBER, //Decapping causes them to bug out, badly, and need admin intervention to fix. Bandaid fix.
 		TRAIT_PIERCEIMMUNE, //Prevents weapon dusting and caltrop effects due to them transforming when killed/stepping on shards.
 		TRAIT_LONGSTRIDER,
 		TRAIT_PERFECT_TRACKER,
 		TRAIT_NOPAINSTUN, //This bad boy ENDVRES
-		TRAIT_NIGHT_VISION,
-		TRAIT_NIGHT_OWL,
 		TRAIT_BIGGUY,
 	)
 	inherent_biotypes = MOB_HUMANOID

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/mirecrawler.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/mirecrawler.dm
@@ -35,15 +35,12 @@
 		TRAIT_KNEESTINGER_IMMUNITY, //All of these are dendorite transformations, they are ALL blessed by dendor
 		TRAIT_STRONGBITE,
 		TRAIT_BREADY, //Ambusher
-		TRAIT_ORGAN_EATER,
 		TRAIT_WILD_EATER,
 		TRAIT_HARDDISMEMBER, //Decapping causes them to bug out, badly, and need admin intervention to fix. Bandaid fix.
 		TRAIT_PIERCEIMMUNE, //Prevents weapon dusting and caltrop effects due to them transforming when killed/stepping on shards.
 		TRAIT_LONGSTRIDER,
 		TRAIT_INFINITE_ENERGY, //It's a 5 strength spiderling, what's the worst that could happen?
 		TRAIT_PERFECT_TRACKER,
-		TRAIT_NIGHT_VISION,
-		TRAIT_NIGHT_OWL,
 	)
 	inherent_biotypes = MOB_HUMANOID
 	armor = 5


### PR DESCRIPTION
## About The Pull Request
This is just a balance pass for https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1556

## Testing Evidence
It compiles.

## Why It's Good For The Game
The mire crawler form was horrid and the mole form was overtuned. This brings them better in line with each other. Mole can now dig but no longer gets 20 strength and titanium claws and master unarmed.
