### PR TITLE
He Weeps, And Is Disappointed In You: Stigmata amendment requires adjacency & channel time

### DIFF
--- a/modular_scarletreach/code/modules/jobs/job_types/roguetown/adventurer/stigmata.dm
+++ b/modular_scarletreach/code/modules/jobs/job_types/roguetown/adventurer/stigmata.dm
@@ -94,6 +94,11 @@
 		return FALSE
 	
 	var/mob/living/carbon/human/H = targets[1]
+
+	if (!user.Adjacent(H))
+		to_chat(user, span_warning("You must be next to whoever you wish to AMEND!"))
+		revert_cast()
+		return FALSE
 	
 	if(H == user)
 		to_chat(user, span_warning("You cannot AMEND yourself!"))
@@ -115,6 +120,12 @@
 		if (alert(user, "THEY ARE ASHEN WITH STILLED BREATH. AMENDMENT MAY INSTANTLY KILL YOU, STIGMATA. PROCEED?", "SELF-PRESERVATION", "YES", "NO") != "YES")
 			revert_cast()
 			return
+	
+	user.visible_message(span_warning("[user] kneels down besides [H] and gently lays their hands upon them..."))
+	if (!do_after(user, 3 SECONDS, target = H))
+		to_chat(user, span_warning("Your AMENDMENT was interrupted!"))
+		revert_cast()
+		return FALSE
 	
 	// Heal the target
 	H.adjustBruteLoss(-brute_transfer)


### PR DESCRIPTION
## About The Pull Request

Nobody on this ratchet-ass server can be trusted with anything, especially not the legion of no-interaction driveby amending Fluvian noble stigmatas (zesus fucking pyst) that keep killing themselves in the town square taking people's damage without a single word.

You must now be next to someone and succeed a 3 second channel to AMEND them of their wounds. Absolver is completely unaffected.

## Testing Evidence

<img width="442" height="119" alt="image" src="https://github.com/user-attachments/assets/8e6e23c0-06a6-4b7c-9380-13b91076132e" />

## Why It's Good For The Game

I hate you people so much.
