### PR TITLE
Fixes Eoran bud being able to be removed by drag-dropping 

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -26,12 +26,22 @@
 	..()
 	REMOVE_TRAIT(user, TRAIT_PACIFISM, "peaceflower_[REF(src)]")
 
-/obj/item/clothing/head/peaceflower/attack_hand(mob/user)
+/obj/item/clothing/head/peaceflower/proc/at_peace_check(mob/user)
 	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		if(src == C.head)
-			to_chat(user, "<span class='warning'>I feel at peace. <b style='color:pink'>Why would you want anything else?</b></span>")
-			return
+		var/mob/living/carbon/carbon_user = user
+		if(src == carbon_user.head)
+			to_chat(user, "<span class='warning'>You feel at peace. <b style='color:pink'>Why would you want anything else?</b></span>")
+			return TRUE
+	return FALSE
+
+/obj/item/clothing/head/peaceflower/attack_hand(mob/user, list/modifiers)
+	if(at_peace_check(user))
+		return
+	return ..()
+
+/obj/item/clothing/head/peaceflower/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	if(at_peace_check(usr))
+		return
 	return ..()
 
 /obj/effect/proc_holder/spell/invoked/bud


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Its supposed to be unremoveable by yourself, but fails to account for drag clicking.

Basically stolen from https://github.com/tgstation/tgstation/pull/59405

I feel disturbed that I remember when you can do this with the heroine bud on tg.

## Testing Evidence

Went in, tried to take it off via click dragging, didn't work.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Bugfix good.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
