### PR TITLE
Court Magos QoL changes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -56,11 +56,10 @@
 		/datum/skill/craft/alchemy = SKILL_LEVEL_MASTER,
 		/datum/skill/magic/arcane = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/polearms = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_NOVICE,
-		/datum/skill/misc/athletics = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
@@ -96,7 +95,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	beltr = /obj/item/storage/keyring/mage
 	beltl = /obj/item/storage/magebag/starter
-	id = /obj/item/clothing/ring/gold
+	id = /obj/item/scomstone
 	r_hand = /obj/item/rogueweapon/woodstaff/riddle_of_steel/magos
 	backl = /obj/item/storage/backpack/rogue/satchel
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Increases Polearms from Novice to Apprentice (why this was ever like this, and never changed, is beyond me)
Increases Athletics from Novice to Apprentice
Removes Swords apprentice (rarely used and you need knight training regardless if you want swords to be viable with this class)
Replaces gold ring (???) with Scomstone

## Testing Evidence

It's like 4 lines, if it doesn't work, I'll eat my shoe live on stream

## Why It's Good For The Game

This isn't crazy balancejakking, more quality of life improvements for court magos. Already a busy role, it's annoying to have to worry about hitting a training dummy at the start of every round for apprentice polearms. Similarly, athletics feels goofy to level as an esteemed mage, by running in circles for twenty minutes, and they desperately need the extra five points of stamina.

Stewards, and even court physicians, get a scomstone, and the court mage is often out of the loop on pretty much anything, so a scomstone should make them easier to reach and communicate with. 