### PR TITLE
Gives princes the consort crown instead of circlet

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -82,7 +82,7 @@
 
 	if(equipment_choice == "Wartime Outfit")
 		// Original daring twit equipment
-		head = /obj/item/clothing/head/roguetown/circlet
+		head = /obj/item/clothing/head/roguetown/nyle/consortcrown
 		armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/royal
 		pants = /obj/item/clothing/under/roguetown/tights
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
@@ -101,7 +101,7 @@
 			shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/prince
 		if(should_wear_femme_clothes(H))
 			shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/princess
-		head = /obj/item/clothing/head/roguetown/circlet
+		head = /obj/item/clothing/head/roguetown/nyle/consortcrown
 		belt = /obj/item/storage/belt/rogue/leather/cloth/lady
 		beltr = /obj/item/storage/keyring/heir/warrior
 		beltl = /obj/item/rogueweapon/huntingknife/idagger/steel/special
@@ -143,7 +143,7 @@
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/prince
 	if(should_wear_femme_clothes(H))
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/princess
-	head = /obj/item/clothing/head/roguetown/circlet
+	head = /obj/item/clothing/head/roguetown/nyle/consortcrown
 	belt = /obj/item/storage/belt/rogue/leather/cloth/lady
 	beltr = /obj/item/storage/keyring/heir/mage
 	beltl = /obj/item/rogueweapon/huntingknife/idagger/steel/special
@@ -182,7 +182,7 @@
 
 /datum/outfit/job/heir/aristocrat/pre_equip(mob/living/carbon/human/H)
 	..()
-	head = /obj/item/clothing/head/roguetown/circlet
+	head = /obj/item/clothing/head/roguetown/nyle/consortcrown
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/storage/keyring/heir
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
@@ -231,7 +231,7 @@
 
 /datum/outfit/job/heir/inbred/pre_equip(mob/living/carbon/human/H)
 	..()
-	head = /obj/item/clothing/head/roguetown/circlet
+	head = /obj/item/clothing/head/roguetown/nyle/consortcrown
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/storage/keyring/heir
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich


### PR DESCRIPTION
## About The Pull Request

As stated in the title gives all prince subclasses and base prince class the gem encrusted crown, the one that suitors and the consort get instead of a gold circlet

## Testing Evidence

1-line change, shouldn't break I hope

## Why It's Good For The Game

Gives princes a proper crown instead a gold circlet that can be bought by anyone at the merchant to make them more unique in that they are a role with considerable power, the outfit should show that instead of something anyone can mimic for 100 mammons at the merchan.

