### PR TITLE
Noc blindness removal

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -43,7 +43,6 @@
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/invoked/blood_heal			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/invoked/invisibility/miracle	= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/blindness				= CLERIC_T2,
 					/obj/effect/proc_holder/spell/self/noc_spell_bundle			= CLERIC_T3,
 					/obj/effect/proc_holder/spell/invoked/wound_heal			= CLERIC_T4,
 	)


### PR DESCRIPTION
## About The Pull Request

Bad spell. Has to go. Can't be balanced - no degree of chaincasting soft CC this oppressive can be reasonably balanced in a way that makes it worth having and not also worth spamming.

## Testing Evidence

one-liner

## Why It's Good For The Game

Watched two fights today where someone spent pretty much a full minute or more just chain-blinded by a random passing-by acolyte with no prelude or counterplay available to them. We can do better than this.
