### PR TITLE
Typebaiter's Woe: Feint auto-fails on targets not in combat mode

### DIFF
--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -199,6 +199,12 @@
 		user.visible_message(span_danger("[user] attempts to feint an attack at [L], but only makes a fool of themselves!"))
 		user.OffBalance(3 SECONDS)
 		user.apply_status_effect(/datum/status_effect/debuff/feintcd)
+		for(var/mob/living/carbon/human/H in view(7, user))
+			if(H == user || !H.client)
+				continue
+			if(HAS_TRAIT(H, TRAIT_XYLIX) && !H.has_status_effect(/datum/status_effect/buff/xylix_joy))
+				H.apply_status_effect(/datum/status_effect/buff/xylix_joy)
+				to_chat(H, span_info("Such a curt display of hubris amuses the Laughing God!"))
 		return
 	else
 		user.visible_message(span_danger("[user] feints an attack at [target]!"))


### PR DESCRIPTION
## About The Pull Request

Feinting a player target that is not in combat mode now automatically fails, knocking you off balance for 3 seconds and putting feint on CD. OFF-BALANCE IS NOT A KNOCKDOWN. YOU NEED TO KICK AN OFF-BALANCE PERSON TO KNOCK THEM OVER.

Any Xylixians within 7 tiles that witness this receive the Trickster's Joy effect (+1 FOR) similar to seeing someone laugh or giggle.

This does not apply to NPCs.

## Testing Evidence

<img width="464" height="140" alt="image" src="https://github.com/user-attachments/assets/b95e8f9f-6fda-4368-8790-718159efe43b" />

## Why It's Good For The Game

You cannot have a combat discussion without someone bringing up feint. Feint this, feint that. Feint feint feint. Half of combat is feinting and fucking up dudes. Half of dogshit typebaiting behavior is also feinting people and immediately grabspamming them into hell pins while they can't do anything about it. Not anymore! Kick idiots who attempt to typebait you and grapple THEM instead. Or stab them in the eyeball.

This changes that. It also introduces a new set of high-level play where people who successfully cold read another's feint attempt can toggle off cmode to try and bait out a feint for the off-balance the autofail gives, at the cost of severely reducing their defense for the duration.
