### PR TITLE
Training Dummy & Custom Sign QoL

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -773,7 +773,7 @@
 		var/can_write = FALSE
 		if((user.used_intent.blade_class == BCLASS_STAB) && (W.wlength == WLENGTH_SHORT))
 			can_write = TRUE
-		if(istype(W, /obj/item/needle/thorn))
+		if(istype(W, /obj/item/natural/thorn))
 			can_write = TRUE
 		if(istype(W, /obj/item/natural/feather))
 			can_write = TRUE


### PR DESCRIPTION
## About The Pull Request
Adds the following:
- Training dummy has a do_after, and stops you from doing it if you're knocked down.
- Lets you use feathers & thorns on custom signs.

## Testing Evidence
<img width="1136" height="745" alt="Autotrain" src="https://github.com/user-attachments/assets/d499d4e8-b05a-49be-9ce8-4b246ce53785" />
<img width="1043" height="690" alt="Signs" src="https://github.com/user-attachments/assets/8419456b-2217-489b-ab6c-affc5ebe47ed" />

## Why It's Good For The Game
There are a few things that bothered me.
- One, I won't have to mash my mouse key 100 times every round to get to fucking apprentice in a skill. I would like to change it to train to journeyman but that's another can of worms that's been debated.
- Two, the amount of times a player or myself thought "Oh I can just use a feather or thorn on a sign to write!' and was wrong and disappointed is at least enough to count on both hands. This ends now!