### PR TITLE
Fixes null magic ring

### DIFF
--- a/code/rt.dm
+++ b/code/rt.dm
@@ -3,7 +3,7 @@
 //    #define DEPLOY_TEST
 //    #define ROGUEWORLD
 #endif
-#define FASTLOAD
+
 #ifdef FASTLOAD
     #define FORCE_MAP "_maps/roguetest.json"
 // #else


### PR DESCRIPTION
## About The Pull Request

Anyone with at least basic code understanding will immediately see the issue.

YES. Antimagic component was subscribing to COMSIG_MOB_RECEIVE_MAGIC only when the item was equipped/unequipped when component's parent was set to obj/item type. In turn, this made null magic rings practically useless - you had to rmb them, unequip and equip to make them actually block magic.

Changed component's logic slightly - in case it is attached to item, it will check if item's loc is a mob - its wearer - subscribing to mob's signals in turn to make it work without necessary unequip/equip coal routine.

## Testing Evidence

<img width="1722" height="768" alt="image" src="https://github.com/user-attachments/assets/06ccae49-8e39-468a-bbd6-8d4432cb93bd" />

## Why It's Good For The Game

Uhhh I think I need those bugs GONE