### PR TITLE
Adds 3 New Witch Forms!

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
@@ -94,7 +94,7 @@
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/witch/lesser_wolf)
 			if("Lesser Vernard")
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/witch/lesser_vernard)
-			if("Rous")
+			if("Small Rous")
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/witch/rous)
 			if("Cabbit")
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/witch/cabbit)


### PR DESCRIPTION
## About The Pull Request
Adds 3 new forms for witches to choose:
- Lesser Vernard! The fox form, much like the lesser volf... it is technically weaker than it by a small margin in terms of damage.
- Cabbit! This is 1 con weaker than the cat form. It has more speed, though.
- Small Rous! This one was for fun. You are as fast as the cabbit, but you're way weaker and will likely shapeshift out with 1 hit in trade of a small hitbox. Consider it your challenge form. If I could add a way for people to pick you up and put you in their pocket I would.

## Testing Evidence
<img width="329" height="404" alt="Witch" src="https://github.com/user-attachments/assets/538ff145-9b90-476f-8011-f0b2b1dc06b6" />

## Why It's Good For The Game
Witch is one of my favorite towner classes, and it needs more forms. Currently there are no sprites for the spell scrolls of the new forms, but it all runs and should be fine for now. Since the witch can only pick one form, and it is mostly flavor preference when picking, this addition should be harmless.

If the slightly boosted speed on cabbit and rous ends up too much (which it didn't feel like in testing), then I will equal it out to the rest of them.
