### PR TITLE
Monster Hunter Expansion! Armor training, more weapon options and glass cannon build!

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -259,14 +259,14 @@
 		if("Dodge Expert + Studded Leathers") //Be the swift little shit you always wanted to be. Nothing on your head or legs to save you though!
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 			H.change_stat(STATKEY_SPD, 1)
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/roguetown/armor/leather/studded, SLOT_ARMOR, TRUE)
 			pants = /obj/item/clothing/under/roguetown/trou/leather
 			head = /obj/item/clothing/head/roguetown/bucklehat
 		if("Cuirass + Rotbite Immune") //Closer to traditional Monster Hunter. You are a tinge smarter - and immune to deadite bites)
 			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_ZOMBIE_IMMUNE, TRAIT_GENERIC)
 			H.change_stat(STATKEY_INT, 1)
-			armor =	/obj/item/clothing/suit/roguetown/armor/plate/half/fluted/ornate
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/roguetown/armor/plate/half/fluted/ornate, SLOT_ARMOR, TRUE)
 			pants = /obj/item/clothing/under/roguetown/splintlegs
 			beltl = pick(
 					/obj/item/reagent_containers/glass/bottle/alchemical/strpot,


### PR DESCRIPTION
## About The Pull Request
What if Monster Hunter *was* a bit better? What if they were, in fact, able to hunt monsters efficiently?

This PR aims to improve them in a few areas!
- They get *journeyman wrestling*, no matta' what. Same with Steelhearted - they saw some shit, man.
- NO LONGER automatically starts with a little pot - more on that later.
- NO LONGER automatically good with swords ~~and knives.~~ 
- You get apprentice knives no matter what because hunting knife start. Just in case. May remove if it is deemed "too much".

They can choose between three **armor options**: 
- Light, with dodge expert and +1 speed, 
- **Medium**, where they get immunity to deadite bites, hauberk, +1 INT and the potion, and 
- **Heavy**, where they lose 1 speed but gain 1 CON and start with the cuirass they used to start with.
- Added whip + buckler and axe as 'steel' weapon options!
- If you're old, you are guaranteed to get Expert on your weapons of choice.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It compiled when tested so should work just fine!
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
More options for Monster Hunters, making old monster hunters a thing, and generally giving them more options!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
