### PR TITLE
it’s ogre

### DIFF
--- a/code/modules/jobs/job_types/roguetown/ogre/ogre.dm
+++ b/code/modules/jobs/job_types/roguetown/ogre/ogre.dm
@@ -3,8 +3,8 @@
 	flag = OGRE
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	allowed_races = OGRE_RACE_TYPES
 	allowed_sexes = list(MALE, FEMALE)
 	tutorial = "You are a migrating ogre from Gronn or another province of the world. Only recently have ogres begun to find their way into this region, and it smells of opportunity and a good meal. From Grenzelhoft to Naledi, all know the value of an ogre, and to fear a hungry one even more"


### PR DESCRIPTION
Temporarily disables ogre slots entirely until they are reworked. 

## Testing Evidence

It works. 

## Why It's Good For The Game
There’s no sense leaving them at an anemic 2 and it’s been discussed to death that they need a rework to function as they’re currently nonfunctional. 

Best to turn them off temporarily until TiredGuy has them fixed. 
