### PR TITLE
Strong Stance Bonuses

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -354,6 +354,10 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 //We will round to this value in damage calculations.
 #define DAMAGE_PRECISION 0.1
 
+#define STRONG_STANCE_DMG_BONUS 0.1
+#define STRONG_SHP_BONUS 2
+#define STRONG_INTG_BONUS 2
+
 //bullet_act() return values
 #define BULLET_ACT_HIT				"HIT"		//It's a successful hit, whatever that means in the context of the thing it's hitting.
 #define BULLET_ACT_BLOCK			"BLOCK"		//It's a blocked hit, whatever that means in the context of the thing it's hitting.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -266,8 +266,6 @@
 		var/mob/living/carbon/C = user
 		if(C.domhand)
 			used_str = C.get_str_arms(C.used_hand)
-	if(istype(user.rmb_intent, /datum/rmb_intent/strong))
-		used_str++
 	if(istype(user.rmb_intent, /datum/rmb_intent/weak))
 		used_str--
 	if(ishuman(user))
@@ -376,86 +374,7 @@
 			miner.mind.add_sleep_experience(/datum/skill/labor/mining, (miner.STAINT*0.2))
 		if(DULLING_SHAFT_CONJURED)
 			dullfactor = 1.2
-		if(DULLING_SHAFT_WOOD)	//Weak to cut / chop. No changes vs stab, resistant to blunt
-			switch(user.used_intent.blade_class)
-				if(BCLASS_CUT)
-					if(!I.remove_bintegrity(1))
-						dullfactor = 0.5
-					else
-						dullfactor = 1.3
-				if(BCLASS_CHOP)
-					if(!I.remove_bintegrity(1))
-						dullfactor = 0.5
-					else
-						dullfactor = 1.5
-				if(BCLASS_STAB)
-					dullfactor = 1
-				if(BCLASS_BLUNT)
-					dullfactor = 0.7
-				if(BCLASS_SMASH)
-					dullfactor = 0.5
-				if(BCLASS_PICK)
-					dullfactor = 0.5
-		if(DULLING_SHAFT_REINFORCED)	//Weak to stab. No changes vs blunt, resistant to cut / chop
-			switch(user.used_intent.blade_class)
-				if(BCLASS_CUT)
-					if(!I.remove_bintegrity(1))
-						dullfactor = 0
-					else
-						dullfactor = 0.5
-				if(BCLASS_CHOP)
-					if(!I.remove_bintegrity(1))
-						dullfactor = 0
-					else
-						dullfactor = 0.7
-				if(BCLASS_STAB)
-					dullfactor = 1.5
-				if(BCLASS_BLUNT)
-					dullfactor = 1
-				if(BCLASS_SMASH)
-					dullfactor = 1
-				if(BCLASS_PICK)
-					dullfactor = 0.7
-		if(DULLING_SHAFT_METAL)	//Very weak to blunt. No changes vs stab, highly resistant to cut / chop. Pick can actually damage it.
-			switch(user.used_intent.blade_class)
-				if(BCLASS_CUT)
-					if(!I.remove_bintegrity(1))
-						dullfactor = 0
-					else
-						dullfactor = 0.25
-				if(BCLASS_CHOP)
-					if(!I.remove_bintegrity(1))
-						dullfactor = 0
-					else
-						dullfactor = 0.4
-				if(BCLASS_STAB)
-					dullfactor = 0.75
-				if(BCLASS_BLUNT)
-					dullfactor = 1.3
-				if(BCLASS_SMASH)
-					dullfactor = 1.5
-				if(BCLASS_PICK)
-					dullfactor = 1
-		if(DULLING_SHAFT_GRAND)	//Resistant to all
-			switch(user.used_intent.blade_class)
-				if(BCLASS_CUT)
-					if(!I.remove_bintegrity(1))
-						dullfactor = 0
-					else
-						dullfactor = 0.5
-				if(BCLASS_CHOP)
-					if(!I.remove_bintegrity(1))
-						dullfactor = 0
-					else
-						dullfactor = 0.5
-				if(BCLASS_STAB)
-					dullfactor = 0.5
-				if(BCLASS_BLUNT)
-					dullfactor = 0.5
-				if(BCLASS_SMASH)
-					dullfactor = 1
-				if(BCLASS_PICK)
-					dullfactor = 0.5
+
 	var/newdam = (I.force_dynamic * user.used_intent.damfactor) - I.force_dynamic
 	if(user.used_intent.damfactor > 1)	//Only relevant if damfactor actually adds damage.
 		if(dullness_ratio <= SHARPNESS_TIER2_THRESHOLD)
@@ -478,6 +397,10 @@
 				to_chat(user, span_info("The blade is dull..."))
 			newforce *= (lerpratio * 2)
 	testing("endforce [newforce]")
+
+	if(istype(user.rmb_intent, /datum/rmb_intent/strong))
+		newforce += (I.force_dynamic * STRONG_STANCE_DMG_BONUS)
+
 	return newforce
 
 /obj/attacked_by(obj/item/I, mob/living/user)

--- a/code/game/objects/items/rogueweapons/integrity.dm
+++ b/code/game/objects/items/rogueweapons/integrity.dm
@@ -13,6 +13,8 @@
 	var/sharpness_mod = 1
 
 /obj/item/proc/remove_bintegrity(amt as num, mob/user)
+	if(sharpness == IS_BLUNT)
+		return FALSE
 	if(sharpness_mod != 1)
 		amt *= sharpness_mod
 	if(user && HAS_TRAIT(user, TRAIT_SHARPER_BLADES))

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -415,9 +415,14 @@
 					var/dam2take = round((get_complex_damage(AB,user,used_weapon.blade_dulling)/2),1)
 					if(dam2take)
 						var/intdam = used_weapon.max_blade_int ? INTEG_PARRY_DECAY : INTEG_PARRY_DECAY_NOSHARP
+						var/sharp_loss = SHARPNESS_ONHIT_DECAY
 						if(used_weapon == offhand)
 							intdam = INTEG_PARRY_DECAY_NOSHARP
+						if(istype(user.rmb_intent, /datum/rmb_intent/strong))
+							sharp_loss += STRONG_SHP_BONUS
+							intdam += STRONG_INTG_BONUS
 						used_weapon.take_damage(intdam, BRUTE, used_weapon.d_type)
+						used_weapon.remove_bintegrity(sharp_loss, user)
 					return TRUE
 				else
 					return FALSE
@@ -545,6 +550,9 @@
 				playsound(get_turf(src), pick(W.parrysound), 100, FALSE)
 			if(src.client)
 				record_round_statistic(STATS_PARRIES)
+
+			var/def_verb = "parries"
+			var/att_verb = ""
 			if(istype(rmb_intent, /datum/rmb_intent/riposte))
 				src.visible_message(span_boldwarning("<b>[src]</b> ripostes [user] with [W]!"))
 			else
@@ -745,8 +753,13 @@
 			probclip += lucmod * 10
 		if(prob(probclip) && IS && IU)
 			var/intdam = IS.max_blade_int ? INTEG_PARRY_DECAY : INTEG_PARRY_DECAY_NOSHARP
+			var/sharp_loss = SHARPNESS_ONHIT_DECAY
+			if(istype(user.rmb_intent, /datum/rmb_intent/strong))
+				sharp_loss += STRONG_SHP_BONUS
+				intdam += STRONG_INTG_BONUS
+
 			IS.take_damage(intdam, BRUTE, IU.d_type)
-			IS.remove_bintegrity(SHARPNESS_ONHIT_DECAY, src)
+			IS.remove_bintegrity(sharp_loss, src)
 
 			user.visible_message(span_warning("<b>[user]</b> clips [src]'s weapon!"))
 			playsound(user, 'sound/misc/weapon_clip.ogg', 100)


### PR DESCRIPTION
## About The Pull Request

ports https://github.com/Azure-Peak/Azure-Peak/pull/4940

- Strong Stance's "+1 STR" is now +10% damage that ignores STR softcaps.

- Parrying / Getting your weapon clipped vs someone in Strong Stance will cost extra sharpness / durability (if blunt)

- bonus content is that it actually fixes weapons losing sharpness. we had this bugged 4ever.

## Testing Evidence

<img width="407" height="280" alt="image" src="https://github.com/user-attachments/assets/dc568087-cdf8-48cb-8d85-6bd76642277a" />

<img width="416" height="126" alt="image" src="https://github.com/user-attachments/assets/3218176c-a515-4f93-842d-5066e1acdb81" />

## Why It's Good For The Game

strong intent does something that isn't giving you 3% more damage at softcap
