### PR TITLE
Removes the short satchel from loadout selection

### DIFF
--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -35,10 +35,6 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Hand Mirror"
 	path = /obj/item/handmirror
 
-/datum/loadout_item/short_satchel
-	name = "Short Satchel"
-	path = /obj/item/storage/backpack/rogue/satchel/short
-
 //HATS
 /datum/loadout_item/shalal
 	name = "Keffiyeh"


### PR DESCRIPTION
## About The Pull Request

Short satchels are a 3x3 storage item that can be equipped in hip slots. This is a no-brainer pick that gives an obvious mechanical advantage and shouldn't be available in the loadout.

## Testing Evidence

<img width="396" height="87" alt="image" src="https://github.com/user-attachments/assets/1d53fea8-c206-4474-813f-0786cf122085" />

## Why It's Good For The Game

Loadout items are for cosmetics. Offering significant mechanical advantages through loadouts forces players to make a choice between cosmetics and gamer gear, which we don't want. 