### PR TITLE
looking down no longer creates a chat message if you are sneaking

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2152,8 +2152,9 @@
 		ttime = 10 - (STAPER - 5)
 		if(ttime < 0)
 			ttime = 0
-
-	visible_message(span_info("[src] looks down through [T]."))
+	
+	if(m_intent != MOVE_INTENT_SNEAK)
+		visible_message(span_info("[src] looks down through [T]."))
 
 	if(!do_after(src, ttime, target = src))
 		return


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

looking down through an open space no longer displays a message if you are sneaking

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="2555" height="1324" alt="sneaky" src="https://github.com/user-attachments/assets/e9fe7d5b-b55e-45dc-ba13-de0b96021e39" />
looking down while sneaking: no chat message

## Why It's Good For The Game

every other look command functions this way, look down doesn't and its so annoying that it doesn't

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
