### PR TITLE
Infestation Amulet Requirement

### DIFF
--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -173,7 +173,7 @@
 	movement_interrupt = FALSE
 	no_early_release = FALSE
 	devotion_cost = 50 // attack miracle
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross/pestra)
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	sound = 'sound/magic/whiteflame.ogg'
 	chargedloop = /datum/looping_sound/fliesloop
 	associated_skill = /datum/skill/magic/holy


### PR DESCRIPTION
## About The Pull Request

Changes the pestran amulet requirement of the Infestation miracle to any amulet.

## Testing Evidence

<img width="601" height="209" alt="image" src="https://github.com/user-attachments/assets/39b463cc-c17d-4fd5-ac4f-d0bfc26730ff" />
<img width="344" height="507" alt="image" src="https://github.com/user-attachments/assets/08e40358-8959-404f-9714-bc7faf436e6a" />


## Why It's Good For The Game

This enables for priests to be able to cast it. With its current state if you want to cast this you have to carry a pestran amulet as well. Even if you wear your own amulet and a pestran one at the same time. They can clash and render you unable to cast anything at all. With the church research rework being back people can now actually learn this as well I beleive.
