### PR TITLE
Ravox gorget no longer blocks vision behind you when it is up

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -344,6 +344,7 @@
 	flags_inv = HIDENECK
 	dynamic_hair_suffix = ""
 	sewrepair = TRUE
+	block2add = null
 
 /obj/item/clothing/head/roguetown/priestmask
 	name = "solar visage"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

its a gorget, it only covers neck and doesn't visually block vision or cover face, shouldn't block your fov at all. It also doesn't really have really any armor

## Testing Evidence

<img width="1818" height="1339" alt="Ravox templar" src="https://github.com/user-attachments/assets/3ebed1c8-3918-44f2-86d2-27110bdd8fab" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

just a bug from being a subtype of hood

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
