### PR TITLE
Mask On: Ravox bounty examine removal

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -104,7 +104,7 @@
 	domain = "God of Justice, Glory, Battle"
 	desc = "Stalwart warrior, glorious justicier; legends say he came down to the Basin to repel the vile hordes of demons with his own hands, and that he seeks warriors for his divine army among mortals."
 	worshippers = "Warriors, Sellswords & those who seek Justice"
-	mob_traits = list(TRAIT_SHARPER_BLADES, TRAIT_JUSTICARSIGHT)
+	mob_traits = list(TRAIT_SHARPER_BLADES)
 	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
 					/obj/effect/proc_holder/spell/invoked/tug_of_war			= CLERIC_T0,
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T1,


### PR DESCRIPTION
## About The Pull Request

The number of positive interactions this trait has produced over the months of its implementation can be counted on one hand. Time for it to go.

## Testing Evidence

one liner fuck you

## Why It's Good For The Game

Forces validhunters to actually do some hunting based of bounty descriptors. Eliminates Hector Daemos and Average Humen Male Mercenary With A Name That Starts With G And Uses A Grenzelhoft Loadout behavior at the source.