### PR TITLE
Comments Nets

### DIFF
--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -157,7 +157,7 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 		/datum/crafting_recipe/roguetown/survival/stonespear,
 		/datum/crafting_recipe/roguetown/survival/stonesword,
 		/datum/crafting_recipe/roguetown/survival/pot,
-		/datum/crafting_recipe/roguetown/survival/net,
+		//datum/crafting_recipe/roguetown/survival/net,
 		)
 
 	AddElement(

--- a/code/game/objects/items/rogueitems/ropechainbola.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola.dm
@@ -24,7 +24,7 @@
 	. = ..()
 	var/static/list/slapcraft_recipe_list = list(
 		/datum/crafting_recipe/roguetown/survival/ropebelt,
-		/datum/crafting_recipe/roguetown/survival/net,
+		//datum/crafting_recipe/roguetown/survival/net,
 		/datum/crafting_recipe/roguetown/survival/billhook,
 		/datum/crafting_recipe/roguetown/survival/goedendag,
 		/datum/crafting_recipe/roguetown/survival/rucksack,

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_ranged.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_ranged.dm
@@ -120,10 +120,10 @@
 					/obj/item/quiver/sling/iron,
 				)
 
-/datum/supply_pack/rogue/ranged_weapons/net
+/*/datum/supply_pack/rogue/ranged_weapons/net
 	name = "Net"
 	cost = 20
 	contains = list(
 					/obj/item/net,
 					/obj/item/net
-				)
+				)*/

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -58,22 +58,14 @@
 	if(!skipcatch)	//ugly, but easy
 		if(can_catch_item())
 			if(istype(AM, /obj/item))
-				if(!istype(AM, /obj/item/net))
-					var/obj/item/I = AM
-					if(isturf(I.loc))
-						I.attack_hand(src)
-						if(get_active_held_item() == I) //if our attack_hand() picks up the item...
-							visible_message("<span class='warning'>[src] catches [I]!</span>", \
-											"<span class='danger'>I catch [I] in mid-air!</span>")
-							throw_mode_off()
-							return 1
-				else
-					var/obj/item/net/N
-					visible_message("<span class='warning'>[src] tries to catch \the [N] but gets snared by it!</span>", \
-									"<span class='danger'>Why did I even try to do this...?</span>") // Hahaha dumbass!!!
-					throw_mode_off()
-					N.ensnare(src)
-					return
+				var/obj/item/I = AM
+				if(isturf(I.loc))
+					I.attack_hand(src)
+					if(get_active_held_item() == I) //if our attack_hand() picks up the item...
+						visible_message("<span class='warning'>[src] catches [I]!</span>", \
+										"<span class='danger'>I catch [I] in mid-air!</span>")
+						throw_mode_off()
+						return 1
 	..()
 
 

--- a/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
@@ -1,4 +1,4 @@
-/datum/crafting_recipe/roguetown/survival/net
+/*/datum/crafting_recipe/roguetown/survival/net
     name = "net"
     category = "Ranged"
     result = /obj/item/net
@@ -8,7 +8,7 @@
         /obj/item/natural/stone = 3,
         )
     verbage_simple = "braid"
-    verbage = "braids"
+    verbage = "braids"*/
 
 /datum/crafting_recipe/roguetown/survival/bowstring
     name = "fiber bowstring"


### PR DESCRIPTION
## About The Pull Request
This PR removes throwing nets from crafting and imports for the following reasons:

- Nets do not currently respect the thrown object deflection system (accessed by swinging a weapon moments before you are hit), and will ensnare you regardless, often to buggy effect.
- Nets will sometimes permanently debuff you, with the status effect remaining even after you have snapped it or slipped out of it.
- Resisting out of a net shares the same click cooldown as attempting to resist out of handcuffs, which is to say: After resisting out of a net, you cannot click anything for ten seconds.
- Lack of visual feedback for being ensnared means someone can be netted in a hectic fight and simply not know.
- Toggling throw to catch a net just gives you a snarky message and ensnares you anyway, often resulting in glitches. This PR lays the groundwork for fixing nets by removing that, as well.
- General lack of counterplay compounds on all the aforementioned bugs and issues.


While these were fine for as long as nets remained an obscure item that not many people used, they have recently gained an uptick in usage. With all that said, they will be disabled until someone volunteers to rework them.

## Testing Evidence
It compiles.

## Why It's Good For The Game
See the 'About The Pull Request' section.
