### PR TITLE
high perception matters more for pickpocket defense

### DIFF
--- a/code/game/objects/items/rogueweapons/intents/mmb/steal.dm
+++ b/code/game/objects/items/rogueweapons/intents/mmb/steal.dm
@@ -25,10 +25,10 @@
 			to_chat(user, span_notice("[target_human] is tense and is more likely to detect me."))
 
 		if(HAS_TRAIT(user, TRAIT_CULTIC_THIEF)) // Matthios blesses his devout with rolling advantage on thieving checks.
-			advantageroll = roll("1d12") + (thiefskill * 2) + (user.STASPD / 3)
+			advantageroll = roll("1d10") + (thiefskill * 2) + (user.STASPD / 3)
 		
 		// Used for showing fail chance.
-		var/chance2steal = max(round(((12 + (thiefskill * 2) + (user.STASPD / 3) - (targetperception)) / 12 ) * 100, 1), 0)
+		var/chance2steal = max(round(((10 + (thiefskill * 2) + (user.STASPD / 3) - (targetperception)) / 10 ) * 100, 1), 0)
 
 		//Mathematically:
 		// SPD stat is to give an initial baseline to lower skilled thieves and reward speedy thieves slightly.


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

adds perception above 10 twice to perception, effectively doubling the impact it has in terms of resisting a pickpocket attempt.

This basically means someone at 15 perception is much, much harder to steal from than 10 perception now.

this essentially means that its impossible to pickpocket from people with 20 perception.

decreases the upper bounds of the part roll as well to 1d10 from 1d12.

## Testing Evidence

Compiles and runs.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

while it is true that anyone specced into perception has basically a 100% chance of noticing the theft afterwards those who do should be more resistant to pickpocketing as it is currently. Which, was an oversight on my part as I shifted the mechanic more towards "are you noticed after the fact" rather than "are you prevented from pickpocketing at all"
