### PR TITLE
Monster Hunter QOL

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -282,6 +282,7 @@
 		if("Slurbow") //WHOA!! Don't worry, they don't start with any crossbow skill or bonus PER. The Slurbow's description implies it's a common weapon for highwaymen, so it's not impossible to see it in the hands of an adventurer.
 			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow/old //their powered-down version of the inquisition slurbow
 			beltl = /obj/item/quiver/bolts
+			H.change_stat("perception", 3)
 	var/silver = list("Arming Sword","Short Sword", "Dagger","Tossblades")
 	var/silver_choice = input("Choose your silver, for slaying monsters.", "TAKE UP ARMS") as anything in silver
 	switch(silver_choice)


### PR DESCRIPTION
## About The Pull Request

Gives monster hunters +3 perception if they choose the slurbow as their primary weapon

## Testing Evidence

compiled +1 line change

## Why It's Good For The Game

Monster hunters currently get only 12 perception as a base stat and 14 if you choose the best perception statpack

Now monster hunters will get 15 perception as base going up to 17 if they choose a dedicated statpack meaning more damage and more fun for those who actually decide to use the slurbow, you shouldn't have to suffer for choosing the bow.
