### PR TITLE
gives all ogres str uncapped

### DIFF
--- a/code/modules/jobs/job_types/roguetown/ogre/ogre.dm
+++ b/code/modules/jobs/job_types/roguetown/ogre/ogre.dm
@@ -21,4 +21,4 @@
 	always_show_on_latechoices = TRUE
 	cmode_music = 'sound/music/combat.ogg'
 
-	job_traits = list(TRAIT_OUTLANDER, TRAIT_STEELHEARTED)
+	job_traits = list(TRAIT_OUTLANDER, TRAIT_STEELHEARTED, TRAIT_STRENGTH_UNCAPPED) // big fuckoff strong guys

--- a/code/modules/jobs/job_types/roguetown/ogre/ogreclasses/avatar.dm
+++ b/code/modules/jobs/job_types/roguetown/ogre/ogreclasses/avatar.dm
@@ -8,7 +8,7 @@
 	cmode_music = 'sound/music/combat_maniac.ogg' // this one is good
 	maximum_possible_slots = 1
 
-	traits_applied = list(TRAIT_STRENGTH_UNCAPPED, TRAIT_CRITICAL_RESISTANCE, TRAIT_NOPAINSTUN, TRAIT_CALTROPIMMUNE, TRAIT_STRONGBITE, TRAIT_MEDIUMARMOR) //strongbite might be funny
+	traits_applied = list(TRAIT_CRITICAL_RESISTANCE, TRAIT_NOPAINSTUN, TRAIT_CALTROPIMMUNE, TRAIT_STRONGBITE, TRAIT_MEDIUMARMOR) //strongbite might be funny
 	subclass_stats = list( 
 		STATKEY_STR = 4, 
 		STATKEY_CON = 6,

--- a/code/modules/jobs/job_types/roguetown/ogre/ogreclasses/dumdum.dm
+++ b/code/modules/jobs/job_types/roguetown/ogre/ogreclasses/dumdum.dm
@@ -8,7 +8,7 @@
 	cmode_music = 'sound/music/combat_guard3.ogg' // i think this is unused, but i like the song
 
 
-	traits_applied = list(TRAIT_NOPAINSTUN, TRAIT_CALTROPIMMUNE, TRAIT_STRONGBITE, TRAIT_STRENGTH_UNCAPPED, TRAIT_MEDIUMARMOR, TRAIT_NASTY_EATER, TRAIT_CRITICAL_RESISTANCE) //strongbite might be funny
+	traits_applied = list(TRAIT_NOPAINSTUN, TRAIT_CALTROPIMMUNE, TRAIT_STRONGBITE, TRAIT_MEDIUMARMOR, TRAIT_NASTY_EATER, TRAIT_CRITICAL_RESISTANCE) //strongbite might be funny
 	subclass_stats = list( 
 		STATKEY_STR = 4, 
 		STATKEY_CON = 4,


### PR DESCRIPTION
## About The Pull Request
Gives ogres (the class, not the race, incase there might be exteremely non combatant ogre roles in the future like ogre slaves or sum) an innate strength uncapped trait

## Testing Evidence
Its just trait changes, should work just fine

## Why It's Good For The Game
Ogres, as they are right now, feel pretty underwhelming. They're supposed to be strong, but right now their strength can be matched by wretches, and the onimusha wretch can have as much strength as an ogre as well as the strength unbound trait. If outnumbered, even with this change the ogres are still gonna get steamrolled, and if they arent outnumbered, its honestly the problem of whoever decided to fight them, most likely being keep or town roles, which are generally not meant to fight 1v1's anyways, and should be capable of outrunning an ogre.