### PR TITLE
Fix Player-Made Bounties

### DIFF
--- a/code/modules/roguetown/roguemachine/bounty.dm
+++ b/code/modules/roguetown/roguemachine/bounty.dm
@@ -166,16 +166,16 @@
 	SStreasury.log_entries += "+[royal_tax] to treasury (bounty tax)"
 
 	amount -= royal_tax
-
+/*
 	var/race = target.dna.species
 	var/gender = target.gender
 	var/list/d_list = target.get_mob_descriptors()
 	var/descriptor_height = build_coalesce_description_nofluff(d_list, target, list(MOB_DESCRIPTOR_SLOT_HEIGHT), "%DESC1%")
 	var/descriptor_body = build_coalesce_description_nofluff(d_list, target, list(MOB_DESCRIPTOR_SLOT_BODY), "%DESC1%")
 	var/descriptor_voice = build_coalesce_description_nofluff(d_list, target, list(MOB_DESCRIPTOR_SLOT_VOICE), "%DESC1%")
-
+*/
 	// Finally create bounty
-	add_bounty(target.real_name, race, gender, descriptor_height, descriptor_body, descriptor_voice, amount, FALSE, reason, user.real_name)
+	add_bounty(target.real_name, amount, FALSE, reason, user.real_name)
 
 	//Announce it locally and on scomm
 	playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)


### PR DESCRIPTION
## About The Pull Request

Fixes this [bug](https://github.com/Scarlet-Reach/Scarlet-Reach/issues/1740) which both displayed bounties incorrectly, and also seemed to prevent them from being claimed by the CASTIFICO (from my own, limited testing anyway).

## Testing Evidence

Here it is now displaying properly
<img width="374" height="56" alt="image" src="https://github.com/user-attachments/assets/72b284aa-c054-48d2-92f7-79809684e371" />

And the CASTIFICO claiming the player-placed bounty
<img width="545" height="143" alt="image" src="https://github.com/user-attachments/assets/e27a8a91-ed93-460e-8ce8-87faaeef78f0" />


## Why It's Good For The Game

Features should work as intended, and it's also good to let players be a bit mean to each other.