### PR TITLE
Makes the steel chain skirt medium armor, plate tassets heavy armor

### DIFF
--- a/code/modules/clothing/rogueclothes/pants.dm
+++ b/code/modules/clothing/rogueclothes/pants.dm
@@ -465,7 +465,6 @@
 	desc = "A knee-length mail skirt, warding cuts against the thighs without slowing the feet."
 	icon_state = "chain_skirt"
 	item_state = "chain_skirt"
-	armor_class = ARMOR_CLASS_MEDIUM
 	grid_height = 32
 	grid_width = 64
 
@@ -475,7 +474,6 @@
 	gender = PLURAL
 	icon_state = "plate_skirt"
 	item_state = "plate_skirt"
-	armor_class = ARMOR_CLASS_HEAVY
 	grid_height = 64
 	grid_width = 64
 


### PR DESCRIPTION
## About The Pull Request

Changes steel chain skirts to medium armor and grants them groin coverage, making them in-line with the steel chausses since they have the same armor values. Does the same with steel plate tassets.

## Testing Evidence

<img width="398" height="71" alt="image" src="https://github.com/user-attachments/assets/151b0cc3-a6d3-4cea-9973-3ed879abae1e" />

## Why It's Good For The Game

Light-tier armor should not be getting medium-tier protection. Medium-tier armor should not be getting heavy-tier protection. This makes them cosmetic options, and opens up the option of a future PR that gives knights pants or skirts depending on clothing preference.