### PR TITLE
Scroll of Mirror Transform for the Brassface

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -208,6 +208,13 @@
 	icon_state ="scrolldarkred"
 	remarks = list("Redi damnatos..", "Exitio ad Necram scriptor exolvuntur..", "Ossa in propinquus..")
 
+/obj/item/book/granter/spell/blackstone/mirror_transform
+	name = "Scroll of Mirror Transform"
+	spell = /obj/effect/proc_holder/spell/invoked/mirror_transform
+	spellname = "Mirror Transform"
+	icon_state ="scrolldarkred"
+	remarks = list("Figura mea..", "Meum est mutare..", "Species mea transferet..")
+
 /obj/item/book/granter/spell/blackstone/sicknessray
 	name = "Scroll of Sickness Ray"
 	spell = /obj/effect/proc_holder/spell/invoked/projectile/sickness

--- a/code/modules/cargo/packsrogue/bathmatron/bath_rogue.dm
+++ b/code/modules/cargo/packsrogue/bathmatron/bath_rogue.dm
@@ -76,3 +76,8 @@
 	contains = list(
 					/obj/item/storage/belt/rogue/leather/smokebelt
 				)
+
+/datum/supply_pack/rogue/bath_rogue/mirror_transform //This is here for...err...you know what people use mirror transform for, also it changes your appearance so..thieves logically would want that
+	name = "Scroll of Mirror Transform"
+	cost = 100			// its a scroll that gives you a spell, if you can't afford it find a mage to cast it on you instead
+	contains = list(/obj/item/book/granter/spell/blackstone/mirror_transform)


### PR DESCRIPTION


## About The Pull Request

This PR adds the Mirror transform spell into the brassface as a purchaseable scroll.

## Evidence it works

![](https://i.gyazo.com/b7b25105a4aed4c840688e574913902b.png)

![](https://i.gyazo.com/3b17a83776ab23a185acc8c27dbc0696.png)


![](https://i.gyazo.com/032627af90ee6048ca5ab475ffd99e79.png)




## WHY IS IT GOOD FOR THE GAME?

The brothel has 2 uses for it
to sell to thieves who might want to change their appearance to evade capture more efficently

people who want a bigger you know what im talking about and why people use mirror transform

If I am honest, I am the person mentioned in the last reason
