### PR TITLE
Oyster Fishing Changes

### DIFF
--- a/code/modules/roguetown/roguejobs/fisher/leeches.dm
+++ b/code/modules/roguetown/roguejobs/fisher/leeches.dm
@@ -28,8 +28,6 @@
 		/obj/item/reagent_containers/food/snacks/fish/angler = 170,
 		/obj/item/reagent_containers/food/snacks/fish/lobster = 180,
 		/obj/item/reagent_containers/food/snacks/fish/bass = 230,
-		/obj/item/reagent_containers/food/snacks/fish/clam = 50,
-		/obj/item/roguegem/oyster = 100, //Probably best to have one clam type instead of two, but whatever
 		/obj/item/reagent_containers/food/snacks/fish/clownfish = 40,
 		/obj/item/grown/log/tree/stick = 3,
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
@@ -52,6 +50,8 @@
 	// This is super trimmed down from the ratwood list to focus entirely on shellfishes
 	cageloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/oyster = 214,
+		/obj/item/roguegem/oyster = 150, //Probably best to have one clam type instead of two, but whatever
+		/obj/item/reagent_containers/food/snacks/fish/clam = 150,
 		/obj/item/reagent_containers/food/snacks/fish/shrimp = 214,
 		/obj/item/reagent_containers/food/snacks/fish/crab = 214,
 		/obj/item/reagent_containers/food/snacks/fish/lobster = 214,

--- a/code/modules/roguetown/roguejobs/fisher/worms.dm
+++ b/code/modules/roguetown/roguejobs/fisher/worms.dm
@@ -38,7 +38,6 @@
 		/obj/item/reagent_containers/food/snacks/fish/angler = 140,
 		/obj/item/reagent_containers/food/snacks/fish/lobster = 150,
 		/obj/item/reagent_containers/food/snacks/fish/bass = 210,
-		/obj/item/reagent_containers/food/snacks/fish/clam = 40,
 		/obj/item/reagent_containers/food/snacks/fish/clownfish = 20,
 		/obj/item/grown/log/tree/stick = 3,
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
@@ -61,6 +60,8 @@
 	// This is super trimmed down from the ratwood list to focus entirely on shellfishes
 	cageloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/oyster = 214,
+		/obj/item/roguegem/oyster = 150, //Probably best to have one clam type instead of two, but whatever
+		/obj/item/reagent_containers/food/snacks/fish/clam = 100,
 		/obj/item/reagent_containers/food/snacks/fish/shrimp = 214,
 		/obj/item/reagent_containers/food/snacks/fish/crab = 214,
 		/obj/item/reagent_containers/food/snacks/fish/lobster = 214,


### PR DESCRIPTION
## About The Pull Request
Adjusts the rarity of clams and gemcraft oysters, and makes them cage-only.

## Testing Evidence
<img width="771" height="533" alt="Fishing" src="https://github.com/user-attachments/assets/9bcc964f-9d6a-4f5e-937b-d59141751693" />

## Why It's Good For The Game
Okay, so currently you could fish clams which were a shellfish type with rods... and not with cages? It was weird, so they went to cage fishing only.

Also, the new gemcraftable oysters were way too rare and leeches only. This adjusts them to worms as well. You will still get them not as often as your other types of shellfish, but still decently enough. I got lucky with 3 of them in a sack full of fish at legendary fishing, for example. FYI, these things only go for like... 10 or so each. They're not that valuable on their own.

Currently, fishing is already incredibly profitable but I wanted a way to make use of all the cool gemcrafting recipes we have by giving fishermen an incentive to work toward to and peddle their shell wares. A clam gives you two shells, and they sell for about 5 or so each which is way less than any rare fish you fish up in the mean time. But you get more chances to RP out making custom items for people with shell jewelry and the like.

This is basically just letting fishers have a bit more fun with their catches instead of where it was previously with having the rarity on these things pretty damn low even at legendary fishing. It also gives people more incentive to cage fish, instead of pull out 1000 fish from the river in 10 minutes of fishing at legendary (cage fishing is much slower).
