### PR TITLE
Improvised Saw Changes

### DIFF
--- a/code/modules/surgery/surgery_tools_rogue.dm
+++ b/code/modules/surgery/surgery_tools_rogue.dm
@@ -233,7 +233,7 @@
 	throwforce = 12
 	wdefense = 3
 	wbalance = 1
-	tool_behaviour = TOOL_IMPROVISED_SAW, TOOL_SAW
+	tool_behaviour = TOOL_SAW
 	sharpness = IS_BLUNT
 
 /obj/item/rogueweapon/surgery/hemostat/improv


### PR DESCRIPTION
## About The Pull Request
Makes the improvised saw work like a handsaw. That's it.

## Testing Evidence
<img width="406" height="369" alt="Sawchange" src="https://github.com/user-attachments/assets/e8156e3f-0b86-4fcb-891b-77317416008d" />

## Why It's Good For The Game
It's a one line change, just the flag.

Why? Unless you're a carpenter towner, use artificer's apprentice or buy a handsaw for like... 50 mammons from the merchant or less from the long ass smith line, you're barred from doing any kind of major carpentry. And I found it funny that an improvised saw couldn't well, SAW PLANKS.

It still functions as a surgery saw too, which I made sure to test so ghetto surgery bros can use it.