### PR TITLE
Makes Squire Errants More Customizable & Fun To Play

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -222,10 +222,8 @@
 		var/weapon_choice = input(H, "Choose your weapon.", "WHAT WILL YOU SWING BEFORE DEATH") as anything in weapons
 		switch(weapon_choice)
 			if("Arming Sword")
-				backl = /obj/item/rogueweapon/scabbard/sword
 				r_hand = /obj/item/rogueweapon/sword/iron
 			if("Shortsword + Shield")
-				beltr = /obj/item/rogueweapon/scabbard/sword
 				backl = /obj/item/rogueweapon/shield/wood
 				r_hand = /obj/item/rogueweapon/sword/short/iron
 			if("Bow & Arrow")
@@ -234,5 +232,4 @@
 				beltr = /obj/item/quiver/arrows
 			if("Spear")
 				r_hand = /obj/item/rogueweapon/spear
-				backl = /obj/item/rogueweapon/scabbard/gwstrap
 	H.set_blindness(0)


### PR DESCRIPTION
## About The Pull Request
Balancejak Balancejak, but perhaps in the favor of things that are good for RP and people to enjoy, and not just Make Class Better To Frag Better.

**Squire Errants**! A little good sidekick class that doesn't really get picked because there are, usually, better classes to play as. You could easily just go Blacksmith apprentice/failed squire and any other (better) combat class. 

The aim here is to make Squire Errant a proper... squire, in a way. 
- Light armor and medium armor are a *little* bit better. Medium armor gets a simple iron breastplate (but no undershirt armor) instead of a haubergeon, whereas light armor gets a gambeson *and* a leather armor. Regular leather pants got turned into hardened ones.
- Apprentice crossbow/bow, as well as apprentice sneaking and baby's Basic Ass Novice Medicine so they can stitch their designated knight up.
- Weapon choice! Spear, Bow and Arrow, Shortsword + shield or just sword. All iron. No expert. Only skill lvl up is bow and arrow into journeyman.
- They start with the polishing cream & brush too, to maintain their designated knight's armor!
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Works On My Machine!
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Makes Squire Errant a bit better without it being just Straight buff. Actual squire is still better, and other classes are better for combat. You can at least take care of your Designated Boss Figure's gear now!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
