### PR TITLE
makes the church bell actually ring across Z levels + range increase

### DIFF
--- a/code/game/objects/items/rogueitems/bells.dm
+++ b/code/game/objects/items/rogueitems/bells.dm
@@ -107,11 +107,16 @@
 		if(distance <= 7)
 			to_chat(player, span_notice("The church bell rings, echoing solemnly through the area."))
 			continue
-		if(distance >= 200)
+		if(distance <= 150)
+			to_chat(player, span_notice("The church bell rings, echoing solemnly through the area."))
+			player.playsound_local(get_turf(player), 'sound/misc/bell.ogg', 35, FALSE, pressure_affected = FALSE)
 			continue
 
+		to_chat(player, span_notice("The church bell rings, echoing distantly from afar."))
 		player.playsound_local(get_turf(player), 'sound/misc/bell.ogg', 35, FALSE, pressure_affected = FALSE)
-		to_chat(player, span_notice("The church bell rings, echoing solemnly through the area."))
+
+
+
 
 /obj/item/jingle_bells
 	name = "jingling bells"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

basically adapts the same code from signal horns to make it work across Z levels

Is now global. If farther than 150 away, it has a different message. Also plays the sound too.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

Tested, works fine, can't really solo test the bell without other players but it doesn't break or anything.

## Why It's Good For The Game

The bell is so cool but its horrible that its so utterly useless because it doesn't work across Z levels so it only works if people are on the z level

this fixes that

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
