### PR TITLE
Fix WW name jank

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -40,8 +40,6 @@
 
 	// Werewolf reverts to human form during the day
 	else if(transformed)
-		H.real_name = wolfname
-		H.name = wolfname
 
 		if(GLOB.tod != "night")
 			if(!untransforming)
@@ -91,6 +89,12 @@
 	W.gender = gender
 	W.regenerate_icons()
 	W.stored_mob = src
+
+	// Set the werewolf's name from the antagonist datum
+	var/datum/antagonist/werewolf/Were = mind.has_antag_datum(/datum/antagonist/werewolf/)
+	if(Were)
+		W.real_name = Were.wolfname
+		W.name = Were.wolfname
 	W.limb_destroyer = TRUE
 	W.ambushable = FALSE
 	W.cmode_music = 'sound/music/combat_druid.ogg'


### PR DESCRIPTION
## About The Pull Request

Copying this [PR](https://github.com/Azure-Peak/Azure-Peak/pull/4755) from Azure that makes the name change happen only after checking if you still have the werewolf antag datum. No more getting stuck with your WW name after dying and being revived, hopefully.

## Testing Evidence

The Azure coder took a video of their testing, and I copied their code exactly. I did test it on a localhost and it worked the same, but I should probably get video recording software myself.

## Why It's Good For The Game

It's a bit annoying to be stuck with your WW name after being killed and cured.
