### PR TITLE
fixes body part eating as werewolf

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -167,7 +167,7 @@
 
 /obj/item/bodypart/onbite(mob/living/carbon/human/user)
 	if((user.mind && user.mind.has_antag_datum(/datum/antagonist/zombie)) || istype(user.dna.species, /datum/species/werewolf))
-		if(owner.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || owner.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
+		if(user.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || user.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
 			to_chat(user, span_notice("My power is weakened, I cannot heal!"))
 			return
 		if(do_after(user, 50, target = src))


### PR DESCRIPTION

## About The Pull Request

firestack silver rework pr accidentally changed the check to use owner (the owner of the limb (which was always nobody since it's a disembodied limb)) rather than the user which runtimed since it was checking null for status effects

## Testing Evidence

<img width="522" height="118" alt="image" src="https://github.com/user-attachments/assets/b284169f-b5a7-4377-9a2f-43bd721473ef" />

## Why It's Good For The Game

bugfix