### PR TITLE
Paladins automatically regenerate devotion (like every other cleric class)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -343,7 +343,7 @@
 			head = /obj/item/clothing/head/roguetown/helmet/heavy/bucket
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
+	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
 	var/weapons = list("Longsword","Mace","Flail")
 	var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	switch(weapon_choice)


### PR DESCRIPTION
## About The Pull Request

Gives paladins some basic devotion regen, equivalent to what monk gets. Previously, they had none.

## Testing Evidence

one-liner

## Why It's Good For The Game

It is absolute hell on earth to play a miracle class in 2025 that doesn't have devotion regen. Nobody enjoys spamming prayer do_afters silently for 10 minutes to be able to play the game.
