### PR TITLE
Door (un)Stuck: Death's Door removal & Necra spell tier rebalance

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -173,11 +173,10 @@
 					/obj/effect/proc_holder/spell/invoked/necras_sight			= CLERIC_T0,
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/invoked/avert					= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/deaths_door			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/invoked/blood_heal			= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/fieldburials			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/targeted/abrogation			= CLERIC_T2,
 					/obj/effect/proc_holder/spell/invoked/speakwithdead			= CLERIC_T3,
-					/obj/effect/proc_holder/spell/invoked/fieldburials			= CLERIC_T3,
 					/obj/effect/proc_holder/spell/invoked/wound_heal			= CLERIC_T4,
 	)
 	confess_lines = list(


### PR DESCRIPTION
## About The Pull Request

Death's Door (Necra T1) has been comically broken for almost a year and a half now. I sat down and started trying to fix it and couldn't escape The Question as to whether it was worth keeping or not, so I've opted to delete it from the Necra tier list and replace it with Field Burials at T1 instead.

## Testing Evidence

one-liner

## Why It's Good For The Game

When DD wasn't broken, it also created some complicated interactions where Necrans (of which there is a LOT because their kit is really very strong to the point of being fundamentally bothersome) could exploit skeletons having shitty grapple resistance and just chain-shove them into the portal to kill them instantly. People skilled with this approach could end entire lich sieges in a duo within a minute.

On top of that, DD being broken frequently necessitates admin intervention (it happens on average a round every 2-3 days), and we get a surprising number of tickets about deadite-rot players getting stuffed into the portal and irrevocably round-removed by Necrans either by accident or wholly on purpose.

Best to just see it off. In exchange, Field Burials at T1 means that Necran templars and Paladins can roam the map disposing bodies for a little bit of coin.
