### PR TITLE
A very specific bandaid for wandering monk

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -124,7 +124,7 @@
 		if("Knuckle Dusters")
 			backpack_contents += list(/obj/item/rogueweapon/knuckles/bronzeknuckles = 1)
 		if("Quarterstaff")
-			H.put_in_hands(new /obj/item/rogueweapon/woodstaff/quarterstaff/steel(H), TRUE)
+			r_hand = (/obj/item/rogueweapon/woodstaff/quarterstaff/steel)
 			H.adjust_skillrank(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/unarmed, SKILL_LEVEL_NOVICE, TRUE)
 	H.cmode_music = 'sound/music/combat_holy.ogg' // left in bc i feel like monk players want their darktide


### PR DESCRIPTION
## About The Pull Request
Zizo ate my weapon in 2 rounds out of 5, i am ANGEREY.
Slight change of how wandering monk gets his roundstart weapon due to a funny bug:
If you choose your weapon during initial stunned period - you will not get it. Using either r_hand or available back slot fixes that, chose the former.
## Testing Evidence
1. Oneliner
2. 
<img width="336" height="117" alt="image" src="https://github.com/user-attachments/assets/4d993f01-8621-4596-a9ab-a3ba7d2eea9d" />

## Why It's Good For The Game

It is somewhat easy to be left without a weapon if you click too fast, especially during roundstart of highpop rounds, where tidi is the highest it can be. And i can't be the only suffering.