### PR TITLE
Pardon my French (Otavan accent tweaks)

### DIFF
--- a/strings/french_replacement.json
+++ b/strings/french_replacement.json
@@ -11,9 +11,7 @@
 		"captain": "capitaine", 
 		"cook": "cuisinier", 
 		"dad": "papa",
-		"father": "père",
 		"mom": "maman",
-		"mother": "mère",
         "hello": "'allo",
 		"hi": "salut",
         "thanks": "merci",   
@@ -51,10 +49,11 @@
 		"for": "pour",
 		"shit": "merde",
 		"my": "mon",
+		"me": "moi",
 		"please": "s’il vous plaît",
 		"goodbye": "au revoir",
-		"sorry": "pardon",
 		"small": "petit",
+		"little": "petit",
 		"shop": "boutique",
 		"cheers": "santé",
 		"threesome": "ménage à trois",
@@ -76,7 +75,7 @@
 		"cheese omelette": "omelette du fromage",
 		"good morning": "bonjour",
 		"good evening": "bonsoir",
-		"oh my, my": "oo là là",
+		"my, my": "oo là là",
 		"good enough": "suffisant",
 		"my love": "mon amour",
 		"my darling": "mon coeur",
@@ -94,7 +93,10 @@
 		"to your health": "à votre santé",
 		"very good": "très bon",
 		"very well": "très bien",
-		"excuse me": "excusez-moi"
+		"excuse me": "excusez-moi",
+		"so it goes": "c'est la vie",
+		"such is life": "c'est la vie",
+		"that's life": "c'est la vie"
 
 	},
     "syllable": {


### PR DESCRIPTION
## About The Pull Request
I mostly made this to remove "sorry" into "pardon" as it usually makes for very odd sentence structure. Often you'll have to adjust to an accent, but 'sorry' is too common of a word, and it comes up a lot and looks very silly.

Also removed "father" into "pere" and "mother" into "mere", mostly because I think both sound silly when referring to the priest/priestess, and it's not easy to understand for people unfamiliar with the French. 

Added:
* "so it goes", "such is life", and "that's life" -> "c'est la vie"
* "me" ->"moi"
* "little" -> "petit"
* Tweaked "oh my, my" -> "oo la la" to "my, my" because nobody is ever gonna be saying oh my, my

## Testing Evidence
I'm an expert, trust me.

## Why It's Good For The Game
I personally think the Otavan accent is in a good place, and I don't really know what else I'd tweak about it at this rate. Any other phrases I could think of are too much of a hard sell, because they're not commonly used for people who don't speak french. C'est la vie is cute, petit is cute, and moi is cute. 

If anyone has any suggestions to what they'd like to see, in case I missed any commonly used/relatively easy to understand phrases, or terms of endearment, please let me know. Otherwise, I think it's in a good spot right now, and I don't think it needs any heavy changes, as the accent does pop up quite a bit. This just removes a bit of silliness.