### PR TITLE
Scarlet Reach Wrapped 1325: Race lore returns to default AP basis

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/goblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/goblin.dm
@@ -43,17 +43,8 @@
 	race = /datum/species/goblin/hell
 
 /datum/species/goblin/hell
-	name = "infernal goblin thrall"
+	name = "hell goblin"
 	id = "goblin_hell"
-	desc = "<b>Infernal Goblin Thrall: A Soul Burned</b><br> \
-	These are goblins of the Red Tribe of the southern islands of Etrusca, tainted by demonic energy just as those who became the tieflings were. \
-	Sailors and traders by tradition, at times madness lay claim to a boatswain, \
-	a heart weakened by desperation or greed will give in to hunger and rage. \
-	With their souls claimed in moments of hatred, their will consumed by Graggar, \
-	the goblin husks are often found congregating around demonic hotspots or dark mages, \
-	the infernal pollution in the empty vessels drawing them towards hellish fonts. Somewhat weaker than most other thralls.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>Critical Weakness, Inhumen Digestion</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>LANGUAGE: Orcish - ,o</b></span> </br>"
 	raceicon = "goblin_hell"
 
 /mob/living/carbon/human/species/goblin/cave
@@ -67,16 +58,7 @@
 	race = /datum/species/goblin/cave
 
 /datum/species/goblin/cave
-	name = "cave goblin thrall"
 	id = "goblin_cave"
-	desc = "<b>Cave Goblin Thrall: A Soul Buried</b><br>\
-	These are goblins of the Taiga Tribe who were likely followers of Malum in their lives, \
-	native to the Ironwood Forests in northwest Grenzelhoft. Miners and woodcutters by trade, \
-	sometimes a goblin will wander too deep into the cavern depths, or be lost in the woodland mist to emerge days later with madness in their heart. \
-	With their souls claimed in a moment of doubt or fear, Graggar has consumed their will and left them a thralled husk to haunt the wild places. \
-	This one has likely fled across the border from Grenzelhoft to make it to the Reach alive, to finally die now at your hands.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>Critical Weakness, Inhumen Digestion</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>LANGUAGE: Orcish - ,o</b></span> </br>"
 	raceicon = "goblin_cave"
 
 /mob/living/carbon/human/species/goblin/sea
@@ -87,17 +69,8 @@
 /mob/living/carbon/human/species/goblin/npc/ambush/sea
 	race = /datum/species/goblin/sea
 /datum/species/goblin/sea
-	name = "sea goblin thrall"
 	raceicon = "goblin_sea"
 	id = "goblin_sea"
-	desc = "<b>Sea Goblin Thrall: A Soul Keelhauled</b><br>\
-	These are goblins of the Frost Tribe who were likely followers of Abyssor or Ravox in their lives, \
-	native to the cold northern isles of Hammerhold. Traditional carpenters and fishermen, at times a goblin will become a sea goblin, \
-	and join the raiding parties that raze the southern coastlines. In time some lose themselves to the violence, \
-	their wills consumed by Graggar and souls enthralled. These husks of northern goblins haunt the waterways and gather in simple raiding camps, \
-	ready to pillage their new surroundings. They are common where Hammerhold raiders can be found.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>Critical Weakness, Inhumen Digestion</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>LANGUAGE: Orcish - ,o</b></span> </br>"
 
 /mob/living/carbon/human/species/goblin/moon
 	name = "moon goblin"
@@ -107,17 +80,7 @@
 /mob/living/carbon/human/species/goblin/npc/ambush/moon
 	race = /datum/species/goblin/moon
 /datum/species/goblin/moon
-	name = "moon goblin thrall"
 	id = "goblin_moon"
-	desc = "<b>Moon Goblin Thrall: Scholar Turned Mad</b><br>\
-	These are goblins of the Bone Tribe who followed Noc in their lives and became skilled mages, \
-	before Graggar had claimed their souls and consumed their will. Native to the Otavan woodlands, \
-	after being enthralled these nomads madly wander the wilderness, babbling and weeping for the knowledge they have lost. \
-	No longer can they cast magic as thralls of the Ascendent, \
-	the mana in their body having crystalized into narcotic moonsugar that spills out once they are cracked open. \
-	It is some small miracle this one made it all the way to the Reach alive, to die now at your hands.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>Critical Weakness, Inhumen Digestion</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>LANGUAGE: Orcish - ,o</b></span> </br>"
 	raceicon = "goblin_moon"
 
 /datum/species/goblin/moon/spec_death(gibbed, mob/living/carbon/human/H)
@@ -150,15 +113,8 @@
 
 
 /datum/species/goblin
-	name = "goblin thrall"
+	name = "goblin"
 	id = "goblin"
-	desc = "<b>Goblin Thrall: Consumed by Hate</b><br>\
-	These are goblins of the Moss Tribe who were likely followers of Noc in their lives as the creator of their species, \
-	this race of goblins being native to the Reach and devastated as Graggar has consumed nearly all of their clans in the province. \
-	Traditionally farmers and militiamen, the wars between Grenzelhoft and Otava opened the way for Graggar to claim their souls as they were weakened by hate and uncertainty. \
-	Now empty husks, a bounty lays on their dangerous heads. While there is no bounty for unmutated goblins of this tribe, prejudice against them remains high.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>Critical Weakness, Inhumen Digestion</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>LANGUAGE: Orcish - ,o</b></span> </br>"
 	species_traits = list(NO_UNDERWEAR,NOEYESPRITES)
 	inherent_traits = list(TRAIT_RESISTCOLD, TRAIT_RESISTHIGHPRESSURE, TRAIT_RESISTLOWPRESSURE, TRAIT_RADIMMUNE, TRAIT_CRITICAL_WEAKNESS, TRAIT_NASTY_EATER)
 	no_equip = list(SLOT_SHIRT, SLOT_WEAR_MASK, SLOT_GLOVES, SLOT_SHOES, SLOT_PANTS, SLOT_S_STORE)

--- a/code/modules/mob/living/carbon/human/species_types/species/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/aasimar.dm
@@ -6,15 +6,16 @@
 	id = "aasimar"
 	origin_default = /datum/virtue/origin/otava
 	origin = "Otava"
-	desc = "<b>Aasimar: Child of Destiny</b><br>\
-	Created by Psydon was the Divine Family, ten sibling gods who helped to create \
-	the world and safeguard it from decay and destruction; and from the gods came the angels, \
-	made by the ten to serve as they had for Psydon as caretakers and shepherds. \
-	Rarely an angel and mortal will create life together, and these children often grow up told about the great destiny they will surely fulfill. \
-	Compared to a standard human they are on average more frail and tall, and have an otherworldly beauty no matter their parentage. \
-	Their very blood brings fortune, and their deaths are ill omens. <br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 FOR</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> LANGUAGE: Celestial - ,c</b></span> </br>"
+	desc = "<b>Aasimar</b><br>\
+	Aasimar are born of a rare union between Humens and Angels. \
+	They bear the mark of their celestial touch through their many varying physical features. \
+	Their looks resemble the traditional characteristics of whichever of the Gods their Angel parent was associated with. \
+	Most commonly, Aasimar are similar to Humens, albeit taller, and commonly possess an uncanny beauty. \
+	When compared to the average Humen, they have strangely colored skin and are more physically frail. \
+	Because of their upbringing, they make for natural conduits for godly powers. \
+	Scarlet Reaches' populace holds them with a mixture of uneasy mixture of fear and respect. \
+	Due to their celestial nature, it is widely believed that an Aasimar's death is a bad omen...<br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 FOR</b></span> </br>"
 
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY)
 	inherent_traits = list(TRAIT_NOMOBSWAP)

--- a/code/modules/mob/living/carbon/human/species_types/species/akula.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/akula.dm
@@ -8,17 +8,15 @@
 	origin_default = /datum/virtue/origin/etrusca
 	origin = "Etrusca"
 	base_name = "Beastvolk"
-	desc = "<b>Axian: Sharks of Etrusca</b><br>\
-	During Psydon’s battle with Zizo, great floods threatened people on the coasts of the province of Etrusca. \
-	Abyssor heard these prayers and stepped in, transforming those threatened by the flood into fishy abominations. \
-	They survived the crisis, and became reliable for strength and durability. \
-	They then spread across the world through trade and job contracts, anywhere the tide will go. \
-	A wanderlust afflicts most Axians, they travel through ports looking for work and opportunity often. \
-	Often they end up in mercenary companies or as dockhands and sailors to the Merchant Guild.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 CON | +1 END</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> Waterbreathing|Denizen of the Deep</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> LANGUAGE: Abyssal - ,p</b></span> </br>"
-
+	desc = "<b>Axian</b><br>\
+	Axians are a proud, shark-like people that have a heritage founded in maritime trade, \
+	tax evasion, and piracy. They have a strong distaste for the nobility and taxation, \
+	making them a target of discrimination in the Scarlet lands. They are oftentimes scapegoats for crime. \
+	Due to their penchant for trade and travel, they can be found all over the world, oftentimes \
+	seeing places many could not even dream of. They look down at those they considered the 'settled' \
+	and often uproot themselves quite often in their lifetimes. However, due to the isolation in Scarlet Reach, many Axians \
+	find their sanity being clawed away as they find themselves stuck in one place.<br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 CON | +1 END</b></span> </br>"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	inherent_traits = list(TRAIT_WATERBREATHING, TRAIT_SEA_DRINKER)

--- a/code/modules/mob/living/carbon/human/species_types/species/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/anthromorph.dm
@@ -7,13 +7,12 @@
 	base_name = "Beastvolk"
 	use_titles = TRUE
 	race_titles = list("Cat-Kin", "Dog-Kin", "Volf-Kin", "Lion-Kin", "Venard-Kin", "Tiger-Kin", "Sheep-Kin", "Goat-Kin", "Rous-Kin", "Possum-Kin", "Pig-Kin", "Boar-Kin", "Rabbit-Kin", "Cabbit-Kin", "Horse-Kin", "Donkey-Kin", "Hyena-Kin", "Deer-Kin", "Bear-Kin", "Panda-Kin", "Coyote-Kin", "Moose-Kin", "Jackal-Kin", "Panther-Kin", "Lynx-Kin", "Leopard-Kin", "Monkey-Kin", "Bird-Kin", "Seal-Kin", "Bat-Kin", "Otter-Kin", "Cow-Kin", "Bull-Kin", "Monster-Kin", "Chimera")
-	desc = "<b>Wild-Kin: Minor Races of the World</b><br>\
-	A catch-all for various races of the planet too few in number to be properly remembered by the common citizens of the kingdoms. \
-	They are individual species with wildly varied origins, the rumor of crossbreeding or divine curses being a common prejudice no matter where they end up. \
-	Most locals of the Scarlet Reach tend to associate wildkin with Dendor as one of his creations, \
-	but they can be creations or devotees of any divinity. Their beastblood grants them a slight advantage in spotting dangers and enduring trials, \
-	but runs the risk of being lumped in with other “furskins”. And as some wildkins act brashly, \
-	it drags the rest of the races to be compared to simple animals.<br> \
+	desc = "<b>Wild-Kin</b><br>\
+	A product of Dendor's enigmatic meddling in mortals races. The average wild-kin suffers from animalistic urges that vary in severity, \
+	from simply avoiding certain foods to smoldering desires to howl at the moon or chase prey. Usually these urges are tied to the animal that the wild-kin is melded with, \
+	making them rather predictable. Despite this, the way each wild-kin approaches their bizarre physiology and psychology varies, \
+	creating a diverse race of people who may not even empathise with one another. And whilst Dendor is considered the main culprit for Wild-kin, there are those created through other means, \
+	akin to Noc's stolen knowledge that created lupians and other abstract experimentation or circumstance.<br> \
 	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 CON | +1 PER</b></span> </br> \
 	<span style='color: #cc0f0f;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>(Wild-kin are not a template race to play your own custom race. If you play a wild-kin, \
 	you are expected to roleplay to the setting and the race's lore.)</b></span> </br>"

--- a/code/modules/mob/living/carbon/human/species_types/species/anthromorphsmall.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/anthromorphsmall.dm
@@ -8,13 +8,12 @@
 	base_name = "Beastvolk"
 	use_titles = TRUE
 	race_titles = list("Catvolk", "Dogvolk", "Venardvolk", "Rousvolk", "Possumvolk", "Pigvolk", "Rabbitvolk", "Raccoonvolk", "Red Pandavolk", "Sealvolk", "Hyenavolk", "Coyotevolk", "Jackalvolk", "Batvolk", "Ottervolk", "Monstervolk")
-	desc = "<b>Verminvolk: Outcasts of the World</b><br>\
-	A catch-all for various races of the world, too few in number and too insignificant in deeds to be remembered by the commoners of the kingdoms. \
-	They are seen as untrustworthy scavengers to most citizens, \
-	seen rooting around in ancient ruins or picking over the corpses of ambushes and the aftermath of large battles. \
-	Locals of the Scarlet Reach tend to associate these diminutive wildkin with crime and low intelligence, \
-	but some use these low expectations to their advantage. Relegated to the fringe of society in outposts, \
-	their diets are often poor in nutrition and unreliable. They commonly work in the city factories yet live under-street, away from the eye of decent folk.<br> \
+	desc = "<b>Verminvolk</b><br>\
+	Verminfolk (also simply called 'vermin') are diminutive creachures, with their origins tracing back to the east. \
+	Though most commonly marsupial, they come in all shapes, but not necessarily all sizes. A penchant for crime is \
+	not uncommon amongst Verminfolk, with many finding work as cutpurses or assassins; naturally agile forms working \
+	in their favor. In recent years, Verminfolk have spread to all corners of the world -- though much to society's \
+	dismay, for their negative reputation is one which they have difficulty parting with. <br> \
 	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 SPD</b></span> </br>"
 	default_color = "444"
 	species_traits = list(

--- a/code/modules/mob/living/carbon/human/species_types/species/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/demihuman.dm
@@ -15,12 +15,10 @@
 	use_titles = TRUE
 	race_titles = list("Half-Cat", "Half-Dog", "Half-Volf", "Half-Lion", "Half-Venard", "Half-Tiger", "Half-Sheep", "Half-Goat", "Half-Rous", "Half-Possum", "Half-Pig", "Half-Boar", "Half-Rabbit", "Half-Cabbit", "Half-Horse", "Half-Donkey", "Half-Hyena", "Half-Deer", "Half-Bear", "Half-Panda", "Half-Coyote", "Half-Moose", "Half-Jackal", "Half-Panther", "Half-Lynx", "Half-Leopard", "Half-Monkey", "Half-Bird", "Half-Seal", "Half-Bat", "Half-Otter", "Half-Cow", "Half-Bull", "Half-Monster", "Kitsune")
 	base_name = "Humen"
-	desc = "<b>Half-Kin: A Beastblood Thinned	</b><br>\
-	The result of union between the major or minor furskinned species, and the humanlike races of the world. \
-	In some parts of Enigma they are shunned as bastards or impure forms of humanity, while other kingdoms treat them as regular citizens, \
-	accepted among both peasants and nobles. In the Scarlet Reach they are accepted as legitimate children and inherit parental titles, \
-	though some see them as impulsive due to their beastblood. Most try to live regular lives as yeomen, scratching up a living in cities, \
-	while others shed inhibition and stigma, living among dendorites.<br> \
+	desc = "<b>Half-Kin</b><br>\
+	The inevitable union between wildkin and some form of humanity or another. \
+	While they also experience animalistic tendencies akin to their full-blooded ancestors, \
+	their intermingling with others has stemmed the severity of such primordial impulses.<br> \
 	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 PER | +1 END</b></span> </br> \
 	<span style='color: #cc0f0f;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>(Half-kin are not a template race to play your own custom race. If you play a half-kin, \
 	you are expected to roleplay to the setting and the race's lore.)</b></span> </br>"

--- a/code/modules/mob/living/carbon/human/species_types/species/dracon.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/dracon.dm
@@ -8,14 +8,13 @@
 	origin_default = /datum/virtue/origin/grenzelhoft
 	origin = "Grenzelhoft"
 	base_name = "Zard"
-	desc = "<b>Drakian: Destined for the Crown</b><br>\
-	A sturdy dragon-like race that lives up to 250 years, it is disputed if their ancestors were draconically-blessed zardmen or cursed by greed. \
-	They have been known to rise to positions of leadership amongst levies and petty nobility of kingdoms, \
-	attracting followers with confidence and a willingness to dirty their hands. Common in the east, they can be found across the world, \
-	yet those who settle in the west find they become associated with Matthios by most commoners. With war across their various homelands, \
-	at times one will rise to lead their community from the front of the conflict. Some say it is bravery and leadership, others say it is delusional egotism.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 STR</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> LANGUAGE: Draconic - ,s</b></span>"
+	desc = "<b>Drakian</b><br>\
+	Mighty, scaled individuals that are particularly reminiscent of the ancient dragons of yore- their true origins are often called into question given that dragons \
+	are so seldom seen in todae's age. They are extremely long-lived compared to other, more fleshy races, and they lack a true homeland- past their tendency to settle in \
+	mountainous regions. Given this propensity, Drakians often find themselves near or amongst Dwarven settlements, either learning to coexist \
+	peacefully with the short-statured folk or finding themselves at odds with them. In recent years, they've been seen more and more frequently within Humen settlements along with \
+	the other races, although their draconic resemblance sometimes lends others to suspicion at first sight.<br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 STR</b></span> </br>"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT

--- a/code/modules/mob/living/carbon/human/species_types/species/dullahan/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/dullahan/dullahan.dm
@@ -7,15 +7,9 @@
 /datum/species/dullahan
 	name = "Dullahan"
 	id = "dullahan"
-	desc = "<b>Dullahan: Business Unfinished</b><br>\
-	At times mistaken for a type of deadite, the Dullahan is not a rotting ghoul or bloodsucking beast. \
-	These are living elves, humans and tieflings, whose souls are in the brain instead of the heart; \
-	the heart still beats, but Lux does not flow through it. They can remove their heads at will, \
-	which most fencers and thieves use to dodge about with their vital skull to be out of an opponent’s reach. \
-	The people afflicted by this condition claim they do not recall how they came to be this way, \
-	but some pious souls claim these are a foul abomination, an accursed creature that masquerades as human. \
-	Tennites in the west have come to associate them with Zizo, as a mockery of Psydon’s creation.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> Easy decapitation</b></span> </br>"
+	desc = "<b>Dullahan</b><br>\
+	The origins of Dullahans are widely unknown. Rumored to be humen accursed with a powerful arcyne energy binding mind to soul, until that connection is forcefully snuffed out. \
+	Such power affects some more than others, altering complexion and even their touch with magic. Their soul burns bright, yet their unknown origins makes them frightening to most."
 	// Stat balancing. Per-server decision. Preferably keep neutral until analysis post testmerges.
 	//race_bonus = list(STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = 1)
 	skin_tone_wording = "Catalyst"

--- a/code/modules/mob/living/carbon/human/species_types/species/dwarf/dwarfm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/dwarf/dwarfm.dm
@@ -9,16 +9,22 @@
 	origin = "Hammerhold"
 	sub_name = "Mountain Dwarf"
 	clothes_id = "dwarf"
-	desc = "<b>Dwarf: Builders of the Cities</b><br>\
-	Created by the hand of Malum as the hammer that would build and forge civilization, \
-	the dwarves are a people proud in the martial defense of their city-state fortresses, and their local traditions. \
-	A dwarf is often stubborn and prideful, but loyal and dedicated to their personal craft. \
-	The fortresses are named after their most plentiful resource and ruled by councils or kings, \
-	and engage in trade with the nations of man around them. At times a fortress might develop a positive relationship with those around it, \
-	with dwarves living among men or sharing their talents in the guild halls of cities.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 CON | +1 END</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> Drunk Healing</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> LANGUAGE: Dwarvish - ,d</b></span> </br>"
+	desc = "<b>Dwarf</b><br>\
+	A proud and robust race of short mountain folk, \
+	the dwarves are known for their pride in martial strength \
+	and the tenacity with which they adhere to their ancient traditions. \
+	A Dwarf, much like the rock that they carve their fortresses out of, \
+	is stubborn and ancient, with their race being the longest lived of all \
+	of the Weeping God's creations. They, like stone, also rarely change \
+	and tend to shun the modernization of the world around them. \
+	Instead, a Dwarf looks to their ancestorial heritage for guidance on \
+	the various challenges they face. Even if, ironically, this behaviour \
+	leads their kind towards technological advacement as they continue \
+	to improve their crafts, both in engineering workshops and the forges. \
+	Dwarves are hearty, but are not known for their speed or eyesight... \
+	Each dwarf hails from a ancient fortress named after the most plentiful mineral.<br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 CON | +1 END</b></span> </br>"
+
 
 	skin_tone_wording = "Dwarf Fortress"
 

--- a/code/modules/mob/living/carbon/human/species_types/species/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/elf/elfd.dm
@@ -8,17 +8,24 @@
 	origin_default = /datum/virtue/origin/otava
 	origin = "Otava"
 	base_name = "Elf"
-	desc = "<b>Dark Elf: A People Divided</b><br>\
-	When the elves were created, some took an arrogant pride that was undue to them, some even claimed themselves equal to Psydon. \
-	When he was about to unleash his wrath, the most arrogant elves tapped into another plane to combat him. \
-	Thus began the first demonic incursion; between the infernal armies and divine wrath, \
-	some made a pact with the demons and hid underground to follow the ascendants. \
-	There the worship of the ascendants is absolute, where the brutal and selfish of society are seen as virtuous, \
-	and the compassionate and gentle are seen as weak fools. They are the source of the Dark Crusade, armies in darksteel plate followed by thralled undead, \
-	burning surface settlements. Entire cities under Otava emptied out when their people turned on the cruel lords and priests, \
-	slaughtering them to rejoin the surface after Psydon’s great sacrifice.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 INT | +1 PER</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> LANGUAGE: Elvish - ,e</b></span> </br>"
+	desc = "<b>Dark Elf</b><br>\
+	\"Elf\" is a catch-all term used for tall, pointy-eared humanoids who can trace their \
+	heritage to the ancient and mysterious Snow Elves. This species of elf, less frequently \
+	seen, are also referred to by some as \"drow,\" and have several key differences \
+	that set them apart from their more well-known and surface-dwelling kin. Chief among these \
+	differences are their dark complexions and origins from the Underdark; a massive subterranean \
+	landscape made up of a vast network of interconnected caves, caverns and tunnels. In this world \
+	hidden deep beneath the soil are several dark elven cities who exist and function far from the \
+	reaches of the rest of the surface-dwelling societies. These are a large part of what has earned \
+	the dark elves their notoriety, for in these cities the worship of the ascendant pantheon is \
+	normalized, and their cruel and bloodthirsty culture reflects this. It was rare to see dark \
+	elves outside of their underground homes, but in recent years, more and more of them have fled \
+	to the surface. The reasons for each dark elf fleeing the Underdark vary depending on the \
+	individual, such as a kinder heart fleeing from a brutal society that scorns them for their \
+	less cruel nature. However, not every dark elf seen on the surface can be safely assumed as \
+	kind, for some leave the Underdark simply to find their own greater heights of power.<br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 INT | +1 PER</b></span> </br>"
+
 /*
 	Former RT Desc: These guys were undead which doesn't really fit considering now you have a ton of them walking around.
 

--- a/code/modules/mob/living/carbon/human/species_types/species/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/elf/elfs.dm
@@ -6,14 +6,20 @@
 	id = "elfw"
 	psydonic = TRUE
 	sub_name = "Wood Elf"
-	desc = "<b>Wood Elf: Guardians of the Grove</b><br>\
-	In the creation of Enigma, Abyssor and Dendor were tasked with making its creatures and lands. \
-	Dendor wanted appreciation for his works, and he made the first race of the world, and the elves looked upon the wilds and praised him. \
-	Typically living 500 years they would carefully protect his sacred groves, \
-	which have become the only wilds untainted by the corruption of a sickened mind. Many elves mourn Dendor but still believe he can be healed, \
-	feverishly protecting the groves and keeping their locations secret. At times they leave for the cities, even siring children with humans.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 SPD</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> LANGUAGE: Elvish - ,e</b></span> </br>"
+	desc = "<b>Elf</b><br>\
+	\"Elf\" is a catch-all term used for tall, pointy-eared humanoids who can trace \
+	their heritage to the ancient and mysterious Snow Elves. This particular species \
+	of elf are what most imagine when they hear the word, and are also known among \
+	the elder races as \"Wood-Elves\". Considering their diverse history, it is extremely \
+	difficult for other mortals to even conceive the various intricacies found in elven \
+	society, thanks in no small part to the hundreds if not thousands of tribes that exist \
+	within their culture. Although ancient and complex, Elves tend to be looked poorly upon by \
+	Humens, as historically the two races have been rivals in various conflicts and \
+	territorial disputes. This, however, does not stop many Humens and Elves from forming \
+	relationships, which are capable of producing half-elven children. Elves are known for \
+	their intelligence and sharp eyes, but their graceful nature typically leaves their bodies \
+	more frail and fragile than most. In these lands, only a handful of the many Elvish tribes are seen.<br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 SPD</b></span> </br>"
 
 	skin_tone_wording = "Tribal Identity"
 

--- a/code/modules/mob/living/carbon/human/species_types/species/goblinp.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/goblinp.dm
@@ -8,17 +8,12 @@
 	origin = "Gronn"
 	is_subrace = TRUE
 	base_name = "Ogroid"
-	desc = "<b>Goblin: Nomadic Tribes of the Night</b><br>\
-	Created by the hand of Noc as a creative and inquisitive species, \
-	tribes of goblins spread across the world from the wind-whipped steppes of Gronn. \
-	While their worship and their culture is different across the nations, a commonality is the nomadic nature of their clans across the wilds. \
-	They have become a favorite of Graggar to capture and devour the souls, releasing empty violent husks into the world’s cities. \
-	These well traveled peoples at times do settle down into villages or join established settlements, \
-	where fast feet aid them when they are mistaken for portal-thralls. \
-	Graggar’s hunger has led to there being more soulless husks in his armies than surviving goblins.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 SPD</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> Inhumen Digestion</b></span> </br>"
-	
+	desc = "<b>Goblin</b><br>\
+	A clever and stubborn nature are two charitable qualities of a goblin - scheming and selfish are less so. The Fell Gods use them as an avatar of malice, sending out \
+	mindless, enthralled waves of the creatures to attack civilization from lunar portals. It leaves the typical goblinoid to cloister in their hidden away tribes, stealing \
+	from the scraps out of fear of reprisal while shooing away outsiders. The cities of Man typically shun them, but it's not unheard of to see one pushing their luck in a \
+	town square or out on a well-traveled road, as even the most backwater peasant can tell the difference between a sapient one and portal-spawn. Usually.<br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 SPD</b></span> </br>"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE)
 	inherent_traits = list(TRAIT_NASTY_EATER)
 	possible_ages = ALL_AGES_LIST

--- a/code/modules/mob/living/carbon/human/species_types/species/golem/doll.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/golem/doll.dm
@@ -9,12 +9,14 @@
 	origin_default = /datum/virtue/origin/otava
 	origin = "Otava"
 	base_name = "Construct"
-	desc = "<b>Porcelain Doll: Servants of Civility</b><br>\
-	After the discovery of the dwarven golems, wizards around the world attempted to replicate the miracle of the Automata to mixed results. \
-	The imperial wizards of the far east made the Doll as an arcane piece of engineering leaned towards administrative and hospitality \
-	needs for a court that valued beauty and civility in its servants. They were made to be elegant and intelligent, \
-	and more than a few are unnerved as these quiet constructs begin to fill courts across the world as advisors and clerks in various guildhouses. \
-	Some folk even suspect there is some foul conspiracy involved.<br> \
+	desc = "<b>Porcelain Doll</b><br>\
+	The pinnacle of both art and craftsmanship, originally made to provide companionship for ladies and wealthy women \
+	alike. Created to be simply toys or novelty decorations for the wealthy, they do not sleep, eat or bleed. However, \
+	due to the dark magic and heretical connotation that they share with the Golems of Giza, they were made to be incredibly \
+	brittle as to promote their subservience and remove any chance these somber creations have of harming their masters. \
+	Over time, they were seen to prove as valuable asset and advisory role due to their intellectual prowess, it is \
+	unknown what provided them with such a gift. A master wanting more engaging conversation? A lord wanting a more \
+	efficient clerk? Regardless, who knows what thoughts their eyes of glass truly conceal?<br> \
 	<span style='color: #cc0f0f;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>-2 STR</span> |<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'> +2 INT | +1 SPD</b></span> </br> \
 	<span style='color: #cc0f0f;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b><span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'>Hungerless, Insomnia, Bloodless. Extremely fragile.</span></b></br>\
 	<span style='color: #cc0f0f;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b><span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'>Capable of installing skill exhibitors in themselves or other Golems.</span></b></br>"

--- a/code/modules/mob/living/carbon/human/species_types/species/golem/golem.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/golem/golem.dm
@@ -8,12 +8,12 @@
 	origin_default = /datum/virtue/origin/naledi
 	origin = "Naledi"
 	base_name = "Construct"
-	desc = "<b>Golem: Guardians of the Mountainhome</b><br>\
-	For centuries the dwarven city-states grew in number, splendor and tightly guarded secrets. \
-	Soon the nations of man grew jealous and began to covet them greatly, culminating in a siege of the Platinum Citadel by the Grenzelhoft Freikorps. \
-	After five months of cannonfire and siege towers, the gates came open to the swinging arms of artificial men, \
-	merciless in the killing of mercenaries. The secret of golems was then spread by forge-priests of Malum, \
-	a creation that requires works of both engineering and magic, which must obey the instruction given on the day of its creation.\
+	desc = "<b>Golem</b><br>\
+	Masterworks of craftsmanship, the first Golems were constructed in the Republic of Giza with similar designs \
+	spreading  spreading across the lands. Created to be the perfect servants, they do not sleep, eat or bleed and the \
+	materials composing their shells makes them more resilient if not slower than most. As of late, a rebellion amongst \
+	the Golems of Giza has given way to a new generation of individualistic arcyne-forged creations. Much of society as a whole is \
+	conflicted on Golems, for their sensibilities vary wildly from one to the next. \
 	<br> \
 	<span style='color: #cc0f0f;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>-1 SPD</span> |<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'> +2 CON</b></span> </br> \
 	<span style='color: #cc0f0f;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b><span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'>Hungerless, Insomnia, Potion/Poison-immunity</span></b></br> \

--- a/code/modules/mob/living/carbon/human/species_types/species/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/halfelf.dm
@@ -7,13 +7,17 @@
 	psydonic = TRUE
 	is_subrace = TRUE
 	base_name = "Humen"
-	desc = "<b>Half-Elf: A history divided</b><br>\
-	Between the elves of the hidden sacred groves or those of the undercities, and the humans of  Enigma, at times a bond is formed. \
-	While most species can crossbreed the odds of a healthy birth or even conception remains low between two species, \
-	yet elves and humans enjoy near-perfect compatibility. They are as diverse as elves and humans across the world. \
-	In the past hatred against them was significant, but they are now considered as equals often in both their parental cultures, \
-	yet some traditional kingdoms such as Otava still believe elves and humans should be separate. \
-	They enjoy both the robust healthiness of humanity, and the keen senses of the elves.<br>\
+	desc = "<b>Half-Elf</b><br>\
+	The child of an Elf and Humen, Half-Elves are generally frowned \
+	upon by the more conservatively minded. However, as racial tensions lower, \
+	the rate of Half-Elf births has continues to increase. So common has it become that some scholars \
+	worry that someday it may be impossible to distinguish the Humens and Elves from one another. \
+	From physical to cultural characteristics, Half-Elves are an incredibly diverse people, \
+	thanks in no small part to the incredibly varied nature of their Humen halves. Indeed, no other race \
+	embodies the term \"melting pot\" quite like the Half-Elves. Due to their half-breed nature, their physical \
+	characteristics can be either more Elvish or more Humen, depending on which of their parents' genes \
+	are more predominant. In terms of cultural identity, a Half-Elf will typically choose to lean more \
+	towards either their Humen or Elvish heritages.<br>\
 	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 CON | +1 PER</b></span> </br>"
 
 	skin_tone_wording = "Tribal Identity"

--- a/code/modules/mob/living/carbon/human/species_types/species/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/halforc.dm
@@ -7,14 +7,18 @@
 	origin_default = /datum/virtue/origin/racial/gronn
 	origin = "Gronn"
 	base_name = "Ogroid"
-	desc = "<b>Half Orcs: Conquerors yet Conquered</b><br>\
-	Created by the hand of Ravox to serve his law and justice, orcs were dutiful and strong people. \
-	Yet when the orcish slave Graggar ascended he dominated a large swath of the species, stealing them away from his creator’s control. \
-	From the steppes of Gronn to the mountains of Kazugan, the orcish tribes have either scattered or been conquered and absorbed in the horde of the Ironmask. \
-	Not all orcs have fallen to the corruption of Graggar, and many flee for safer lands, taking partners among dwarves, elves and humans; \
-	without their clans, they often adopt their non-orcish culture.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 STR</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> LANGUAGE: Orcish - ,o</b></span> </br>"
+	desc = "<b>Half Orcs</b><br>\
+	With the Ironmask clan on a centuries-long warpath to consolidate all orcs beneath their banner, \
+	crushed orc tribes have lost their menfolk, and war-widows have been scattered to the hinterlands. \
+	Between humen civilization and orc savagery, orc-women opting for exile over dishonor have become \
+	more common visitors to fur trading posts and prospecting camps, eventually leading to half-orcs \
+	being born in these rough places otherwise devoid of a fairer sex. Your mother-clan is in thrall \
+	to the Ironmask. True orcs would kill you on sight, seeing you as a mongrel dog, and non-orcish \
+	people cannot decide between regarding you with either mere distrust or outright disgust. Yet \
+	somehow your wandering feet came to Scarlet Reach, where half-orcs ply muscle and their hardiness \
+	in the rough underbelly or outer reaches of society.<br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 STR</b></span> </br>"
+
 
 	skin_tone_wording = "Clan"
 

--- a/code/modules/mob/living/carbon/human/species_types/species/harpy.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/harpy.dm
@@ -10,13 +10,16 @@
 	use_titles = TRUE
 	race_titles = list("Bat-Harpy", "Stork-Harpy", "Finch-Harpy", "Owl-Harpy", "Shrike-Harpy", "Condor-Harpy", "Parrot-Harpy", "Chicken-Harpy", "Turkey-Harpy", "Zad-Harpy", "Osprey-Harpy", "Pigeon-Harpy", "Dove-Harpy", "Gull-Harpy")
 	base_name = "Beastvolk"
-	desc = "<b>Harpy: Songbirds in Flight</b><br>\
-	Called ‘magpies’ by those distrusting or irritated, some mistake this species for a halfkin race. \
-	The harpies are native to the coastal cliffs of Etrusca yet their colonies have spread to great sequoia forests and the chilly tops of mountains far across the world. \
-	As their tribes developed culture and discovered music, they were noticed and favored by Eora, who blessed them with divine ability. \
-	While they can fly with their hollow bones that leave them comparatively frail and weak, they must rely on updrafts and swooping movements, \
-	aided in flight by keen eyes, wit, and a rapid speed. The sight of shadows from above alerts most men, as harpies can lift and drop victims to maim them; \
-	in Grenzelhoft and the Scarlet Reach harpies are not trusted, as they can fly above walls.</br> \
+	desc = "<b>Harpy</b><br>\
+	Harpies, or less ceremoniously known as 'magpies,' resemble the half-kin in appearance at first glance. \
+	One would rightfully assume they are similar in nature- with accuracy even, much to the harpies' chagrin. \
+	Harpies have been uplifted and reconnected to divinity by Eora, having developed culture of music and song which caught the attention of such a goddess. \
+	Their songs and voices may be their own, or proud mimicking other voices they've heard with unnatural accuracy. \
+	\
+	Whilst harpies may fly, their freedom is weighed by corruption of fleshcrafting to this day. Complete open-air freedom is still foreign to them. \
+	Harpies tend to live and gather in colonies at the tops of great sequoia forests and in nearby cliffs. Due to their laden flight, they must employ use of updrafts and proximity to large objects or structures to bolster their limited range and air-dancing performances. \
+	Their serene songs and blissful music can be heard echoing far below, guiding travelers and thieves both to respite... or treasure. For as lifted into grace as they might be, these 'magpies' earn such a nickname from instinctual Matthiosan greed and love for anything that shines. \
+	Yet if one can work past that distrust and compensate them well, harpies make for unparalleled couriers. </br> \
 	<span style='color: #cc0f0f;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>-3 CON | -2 STR</span> |<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'> +1 PER | +1 INT | +2 SPD</b></span> </br> \
 	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>Flight | Innate Singing | Strong Bites</b></span> </br> \
 	<span style='color: #cc0f0f;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>Can't wear boots</span> | <span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'>Slight Fall Damage Reduction </span></b>"

--- a/code/modules/mob/living/carbon/human/species_types/species/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/human/humen.dm
@@ -8,12 +8,14 @@
 	origin_default = /datum/virtue/origin/grenzelhoft
 	origin = "Grenzelhoft"
 	sub_name = "Northern Humen"
-	desc = "<b>Humen: Objectively the Best</b><br>\
-	Created directly by Psydon’s hands the humans were made in his image, determined and proud. \
-	Found across the world they are diverse in belief and culture, yet their differences strengthen the bond of this species. \
-	Even if they hail from nations historically at odds, evolutionary design urges them to help another human in need. \
-	Their people are found in every continent, in the worship of all the Gods, serving as a commonality. \
-	If civilization has touched any corner of the world then humans have left their bootprints in the sand. They hold no dominant traits but a sense of pride.<br>\
+	desc = "<b>Humen</b><br>\
+	Humens (or \"Humans\") are the eldest of the Weeping God's creations. Noted for their \
+	tenacity and overwhelming population, humens are the most commonly seen race across the lands, \
+	at a rate of about ten to one in regions such as Grenzelhoft. However, to the west \
+	the opposite is true. Humens come from a vast swathe of cultures and ethnicities, most of which \
+	have historically been at odds with one another. Being the eldest creations of the Weeping God, humens \
+	tend to find fortune easier than the other races, and are so diverse that no other racial traits \
+	are dominant in their species.<br>\
 	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 END | +1 INT</b></span> </br>"
 
 	skin_tone_wording = "Ancestry"

--- a/code/modules/mob/living/carbon/human/species_types/species/kobold.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/kobold.dm
@@ -8,15 +8,12 @@
 	origin_default = /datum/virtue/origin/racial/gronn
 	origin = "Gronn"
 	base_name = "Zard"
-	desc = "<b>Kobold: Slaves of the Burrow</b><br>\
-	Collectives of kobolds once inhabited the great mountain ranges of Gronn, \
-	these tribes safe from the savage whipping winds of the plains and well defended by their terrain from mounted raiders. \
-	But then came the Iron Dwarves, who besieged the mountains by justification of Malum’s will. The dwarves formed the Iron Burrow, \
-	and the native tribes were made to slave in the mines for gems. Many kobolds follow Matthios as their liberator, \
-	breaking chains and fleeing west for safer lands. Some end up dead fleeing across the steppes of Gronn, but others make it to less cruel regimes.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 FOR</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> LANGUAGE: Draconic - ,s</b></span> </br>"
-
+	desc = "<b>Kobold</b><br>\
+	Short in stature and typically scrawny, these little lizards make up for it in their natural agility. Interestingly, no historical relation has been found between this race and that of the \
+	hardy bog-dwelling Zardmen, past their somewhat-similar appearance. Kobolds often dwell in caves or in the outskirts of civilization, preferring to keep to themselves in small homogeneous groups \
+	or alone rather than engage with tall-folk, given their widespread stereotype of being thieves or ne'er-do-wells. Scarlet Reach is no exception to this, and some Kobolds have even dared to brave the\
+	odds and try their luck amongst Humen society.<br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 FOR</b></span> </br>"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT

--- a/code/modules/mob/living/carbon/human/species_types/species/lamia.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/lamia.dm
@@ -10,16 +10,15 @@
 	use_titles = TRUE
 	race_titles = list("Mervolk", "Eelvolk", "Naga", "Siren", "Gorgon")
 	base_name = "Beastvolk"
-	desc = "<b>Lamia: Raiders of the Coast</b><br>\
-	Like the wildkin of the lands of Enigma, Lamia are a catch-all umbrella term for various humanized spawn of the deep made by Abyssor’s hand. \
-	Mermaids, naga, and sirens all fall into this category. \
-	They are common in warm coastal regions, where their tribes formed villages after being spat out from the tide. \
-	Their history is of conducting raids of terror against the civilized coastal regions, \
-	and the burning of helpless trade vessels that neared their waters. Widely shunned and hardly trusted, many sailors have died at their hands. \
-	Even as some move inland, their bloody reputation follows.<br>\
+	desc = "<b>Lamia</b><br>\
+	The monstrous spawn of Abyssor, snake and humen conjoined together, the deepkin and merfolk. \
+	Sirens, mermaids, nagas and many others fall into 'lamia' categorization. While one could consider them to be of Dendor's, he had no hand in their creation. \
+	Lamia are widespread in the southern coastal regions, where their tribes have settled in aeons ago, much of their written and oral history is filled with accounts \
+	of grand raids on coastal regions, for they have been terrorizing any race that has dared to settle near their waters. For this, they are widely shunned by the other races, \
+	with the exception of Axians and some coast-dwelling Zardmen with whom they share their natural heartlands. Many a sailor has met their end at the claws of Lamias. \
+	Yet... not all of them have stayed in the depths of the abyss, for some of the clans have moved far away from the coastal regions, settling in swamps, forests and even deserts, having spread themselves far and wide aeons ago.<br>\
 	<span style='color: #cc0f0f;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>-1 SPD</span> |<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'> +1 STR</b></span> </br> \
-	<span style='color: #cc0f0f;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>Can't wear boots</span> | <span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'>Strong kicks, Longstrider, Strong stomach</span></b>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'> LANGUAGE: Abyssal - ,p</b></span> </br>"
+	<span style='color: #cc0f0f;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>Can't wear boots</span> | <span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'>Strong kicks, Longstrider, Strong stomach</span></b>"
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR, LIPS, HAIR, LAMIAN_TAIL, OLDGREY, MUTCOLORS)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT

--- a/code/modules/mob/living/carbon/human/species_types/species/lizardfolk.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/lizardfolk.dm
@@ -5,15 +5,15 @@
 	name = "Zardman"
 	id = "lizardfolk"
 	base_name = "Zard"
-	desc = "<b>Zardman: Children of the Wetland</b><br>\
-	Created by Abyssor’s hand they are believed to be savage, some even think them Graggarites. \
-	Native to the wetlands of the Scarlet Reach so infused with mana and crawling with undead, \
-	the Zardmen are naturally suited to survive the mire and thrive in it. The bog hosts isolationist tribes that do not trust softskins, \
-	violently reacting to those who encroach on their lands in skirmishes with both settlers and the wardens who scout ahead. \
-	With hardened scales and an ability to take punishment they are still valuable to keep around, \
-	and individual zardmen have trickled into the cities with the promise of generous payments, rich foods and delicious ale from weaker cityfolk.<br> \
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 CON | +1 END</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> LANGUAGE: Draconic - ,s</b></span> </br>"
+	desc = "<b>Zardman</b><br>\
+	Zardmen are a reptilian people originating from various morasses across the world. They are resilient and enduring \
+	creachures who flourish environments such as swamps and bogs. Zardmen are considered to be fearsome predators on \
+	account of their hardened scales, razor-sharp talons and teeth, but owe much of their survival to close-knit tribal \
+	communities. To the civilized, they are considered little more than savages, for much of the history between them has \
+	been painted with blood and strife. In recent years, many Zardmen born outside of tribes have integrated into Humen \
+	societies -- often as laborers or mercenaries.<br> \
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 CON | +1 END</b></span> </br>"
+	skin_tone_wording = "Skin Colors"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT

--- a/code/modules/mob/living/carbon/human/species_types/species/lupian.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/lupian.dm
@@ -8,13 +8,13 @@
 	origin_default = /datum/virtue/origin/hammerhold
 	origin = "Hammerhold"
 	base_name = "Beastvolk"
-	desc = "<b>Lupian: Wolves of the Northland</b><br>\
-	Created by Dendor’s hand in the cold of Hammerhold, the Lupians were expected to survive by themselves as had his other races. \
-	But as they suffered from cold and malnutrition, intervention came by the spark of Noc’s ingenuity, who taught them how to not just survive, \
-	but to even thrive. These are resilient people with a knack for planning ahead, \
-	who have spread from the frozen northern isles not just as raiders but as settlers, gaining a reputation above other wildkin races as a civilized species. \
-	They are more at home in castles and towns than the untamed wilderness, \
-	yet some still associate them with a dim animalistic nature, created as they were by Dendor’s hand.<br>\
+	desc = "<b>Lupian</b><br>\
+	Lupians are the sons and daughters of Noc. They are a volf-like people hailing from the Northern Regions of the world. \
+	They are resilient, cunning and fight ready creachures capable of surviving the north thanks to their rugged pelts, \
+	sharp teeth and deep-rooted spirit of community. They are very dutiful individuals and make fantastic and fearsome \
+	warriors to those who earn their loyalty. Thanks to their pack minded nature they are slow to trust the other races \
+	but form deep connections with those they do. In recent years they have been driven from the forests by unrest and pressed \
+	into cohabitation with races they'd deem lesser.<br>\
 	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 CON | +1 INT</b></span> </br>"
 	skin_tone_wording = "Pack"
 	species_traits = list(

--- a/code/modules/mob/living/carbon/human/species_types/species/moth.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/moth.dm
@@ -9,13 +9,11 @@
 	origin = "the Underdark"
 	base_name = "Beastvolk"
 	desc = "<b>Fluvian</b><br>\
-	An insectoid species native to the Underdark. Indigenous to Effluvia, a loathsome underground region known for its poisonous waters.<br>\
-	Fluvians are known as the archetypal species for drow slaves, few surface-dwellers realize they have a city of their own: \
-	The sole settlement in Effluvia, Mercuriam. It is here that Pestra's arts are honored; \
-	only the educated are allowed to pass its bronze gates. Denied fluvians must eke out a primitive life in the rotting wilds of Effluvia.<br>\
-	According to the fluvians of Mercuriam, their god, Pestra, has not yet been born. She lies in a nascent cocoon, bestowing wisdom from a time to come.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 SPD | -1 CON</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>Long Jump | Can Eat Clothes</b></span>"
+	Many comparisons have been made to the common moths in an attempt to describe this unique species. From the appetite for clothing to the disconcertingly insectoid appearance, \
+	the name 'Moth' is forever stamped onto the common vocabulary. The comparison, however, falls short on the matter of flight. This species generally congregates within lichen-laden \
+	cave regions or lush forests, given their capacity to digest fiber, and many Fluvian artisans take up the art of clothwork to create expensive export goods from cloth or silk (the latter \
+	of which is found in abundance from the spiders often near their settlements). <br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 SPD</b></span> </br>"
 
 	species_traits = list(EYECOLOR,LIPS,MUTCOLORS,HAIR)
 	possible_ages = ALL_AGES_LIST

--- a/code/modules/mob/living/carbon/human/species_types/species/orc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/orc.dm
@@ -4,14 +4,10 @@
 /datum/species/orc
 	name = "Orc"
 	id = "orc"
-	desc = "<b>Orcs: Forged by Strength</b><br>\
-	Created by the hand of Ravox to serve his law and justice, orcs were dutiful and strong people. \
-	Yet when the orcish slave Graggar ascended he dominated a large swath of the species, stealing them away from his creator’s control. \
-	Some have managed to escape the notice of the Ascendent and have fled to safer regions as the Ironmask warband spreads across Gronn, \
-	yet most warriors of the Orcish clans have ended up either thralled or willingly serving the all-hungering war-maw. \
-	Orcs remain of great health and strength, but Graggar’s grip has dimmed independent thought.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 STR | +1 CON | -1 INT | -1 SPD</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> LANGUAGE: Orcish - ,o</b></span> </br>"
+	desc = "<b>Orcs</b><br>\
+	This is made for events. You shouldn't be able to use this as a normal person, \
+	For courtesies sake however, I've tried to half-assedly balance it for use by players\
+	(+1 Strength, +1 Constitution, -1 Intelligence, -1 Speed)"
 
 	skin_tone_wording = "Clan"
 

--- a/code/modules/mob/living/carbon/human/species_types/species/tabaxi.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/tabaxi.dm
@@ -8,14 +8,14 @@
 	origin_default = /datum/virtue/origin/raneshen
 	origin = "Raneshen"
 	base_name = "Beastvolk"
-	desc = "<b>Tabaxi: Of A Mood Mercurial</b><br>\
-		Slender and taller than a typical human, these wildkin tend to stand equally with elves, \
-		infuriating dwarves with their height. Hailing first from the deep jungles of Etrusca, \
-		they have spread across the world and developed spotted and striped fur of different colorations depending on the biome. \
-		Blessed to be suited as athletes with a sharp sense of awareness, there is some debate on which God may have shown them favor. \
-		Some say Necra guides their sight, Noc their sharp minds, Xylix their curiosity and wit, \
-		yet still most of humanity would not trust them not to snatch their coinpurse; some even think they were made by Matthios, \
-		that they are given to both thievery and treachery.<br>\
+	desc = "<b>Tabaxi</b><br>\
+		Tabaxi are taller than most humans at six to seven feet. \
+		Their bodies are slender and covered in spotted or striped fur. \
+		Like most felines, Tabaxi have long tails and retractable claws. \
+		Tabaxi fur color ranges from light yellow to brownish red. \
+		Tabaxi eyes are slit-pupilled and usually green or yellow. \
+		Tabaxi are competent swimmers and climbers as well as speedy runners. \
+		They have a good sense of balance and an acute sense of smell.<br>\
 		<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 SPD</b></span> </br>"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE, MUTCOLORS)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | SLIME_EXTRACT

--- a/code/modules/mob/living/carbon/human/species_types/species/tiefling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/tiefling.dm
@@ -6,15 +6,16 @@
 	id = "tiefling"
 	origin_default = /datum/virtue/origin/etrusca
 	origin = "Etrusca"
-	desc = "<b>Tiefling: Enemies of Hell</b><br>\
-	In the first demonic incursion of Enigma, the infernal legions came to our world without hesitation. \
-	As great portals opened in the atolls of Etrusca’s southern isles, the kings of the city-states stood in the defense of the planet; \
-	prolonged combat against demonic forces changed the people, \
-	and they took on the appearance of the foul enemy as the energy infused in bones as well as the soil. \
-	Understood as common people in Etrusca’s other city-states and nearby Otava, the rest of Enigma tends to assume they are demonic offspring with humans. \
-	Like most Etruscans they make for fine sailors, capable thinkers and hale bodied, but with a fierce independent streak against nobles.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 CON | +1 INT</b></span> </br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> LANGUAGE: Infernal - ,h</b></span> </br>"
+	desc = "<b>Tiefling</b><br>\
+	The offspring of demons with mortal races, a consequence of demonic incursions into the mortal realm and dark pacts. \
+	Their origins dating back to the demonic invasion of Archdevil Vheslyn who pillaged and ravaged the mortal lands and its people before being stopped by Psydon. \
+	These offspring of demon and mortal races came to be known as 'Tieflings', largely despised by most people for centuries for their unnatural origins and appearances. \
+	It was only recently that they became more tolerated, even if the Church still watches them with a weary eye. \
+	When a Tiefling has offspring, no matter the race of their partner, the child would always be a pureblooded Tiefling. \
+	The taint of their very being going back generations, and no amount of cleansing can be rid of it. \
+	As over a millennium a simple handful of Tieflings have created extended bloodlines linking back to their infernal progenitors. Some Tieflings embrace their demonic origin, while other shun it. \
+	No matter if they embrace their demonic ancestors or not, Tieflings have formed an importance upon their bloodline and family due to often being shunned and hunted through out time in which only those of their blood and kin they could truly trust. <br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 CON | +1 INT</b></span> </br>"
 
 	skin_tone_wording = "Progenitor"
 

--- a/code/modules/mob/living/carbon/human/species_types/species/vulpkanin.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/vulpkanin.dm
@@ -8,12 +8,11 @@
 	origin_default = /datum/virtue/origin/grenzelhoft
 	origin = "Grenzelhoft"
 	base_name = "Beastvolk"
-	desc = "<b>Vulpkian: Creatives of the Forest</b><br>\
-	Created by the hand of Dendor in the earliest era, Xylix took to favor these fox-like wildkin and blessed them with his creative spark. \
-	Native to the mountains and woods of Grenzelhoft, they have spread across the world as explorers and poets, creating art and testing the limits of luck. \
-	Looked upon some as thieves and tricksters, but their sharp minds make them useful in both the guild halls and the stewardies. \
-	Some still favor Dendor and live in his wilderness, but most enjoy the chance and creative spirit of the cities, \
-	especially those who have migrated to the east isles.<br>\
+	desc = "<b>Vulpkian</b><br>\
+	Foxy creatures known for their cleverness and mischief. In ancient history they were Dendor's original champions, but as His madness grew the connect \
+	became frey and forgotten, leaving them to their own devices. Or, at least, that's what they say. Regardless of their contested history, Vulpkian todae live all \
+	across the world in settlements belonging to all races, with no real place to call their native home. Interestingly, their mischeivous nature often results in Vulpkian \
+	finding themselves at-odds with the untrusting Lupians moving in from northern regions.<br>\
 	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 INT | +1 PER</b></span> </br>"
 	default_color = "444"
 	species_traits = list(

--- a/code/modules/mob/living/carbon/human/species_types/species/werewolf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/werewolf.dm
@@ -14,13 +14,6 @@
 /datum/species/werewolf
 	name = "verewolf"
 	id = "werewolf"
-	desc = "<b>Werewolf: Abandoned Warband</b><br>\
-	Once the warriors of Dendor in his abandoned war against the other Gods, \
-	these creatures are left over as soldiers of the wild now unwanted. \
-	They are forgotten by their creator, and remain as enemies of civilization who assail \
-	the frontier outposts and urban city centers. Through bite and claw they infect their victims \
-	to create new conscripts against modern society, turning from man to beast with the shifting of dawn and dusk. \
-	Sheltering in sanctified ground will stop transformations, but poultice must be made with a bloodied fyritius flower, holy water, and silver dust to cure them.<br>"
 	species_traits = list(NO_UNDERWEAR, NO_ORGAN_FEATURES, NO_BODYPART_FEATURES)
 	inherent_traits = list(
 		TRAIT_STRONGBITE,


### PR DESCRIPTION
## About The Pull Request

Reverts the race descriptions and lore back to the AP defaults, as per the request of the lore maintainer.

## Testing Evidence

<img width="530" height="146" alt="image" src="https://github.com/user-attachments/assets/54a21f34-cad3-405d-9152-8719ffdda4b6" />

## Why It's Good For The Game

Humans: Objectively the Best
