### PR TITLE
Oh shit I got my slurbow stolen!   Adds new foreign import weapons

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
@@ -70,3 +70,28 @@
 	name = "Aged Psydonian Longsword"
 	cost = 80
 	contains = list(/obj/item/rogueweapon/sword/long/oldpsysword)
+
+/datum/supply_pack/rogue/merc_weapons/oldslurbow
+	name = "Surplus Slurbow"
+	cost = 190 // high cost as it's quite good
+	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow/old)
+
+/datum/supply_pack/rogue/merc_weapons/fechtfeder
+	name = "Fechtfeder"
+	cost = 60 // it's a training sword
+	contains = list(/obj/item/rogueweapon/sword/long/frei)
+
+/datum/supply_pack/rogue/merc_weapons/longsabre
+	name = "Shalal Sabre"
+	cost = 80
+	contains = list(/obj/item/rogueweapon/sword/long/marlin)
+
+/datum/supply_pack/rogue/merc_weapons/estrucsword
+	name = "Basket-Hilted Longsword"
+	cost = 100
+	contains = list(/obj/item/rogueweapon/sword/long/etruscan)
+
+/datum/supply_pack/rogue/merc_weapon/ridingbow
+	name = "Aavnic Riding Bow"
+	cost = 90
+	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve/steppesman)


### PR DESCRIPTION
## About The Pull Request

Adds five new weapons to the foreign imports section of the merchant

Old Slurbow (No you aren't getting the actual slurbow)
Estrucan longsword, basically a prettier longsword
Shalal Sabre, a long sabre that desert riders (I think?) get
Aavanic riding bow, a bow thats pretty decent but almost never used
Fechtfeder. a training longsword that the swordthief wretch only spawns with for some reason, a shittier longsword meant for dueling


## Testing Evidence

<img width="495" height="818" alt="image" src="https://github.com/user-attachments/assets/f590b972-8732-40d4-ac7f-3c3c087424b7" />
Compiles or something like that

## Why It's Good For The Game

Me thinks that being able to replace unique weapons is pretty nice, now you don't need to go frag the dude who stole your slurbow and you can instead get it for a hefty price, and people can now buy one instead of having to steal it, or steal it anyways, whos going to stop you?

Including some new swords that don't get much love outside obscure mercenary/wretch classes, I've never actually seen the Fechtfeder ever used like once.
