### PR TITLE
Blood and Vein-glory: Yielding reduces bleeding by 80% for 30 seconds

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -217,6 +217,11 @@
 		conbonus = STACON - 10
 	if(mind)
 		amt -= amt * (conbonus * CONSTITUTION_BLEEDRATE_MOD)
+
+	// if we are yielding, our total effective bloodloss is reduced by 80%. encourages people to like, capture dudes and stitch them up and stuff
+	if (has_status_effect(/datum/status_effect/debuff/submissive)) // WE CAN DO THIS NOW BECAUSE STATUS_EFFECTS ARE SUPER CHEAP! YAAAYYYY!!
+		amt = amt * 0.2
+	
 	var/old_volume = blood_volume
 	blood_volume = max(blood_volume - amt, 0)
 	if (old_volume > 0 && !blood_volume) // it looks like we've just bled out. bummer.


### PR DESCRIPTION
## About The Pull Request

Simple but potentially world-changing PR; yielding in combat reduces your effective blood loss by 80% for the next 30 seconds (while you retain the submissive debuff).

This gives captors a chance to perform the appropriate life-saving maneuvers where appropriate and gives people a reason to yield in order to better improve their chances at staying in the round.

People are going to use this to stay alive longer in ordinary circumstances by themselves and that's fine since you're hardstunning yourself for 30 seconds (and adding a serious multiplicative slowdown) to do it.

NOTE: this does not actually literally REDUCE your bleeding. If you have like three arterial wounds when that 30 seconds is up, you're still probably fucked.

## Testing Evidence

it compiles. one-liners

## Why It's Good For The Game

People should die when they are killed, but giving people ways to not die before they're killed is pretty good and cool and keeps people doing roleplaying in the roleplaying game for longer.
