### PR TITLE
Removes steward's key from Councillors

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -65,6 +65,6 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	backl = /obj/item/storage/backpack/rogue/satchel
 	belt = /obj/item/storage/belt/rogue/leather/plaquesilver
-	beltl = /obj/item/storage/keyring/steward // If this turns out to be overbearing re:stewardry bump down to the clerk keyring instead.
+	beltl = /obj/item/storage/keyring/clerk
 	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel
 	cloak = /obj/item/clothing/cloak/stabard/surcoat/councillor


### PR DESCRIPTION
## About The Pull Request

Removes the Steward's key from councillors.

> If this turns out to be overbearing re:stewardry bump down to the clerk keyring instead.

It did turn out to be overbearing.

## Testing Evidence

♥

## Why It's Good For The Game

There's a decent amount of councillors that are helpful to the steward, but for every helpful councillor, there's 2 that abuse the key for various things. Sometimes they run into the stewardry with the steward present, using the nerve, taking keys, without asking. Sometimes they use it to go up into their bedroom and loot their golden circlet at roundstart. Yes, the key accesses everything from the nerve, to their private bedroom, and councillors love to abuse this fact.

There's a lot of steward's keys in circulation. Steward is not enough of an unpopular role to justify this. Especially after the daily wages addition. Even if there's no steward present, you can ask the duke or regent for the master key, and get a steward's key and vault key within 2 minutes. It can be really frustrating trying to play steward when half the court constantly barge in and interrupt their work. The Hand can still be annoying and barge in whenever they want, so the vibe isn't totally dead with this PR.