### PR TITLE
Stop burning off my drip: Insane Grenzelhoft Armor Buffs

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -1963,6 +1963,7 @@
 	detail_tag = "_detail"
 	altdetail_tag = "_detailalt"
 	dynamic_hair_suffix = ""
+	resistance_flags = FIRE_PROOF //It's treated with magickal seed oils or some shit. Trust.
 	max_integrity = 150
 	body_parts_covered = HEAD|HAIR|EARS
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_TWIST)


### PR DESCRIPTION
## About The Pull Request

Makes the Grenzelhat fireproof, so their iconic drip does not burn to ash .5 seconds into taking part in a team fight with a mage present. They treat the fabric with magickal seed-oils or something. You're a roleplayer, right? Use your imagination.

## Testing Evidence
<img width="719" height="485" alt="image" src="https://github.com/user-attachments/assets/b7a650b9-0ede-4e19-acb6-7308a6bc1e14" />
<img width="518" height="354" alt="image" src="https://github.com/user-attachments/assets/797439a8-c7a9-43ee-b569-9862aff31edb" />


## Why It's Good For The Game
Most helmets worth wearing (steel and such) are already fireproof. The hat isn't that strong compared to a proper steel helmet that most people wear, and Grenzels electing to wear it are doing so at great personal risk to their safety  and should be rewarded.

Besides, if you burn my hat off, I'm just going to steal your fancy visored sallet off your corpse after I kill you. This is better for you, this is better for me. Trust.