### PR TITLE
Ties wretch stat bonus to outlaw status

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -84,6 +84,13 @@
 		if (!my_crime)
 			my_crime = "crimes against the Crown"
 		add_bounty(H.real_name, bounty_total, FALSE, my_crime, bounty_poster)
+		H.change_stat("strength", 1)
+		H.change_stat("perception", 1)
+		H.change_stat("intelligence", 1)
+		H.change_stat("constitution", 1)
+		H.change_stat("endurance", 1)
+		H.change_stat("speed", 1)
+		H.change_stat("fortune", 1)
 	if(bounty_face_noface == "No")
 		var/race = H.dna.species
 		var/gender = H.gender


### PR DESCRIPTION
## About The Pull Request
High effort balancejak PR. (Totally)
Original PR changed.
Wretches will only get their omnistat +1 bonus if they have chosen to have their face known (they're tagged as an outlaw)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="556" height="197" alt="image" src="https://github.com/user-attachments/assets/3f434ea5-de7f-4458-bdd7-de0b9707923c" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The game is currently in a state where wretches frequently gang up together into powerful groups of combatants.
If they're gonna do this and get their stat bonus, it should be made more clear that they are valid from the start, I suppose.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
