### PR TITLE
Fixes an oversight of adding dolls and golems to martyr.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -171,7 +171,7 @@
 	if(!allow_all)
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
-			if(HAS_TRAIT(user, TRAIT_ROTMAN) || HAS_TRAIT(user, TRAIT_NOBREATH))	//Can't be a Martyr if you're undead already.
+			if(HAS_TRAIT(user, TRAIT_ROTMAN) || H.mob_biotypes & MOB_UNDEAD)	//Can't be a Martyr if you're undead already.
 				to_chat(H, span_warn("It burns and sizzles! It does not tolerate my pallid flesh!"))
 				H.dropItemToGround(parent)
 				return


### PR DESCRIPTION
## About The Pull Request

Currently there's an oversight where Golem and Dolls can't pick up the martyr sword. This fixes that.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="582" height="242" alt="image" src="https://github.com/user-attachments/assets/541dc63b-6894-486d-94a9-748482035f27" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Construct martyr without their sword is funny but not funny enough.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
