### PR TITLE
Councillor Adjustments

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -38,19 +38,23 @@
 	outfit = /datum/outfit/job/councillor/basic
 	category_tags = list(CTAG_COUNCILLOR)
 	subclass_stats = list(
+		STATKEY_PER = 2,
 		STATKEY_INT = 2,
-		STATKEY_PER = 1,
-		STATKEY_STR = -1,
+		STATKEY_STR = 1,
+		STATKEY_SPD = 1,
 	)
 
 	subclass_skills = list(
+		/datum/skill/misc/riding = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/music = SKILL_LEVEL_NOVICE,
 	)
 
 /datum/outfit/job/councillor


### PR DESCRIPTION
## About The Pull Request

Brings Councillor in line with their Adventurer counterpart - Aristocrat.

## Testing Evidence

Just stats and skills, should work no problem.

## Why It's Good For The Game

While Councillors are a less important role they still have potential to influence a round through RP. 
I found it weird that an adventurer subclass gets better stat and skill spread than them when one is slot limited and the other is a free-form unlimited slot role.
Councillors will still get easily fragged by antagonists and pretty much every other combat role so this is more of a QoL.
