### PR TITLE
Re-Adds Holy Steel Smithing and changes 'swift end's with 'swift jour…

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -315,7 +315,7 @@
 		if(/datum/patron/divine/noc)
 			weapons += "Moonlight Khopesh"
 		if(/datum/patron/divine/necra)
-			weapons += "Swift End"
+			weapons += "Swift Journey"
 		if(/datum/patron/divine/pestra)
 			weapons += "Plaguebringer Sickles"
 		if(/datum/patron/divine/malum)
@@ -353,7 +353,7 @@
 		if("Moonlight Khopesh")
 			H.put_in_hands(new /obj/item/rogueweapon/sword/sabre/nockhopesh(H), TRUE)
 			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
-		if("Swift End")
+		if("Swift Journey")
 			H.put_in_hands(new /obj/item/rogueweapon/flail/sflail/necraflail(H), TRUE)
 			H.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
 		if("Plaguebringer Sickles")

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -942,7 +942,7 @@
 	additional_items = list(/obj/item/ingot/steelholy)
 	created_item = /obj/item/rogueweapon/sword/long/malumflamm
 	i_type = "Weapons"
-/*
+
 /datum/anvil_recipe/weapons/holy/abyssor_katar
 	name = "Barotrauma"
 	req_bar = /obj/item/ingot/steelholy
@@ -966,10 +966,10 @@
 	i_type = "Weapons"
 
 /datum/anvil_recipe/weapons/holy/necra_flail
-	name = "Swift End"
+	name = "Swift Journey"
 	req_bar = /obj/item/ingot/steelholy
 	craftdiff = 3
-	created_item = /obj/item/rogueweapon/flail/necraflail
+	created_item = /obj/item/rogueweapon/flail/sflail/necraflail
 	i_type = "Weapons"
 
 /datum/anvil_recipe/weapons/holy/pestra_dagger
@@ -1008,7 +1008,7 @@
 	craftdiff = 3
 	created_item = /obj/item/rogueweapon/knuckles/eora
 	i_type = "Weapons"
-*/
+
 //Psydonian weapon smithing
 /datum/anvil_recipe/weapons/psy/axe
 	name = "Psydonian War Axe (+1 B. Silver, +1 Stick)"


### PR DESCRIPTION
## About The Pull Request

Holy steel weapons can be forged again. Also changes the titles of swift end with swift journey across the code, given that the weapon itself is called 'swift journey'

## Testing Evidence

<img width="814" height="717" alt="image" src="https://github.com/user-attachments/assets/eeb70356-332c-4846-bba4-289885a3abb3" />
<img width="551" height="409" alt="image" src="https://github.com/user-attachments/assets/ecc6bc83-49b6-4e48-8e3a-1a38a8a54a5f" />
<img width="565" height="208" alt="image" src="https://github.com/user-attachments/assets/aa290240-7526-4932-8008-146deff8b903" />


## Why It's Good For The Game

Holy steel forging was disabled when the ritualist virtue was still a thing and smiths were spamming holy weapons with it. No reason for them to stay disabled when the virtue itself is gone.