### PR TITLE
nerfs firepatting, buffs rolling, makes it so you only roll when lying down

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -385,10 +385,14 @@
 		adjust_fire_stacks(-10, /datum/status_effect/fire_handler/fire_stacks/divine)
 		adjust_fire_stacks(-10, /datum/status_effect/fire_handler/fire_stacks/sunder/blessed)
 		visible_message(span_warning("[src] rolls on the ground, trying to put [p_them()]self out!"))
+		if (fire_status?.stacks + sunder_status?.stacks + divine_status?.stacks + blessed_sunder?.stacks <= 5)
+			addtimer(CALLBACK(src, PROC_REF(check_try_extinguish)), 2 SECONDS) // shitcode but we need this or else clothes won't extinguish after rolling
 	else
 		visible_message(span_notice("[src] pats the flames to extinguish them."))
 		if (fire_status?.stacks + sunder_status?.stacks + divine_status?.stacks + blessed_sunder?.stacks > 5) // might be worth rolling
 			to_chat(src, "<span class='warning'>These flames are intense! I should try rolling on the ground!</span>")
+		if (fire_status?.stacks + sunder_status?.stacks + divine_status?.stacks + blessed_sunder?.stacks <= 1)
+			addtimer(CALLBACK(src, PROC_REF(check_try_extinguish)), 2 SECONDS) // shitcode but we need this or else clothes won't extinguish after patting
 
 /mob/living/carbon/proc/check_try_extinguish()
 	if(!has_status_effect(/datum/status_effect/fire_handler))


### PR DESCRIPTION
## About The Pull Request

basically, fire sucks, especially when you're dealing with it midcombat LOOKING AT YOU SILVER
there's no way to tell whether you're going to pat the fire out or if you're going to roll on the floor and just fuck yourself over, hardstunning yourself in the middle of a fight, basically a death sentence as they're probably going to just refresh the firestack LOOKING AT YOU SILVER LOOKING AT YOU SILVER LOOKING AT YOU SILVER

this PR does three things
- you will now only roll when lying down, resisting while standing will now always attempt to pat the fire out
- rolling is more effective, reducing double the amount of fire stacks, up to ten from five `(firestacks cap at twenty)`
- patting is worse, twice as worse actually, now only reducing one firestack rather than two
always being able to reduce two stacks feels like it'd make fire too not threatening, and would trivialize silver
one is enough to pat out things things like accidentally walking over a burning body or getting hit with a fireball with relative ease, but being hit with things that apply massive amounts of stacks like silver will definitely make you want to disengage and roll, but no longer poses the threat that if you DO try and pat it out, you might just roll and STRAIGHT UP DIE
- also if you're above five firestacks you'll get a message when patting saying you should probably go and roll cause this is bad

also it makes patting reduce `/datum/status_effect/fire_handler/fire_stacks/sunder/blessed` idk what that but rolling on the ground removed it and patting didn't so it seems like an oversight

if rolling is too effective now or patting is too weak we can adjust the numbers, but the only time you'll ever really encounter firestacks above ten is like if a watcher shoots you four times in whichcase you're probably fucked anyways

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

compiled, everything worked
idk how i can really show you that it works other than having vv open and showing you that i'm patting with twenty firestacks and it's reducing one at a time but trust me on this i tested it it works

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

this simultaneously makes firestacks more threatening by making patting less rewarding, so you'll take more ticks of fire damage, and also improves player feedback by no longer randomly hardstunning you when trying to pat out a fire

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
