### PR TITLE
insane schizophrenia post-setup hang fix attempt

### DIFF
--- a/code/controllers/subsystem/rogue/triumphs/triumphs.dm
+++ b/code/controllers/subsystem/rogue/triumphs/triumphs.dm
@@ -303,6 +303,9 @@ SUBSYSTEM_DEF(triumphs)
 
 // Return a value of the triumphs they got
 /datum/controller/subsystem/triumphs/proc/get_triumphs(target_ckey)
+	var/time_remaining = SSticker.GetTimeLeft()
+	if ((SSticker.current_state == GAME_STATE_PREGAME || SSticker.current_state == GAME_STATE_SETTING_UP) && time_remaining <= 30 SECONDS) // temporarily disable this while the round is getting ready to start
+		return 0
 	if(!(target_ckey in triumph_amount_cache))
 		var/target_file = file("data/player_saves/[target_ckey[1]]/[target_ckey]/triumphs.json")
 		if(!fexists(target_file)) // no file or new player, write them in something
@@ -335,7 +338,10 @@ SUBSYSTEM_DEF(triumphs)
 */
 // Display leaderboard browser popup
 /datum/controller/subsystem/triumphs/proc/show_triumph_leaderboard(client/C)
-
+	var/time_remaining = SSticker.GetTimeLeft()
+	if ((SSticker.current_state == GAME_STATE_PREGAME || SSticker.current_state == GAME_STATE_SETTING_UP) && time_remaining <= 30 SECONDS)
+		to_chat(C, span_boldwarning("This view is temporarily disabled until the round starts!"))
+		return
 	var/webpagu = "<B>CHAMPIONS OF SCARLET REACH</B><br>"
 	webpagu += "Current Season: [GLOB.triumph_wipe_season]"
 	webpagu += "<hr><br>"

--- a/code/modules/admin/playerquality.dm
+++ b/code/modules/admin/playerquality.dm
@@ -124,6 +124,10 @@
 	check_pq_menu(theykey)
 
 /proc/check_pq_menu(ckey)
+	var/time_remaining = SSticker.GetTimeLeft()
+	if ((SSticker.current_state == GAME_STATE_PREGAME || SSticker.current_state == GAME_STATE_SETTING_UP) && time_remaining <= 30 SECONDS)
+		to_chat(usr, span_boldwarning("Checking PQ is temporarily disabled until the round starts!"))
+		return
 	if(!fexists("data/player_saves/[copytext(ckey,1,2)]/[ckey]/preferences.sav"))
 		to_chat(usr, span_boldwarning("User does not exist."))
 		return

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -342,7 +342,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			dat += "</td>"
 
 			dat += "<td style='width:33%;text-align:center'>"
-			dat += "<a href='?_src_=prefs;preference=triumphs;task=menu'><b>TRIUMPHS:</b></a> [user.get_triumphs() ? "\Roman [user.get_triumphs()]" : "None"]"
+			dat += "<a href='?_src_=prefs;preference=triumphs;task=menu'><b>TRIUMPHS:</b></a> [user.get_triumphs() ? "\Roman [user.get_triumphs()]" : "UNKNOWN"]"
 			if(SStriumphs.triumph_buys_enabled)
 				dat += "<a style='white-space:nowrap;' href='?_src_=prefs;preference=triumph_buy_menu'>Triumph Buy</a>"
 			dat += "</td>"


### PR DESCRIPTION
## About The Pull Request

A literal crapshoot in the dark to try and stop the post-roundstart disconnect hangs that sometimes happen.

I have an insane theory that there's some kind of ridiculous file handle race condition bullshit happening with triumphs and PQ, particularly since they're both flatfile and triumphs in particular have been getting corrupted and wiped lately, usually right around roundstart for some people.

This PR just makes it so that accessing those views isn't possible in the 30 seconds leading up to the round starting, and also while it is setting up.

I am moderately (read: not very) confident that this shouldn't fuck with triumph-spenders like vices and virtues, but it might. 

There's a very high chance this simply does absolutely fucking nothing at all. Only one way to find out.

NOTE: This WILL make EVERYBODY'S TRIUMPHS APPEAR AS UNKNOWN for the last 30 seconds of setup. Your triumphs have not been wiped. They're still there.

## Testing Evidence

<img width="584" height="125" alt="image" src="https://github.com/user-attachments/assets/58c27420-a756-4f7d-af13-f6217276671e" />

## Why It's Good For The Game

not needing to restart rounds is good
