### PR TITLE
Minor Sapper changes. (Buff + Item availability)

### DIFF
--- a/code/modules/cargo/packsrogue/Pioneer.dm
+++ b/code/modules/cargo/packsrogue/Pioneer.dm
@@ -124,6 +124,11 @@
 	cost = 20
 	contains = list(/obj/item/rogueweapon/huntingknife/idagger/navaja)
 
+/datum/supply_pack/rogue/Pioneer/Saperka
+	name = "Saperka Shovel"
+	cost = 20
+	contains = list(/obj/item/rogueweapon/shovel/saperka)
+
 /datum/supply_pack/rogue/Pioneer/steeltossblades
 	name = "Steel Tossblade Belt"
 	cost = 20

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/pioneer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/pioneer.dm
@@ -27,6 +27,7 @@
 		/datum/skill/craft/crafting = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/carpentry = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/labor/lumberjacking = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/masonry = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,


### PR DESCRIPTION
## About The Pull Request
Gives sappers journeyman masonry so they can do something with all the rocks they mine. Capture bandit sappers and put them to work fixing the keep walls they blew up, because Malum knows there's not any other masons in town.

Puts the sapper's unique shovel in their shop for them. They need it to cast their unique class spell, and if they lose their first one they're just SOL. It costs as much as a longsword.

## Testing Evidence

<img width="527" height="148" alt="image" src="https://github.com/user-attachments/assets/0304a59f-a910-441a-a5c0-76184d78c25f" />

## Why It's Good For The Game

Let bandits build their own little base so we can have warden vs bandit 2fort. I'll add flags soon promise.
Losing your class ability because you got smacked with a lightning bolt in a teamfight sucks. 
You like me and want to merge my PR. 
