### PR TITLE
Rosa Crown + Fancy Coat to Loadout

### DIFF
--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -136,6 +136,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Rosa Crown"
 	path = /obj/item/flowercrown/rosa
 
+/datum/loadout_item/salviacrown
+	name = "Salvia Crown"
+	path = /obj/item/flowercrown/salvia
+
 
 //CLOAKS
 /datum/loadout_item/tabard


### PR DESCRIPTION
## About The Pull Request
Adds the following to loadout selectables:
- Rosa Crown
- Salvia Crown
- Fancy Coat

## Testing Evidence
<img width="636" height="569" alt="Rosacrownloadout" src="https://github.com/user-attachments/assets/1c0435bf-4083-4f51-b7f5-5b0a7c3498e7" />

## Why It's Good For The Game
I am pretty sure someone mentioned the rosa crown not being a loadout item, despite its popularity. The fancy coat is nice too. I also added the salvia crown on request. These are in the RW codebase's loadout list so I don't see why not here. Both are pretty easy to make regardless, and more drip is good.
