### PR TITLE
Xylix Takes The Wheel (Literally): Miracle versions of fetch & repel for Xylix clerics, monk psycross fix

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -201,14 +201,15 @@
 	desc = "The Laughing God, both famous and infamous for his sway over the forces of luck. Xylix is known for the inspiration of many a bards lyric. Speaks through his gift to man; the Tarot deck."
 	worshippers = "Gamblers, Bards, Artists, and the Silver-Tongued"
 	mob_traits = list(TRAIT_XYLIX)
-	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
-					/obj/effect/proc_holder/spell/self/xylixslip				= CLERIC_T0,
-					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/wheel					= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/mockery				= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/blood_heal			= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/mastersillusion		= CLERIC_T2,
-					/obj/effect/proc_holder/spell/invoked/wound_heal			= CLERIC_T4,
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison				= CLERIC_ORI,
+					/obj/effect/proc_holder/spell/self/xylixslip					= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 				= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/projectile/fetch/miracle 	= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/projectile/repel/miracle 	= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/mockery					= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/blood_heal				= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/mastersillusion			= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/wound_heal				= CLERIC_T4,
 	)
 	confess_lines = list(
 		"ASTRATA IS MY LIGHT!",

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -190,7 +190,7 @@
 			H.cmode_music = 'sound/music/combat_baotha.ogg'
 			ADD_TRAIT(H, TRAIT_HERESIARCH, TRAIT_GENERIC)
 		if(/datum/patron/divine/xylix)
-			neck = /obj/item/clothing/neck/roguetown/luckcharm
+			neck = /obj/item/clothing/neck/roguetown/psicross/xylix
 			H.cmode_music = 'sound/music/combat_jester.ogg'
 
 /datum/advclass/cleric/paladin

--- a/code/modules/spells/roguetown/acolyte/xylix.dm
+++ b/code/modules/spells/roguetown/acolyte/xylix.dm
@@ -222,3 +222,17 @@
 		if(prob(50))
 			playsound(H, pick(sounds), 100, TRUE)
 		return TRUE
+
+/obj/effect/proc_holder/spell/invoked/projectile/fetch/miracle
+	name = "Divine Fetch"
+	miracle = TRUE
+	devotion_cost = 10
+	invocation = null
+	associated_skill = /datum/skill/magic/holy
+
+/obj/effect/proc_holder/spell/invoked/projectile/repel/miracle
+	name = "Divine Repel"
+	miracle = TRUE
+	devotion_cost = 14
+	invocation = null
+	associated_skill = /datum/skill/magic/holy


### PR DESCRIPTION
## About The Pull Request

Don't see a lot of Xylix clerics around, and it's probably because their spell list is KIND OF ASS!!!!!

Wheel sucks and is so rarely used that most people have probably never seen it cast, let alone had it cast on them. So I've removed it from the Xylix patron list and replaced it with miracle versions of fetch and repel. I've also shunted their bloodbond tiering into T2 so they don't just get like every conceivably amazing spell right at T1 instead.

These use twice the amount of their arcyne version's stamina cost as devotion, which as highly spammable spells means that they're a realistic contender for chief devotion consumption on martial-based Xylix clerics. As an added bonus, they also don't have spoken incantations like the mage version of these spells.

Adventurer Xylix monks also start with a xylix psycross now instead of some weird +1 FOR granting lucky cabbit foot talisman. Technically a nerf? I guess?

## Testing Evidence

i compile da game, i logga in, i grabba da sack with fetch, i shoota da sack with fetch.

## Why It's Good For The Game

This does mean that between Xylixian slip, fetch and repel, Xylixian clerics can attain world-class levels of incredibly-difficult-to-pin down, which honestly, is sort of how they always should've been. They'll also be absolute fucking gluttons for devotion if they're regularly using all of these things, which means that they'll need to spend a fair bit of time not doing annoying shit to have the capability to do annoying shit.

Also Wheel really fucking sucked. Everybody who's played an acolyte before and hated one of their very limited miracle spells understands how much this sucks.