### PR TITLE
Allows artificers to create all existing SCOM stones

### DIFF
--- a/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
+++ b/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
@@ -180,37 +180,44 @@
 
 // ------------ Rings ----------------
 /datum/anvil_recipe/engineering/serfstone
-	name = "Serf Stone (+1 cog, +1 Topar)"
-	req_bar = /obj/item/ingot/steel
+	name = "Serf Stone (+1 cog, +1 Toper)"
+	req_bar = /obj/item/ingot/bronze
 	additional_items = list(/obj/item/roguegear, /obj/item/roguegem/yellow) //using topar since the description calls it a "dull gem"
 	created_item = /obj/item/scomstone/bad
 	craftdiff = 5
 
-/*	For future updates, if people like the serfstones
+
 /datum/anvil_recipe/engineering/houndstone
-	name = "Houndstone (+1 cog, +1 Topar)"
-	req_bar = /obj/item/ingot/Steel
-	additional_items = list(/obj/item/roguegear, /obj/item/roguegem/yellow)
+	name = "Houndstone (+1 Purified Alloy, +1 Cog, +1 Rontz)"
+	req_bar = /obj/item/ingot/gold
+	additional_items = list(/obj/item/ingot/purifiedaalloy, /obj/item/roguegear, /obj/item/roguegem/ruby)
 	created_item = /obj/item/scomstone/bad/garrison
 	craftdiff = 5
 
 /datum/anvil_recipe/engineering/scomstone
-	name = "SCOM Stone (+1 cog, +1 Gemerald, Arcyne)"
-	req_bar = /obj/item/ingot/Gold
-	additional_items = list(/obj/item/roguegear, /obj/item/roguegem/green)
+	name = "SCOM Stone (Arcyne, +1 Cog, +1 Gold, +1 Gemerald)"
+	req_bar = /obj/item/ingot/gold
+	additional_items = list(/obj/item/roguegear, /obj/item/ingot/gold, /obj/item/roguegem/green)
 	created_item = /obj/item/scomstone
-	skillcraft = /datum/skill/magic/arcane
+	appro_skill = /datum/skill/magic/arcane
 	craftdiff = 5
 
 /datum/anvil_recipe/engineering/emeraldchoker
-	name = "emerald choker (+1 cog, +Gold, +1 Gemerald, Arcyne)"
-	req_bar = /obj/item/ingot/Gold
-	additional_items = list(/obj/item/roguegear, /obj/item/ingot/Gold, /obj/item/roguegem/green)
+	name = "emerald choker (Arcyne, +1 Cog, +1 Gold, +1 Gemerald)"
+	req_bar = /obj/item/ingot/gold
+	additional_items = list(/obj/item/roguegear, /obj/item/ingot/gold, /obj/item/ingot/iron, /obj/item/roguegem/green)
 	created_item = /obj/item/scomstone/listenstone
-	skillcraft = /datum/skill/magic/arcane
+	appro_skill = /datum/skill/magic/arcane
 	craftdiff = 5
-	*/
+	
 
+/datum/anvil_recipe/engineering/crownstone
+	name = "Crownstone (Arcyne, Houndstone, +2 Purified Alloy, +1 Gold, +1 Cog, +1 Rontz, +2 Dorpel)"
+	req_bar = /obj/item/ingot/gold
+	additional_items = list(/obj/item/scomstone/bad/garrison, /obj/item/ingot/purifiedaalloy, /obj/item/ingot/purifiedaalloy, /obj/item/ingot/gold, /obj/item/roguegear, /obj/item/roguegem/ruby, /obj/item/roguegem/diamond, /obj/item/roguegem/diamond)
+	created_item = /obj/item/scomstone/garrison
+	appro_skill = /datum/skill/magic/arcane
+	craftdiff = 6
 
 //golem skill up component, check golem.dm
 /datum/anvil_recipe/engineering/golem_skill_core


### PR DESCRIPTION
## About The Pull Request
This was in the files but disabled, I've enabled it and balanced it as best as I can, but I expect this PR to either be shut down or balanced heavily. I take no hard feelings.

Ideally I'd have some of these recipes use two skills as requirements, but that's not something anvil_recipes supports at the moment. If this becomes the deciding factor, then I will refactor it.

**Serfstone:**
- Changed from iron ingot to bronze ingot just so artificers know it's there
- Recipe is unchanged. It's still cheap. it's still just.. Whatever it is.
- Still needs lv5 Engineering

**SCOMstone & Emerald Choker**
- At 2 gold bars and a gemerald, this brings them to around the same price if not lower than what you'd get at a Merchant. They need Lv5 Arcane, when Artificers start with Lv2.
- Overall, I don't expect Artificers to make these until an hour into the round just based on the skill requirements.
- A mage (or the court mage) could be made to come around and make them
- Antagonists could also make these, since they have a lot of mages that start at lv4 arcane- Assuming they get 2 gold bars and a gemerald(not difficult for wretches, I know).

The big ones:
**Houndstone**
- One gold bar, one purified alloy, and a rontz. 
- This brings it to roughly the same price you'd get when importing the 3 pack from the steward. 
- Purified alloy is also annoying to make and I imagine not many people know how. It needs a great forge, and even if you do have a great forge a houndstone still needs Lv5 Engineering to make, not the arcane skill. This locks out antags from creating it unless they grind the engineering level, which I don't expect anyone but malumites to do.

**Crownstone**
- This needed to be expensive, so I unashamedly kept throwing gems into the recipe until it felt right.
- Requiring a houndstone means that antagonists cannot go around the fact that you either need to steal a houndstone or have lv5 engineering. Lv6 Arcane alone will not help you.
- This also still requires purified alloy, so a great forge will be necessary. 
- At 2 dorpels, 1 rontz, and a houndstone, not to mention the four raw gold ore you'd need, this roughly brings the crownstone to a pricepoint of around 1,000 mammons if purchasing everything- Depending on how much the merchant cheats you this could go higher. 
- I believe a 400 mammon discount compared to importing it is a fair price for all the tedious requirements it needs to be made.

**Why Arcane on some?**
- I don't know. The original creator had it set to arcane and it seemed right to me. It shouldn't be easy to make by anybody and SCOMs seemed to be the field of the arcane.
- Plus, let's not forget that you can actually make SCOMs with arcana crafting right now, so it's not too far fatched.
- This does open the window for the guild to ask mages to come in and make SCOMstones instead of having an artificer train up for it
- I don't know how this will go, to be honest. I'm excited to see it but I'm also pensive. I'm willing to have this tested and fully scrapped if it doesn't go well. It is a big change.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
### RECIPES WERE CHANGED, SCREENSHOTS JUST TO PROVE IT WAS WORKING!!!
<img width="659" height="176" alt="image" src="https://github.com/user-attachments/assets/ae1bbb40-eda3-45c0-987d-4d64033c801f" />

### RECIPES WERE CHANGED, SCREENSHOTS JUST TO PROVE IT WAS WORKING!!!
<img width="2075" height="1039" alt="image" src="https://github.com/user-attachments/assets/e348ee50-7dd2-4056-bb11-2455e2816c92" />

Some screenshots may not match current code. I altered some recipes after testing.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It adds an end-goal to artificers beyond just making masterwork lockpicks and bronze grapplers. The role is... Unfinished. I don't think I'll be the one to finish it, but I saw these recipes commented out and wanted to breath some life into it.

I'm also aware that previously in the lifespan of the server, public SCOMs were disabled. This might see a resurgence of more people using the SCOM as artificer players crank out SCOMstones. However, I believe their current cost does not justify any means of mass production, and they will continue to be rarely bought or made and remain a luxury. You may see more serfstones, though.

(Also the emerald choker is a fire design).
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
