### PR TITLE
Race Desc Shortening

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -259,7 +259,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	ResetJobs()
 	if(user)
 		if(pref_species.desc)
-			to_chat(user, "[pref_species.desc]")
+			to_chat(user, "[pref_species.shortdesc ? "[pref_species.shortdesc]<br><a href='?_src_=prefs;preference=racelorehelp;task=input'>Read More</a>" : "[pref_species.desc]"]")
 		to_chat(user, "<font color='red'>Classes reset.</font>")
 	random_character(gender, FALSE, FALSE)
 	accessory = "Nothing"
@@ -1817,6 +1817,12 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					dat +="<b>Origin Description:</b><br>"
 					dat += "[virtue_origin.origin_desc]"
 					var/datum/browser/popup = new(user, "Race Help", nwidth = 600, nheight = 450)
+					popup.set_content(dat.Join())
+					popup.open(FALSE)
+				if("racelorehelp")
+					var/list/dat = list()
+					dat += "[pref_species.desc]"
+					var/datum/browser/popup = new(user, "[pref_species.name]", nwidth = 600, nheight = 450)
 					popup.set_content(dat.Join())
 					popup.open(FALSE)
 				if("skin_color_ref_list")

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/clothes_id //id for clothes
 	var/name	// this is the fluff name. these will be left generic (such as 'Lizardperson' for the lizard race) so servers can change them to whatever
 	var/desc
+	var/shortdesc // Short description to show upon selecting the race. Defaults to desc if not set.
 	var/default_color = "#FFF"	// if alien colors are disabled, this is the color that will be used by that race
 	var/limbs_icon_m
 	var/limbs_icon_f

--- a/code/modules/mob/living/carbon/human/species_types/species/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/human/humen.dm
@@ -8,15 +8,15 @@
 	origin_default = /datum/virtue/origin/grenzelhoft
 	origin = "Grenzelhoft"
 	sub_name = "Northern Humen"
+	shortdesc = "<b>Humen</b><br>\
+	Humens are a well-known, populous race. Numerous cities of the world teem with their numbers, and just as many ruins show marks of their craftsmanship.<br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 END | +1 INT</b></span>"
 	desc = "<b>Humen</b><br>\
-	Humens (or \"Humans\") are the eldest of the Weeping God's creations. Noted for their \
-	tenacity and overwhelming population, humens are the most commonly seen race across the lands, \
-	at a rate of about ten to one in regions such as Grenzelhoft. However, to the west \
-	the opposite is true. Humens come from a vast swathe of cultures and ethnicities, most of which \
-	have historically been at odds with one another. Being the eldest creations of the Weeping God, humens \
-	tend to find fortune easier than the other races, and are so diverse that no other racial traits \
-	are dominant in their species.<br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 END | +1 INT</b></span> </br>"
+	Humens are a well-known, populous race. Numerous cities of the world teem with their numbers, and just as many ruins show marks of their craftsmanship.<br>\
+	As a people, humens are creatures of contradiction: stubborn but adaptable, social yet bellicose. Their goals are as mercurial and short-lived as they are.<br>\
+	The current era of history is undoubtedly theirs, for however long that may be.<br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 END | +1 INT</b></span> <br><br>\
+	<span style='color: #8B0000'>The Ascendant Matthios, patron of the greedy, rose from the ranks of the humen race. Many other races consider this indicative of Humenity's nature as rude, avaricious beings.</span>"
 
 	skin_tone_wording = "Ancestry"
 

--- a/code/modules/mob/living/carbon/human/species_types/species/moth.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/moth.dm
@@ -8,12 +8,18 @@
 	origin_default = /datum/virtue/origin/racial/underdark
 	origin = "the Underdark"
 	base_name = "Beastvolk"
+	shortdesc = "<b>Fluvian</b><br>\
+	An insectoid species native to the Underdark. Indigenous to Effluvia, a loathsome underground region known for its poisonous waters.<br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 SPD | -1 CON</b></span> </br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>Long Jump | Can Eat Clothes</b></span>"
 	desc = "<b>Fluvian</b><br>\
-	Many comparisons have been made to the common moths in an attempt to describe this unique species. From the appetite for clothing to the disconcertingly insectoid appearance, \
-	the name 'Moth' is forever stamped onto the common vocabulary. The comparison, however, falls short on the matter of flight. This species generally congregates within lichen-laden \
-	cave regions or lush forests, given their capacity to digest fiber, and many Fluvian artisans take up the art of clothwork to create expensive export goods from cloth or silk (the latter \
-	of which is found in abundance from the spiders often near their settlements). <br>\
-	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 SPD</b></span> </br>"
+	An insectoid species native to the Underdark. Indigenous to Effluvia, a loathsome underground region known for its poisonous waters.<br>\
+	Fluvians are known as the archetypal species for drow slaves, few surface-dwellers realize they have a city of their own: \
+	The sole settlement in Effluvia, Mercuriam. It is here that Pestra's arts are honored; \
+	only the educated are allowed to pass its bronze gates. Denied fluvians must eke out a primitive life in the rotting wilds of Effluvia.<br>\
+	According to the fluvians of Mercuriam, their god, Pestra, has not yet been born. She lies in a nascent cocoon, bestowing wisdom from a time to come.<br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> +1 SPD | -1 CON</b></span> </br>\
+	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b> Long Jump | Can Eat Clothes</b></span>"
 
 	species_traits = list(EYECOLOR,LIPS,MUTCOLORS,HAIR)
 	possible_ages = ALL_AGES_LIST


### PR DESCRIPTION


## About The Pull Request

Shortens Humen & Fluvian racial descriptions and adds a 'read more' button to read the full description. Only does these two for now, the rest will wait upon the lore maintainer's consensus and for them to be re-written. Which will probably take a bit.
So this implements the system for future use and adds some examples.

Races without short descriptions just send their full description in chat.

## Testing Evidence

<img width="1279" height="736" alt="image" src="https://github.com/user-attachments/assets/d5bfeb22-d452-44c4-8286-c811bf12e7a7" />

## Why It's Good For The Game

Makes race descriptions more readable while still allowing space for more detailed history and descriptions.
