### PR TITLE
Restores Family / Strata Button Symbol

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1114,6 +1114,6 @@
 					spouse_list += the_person.real_name
 			if(spouse_list.len)
 				spousetext = jointext(spouse_list, ", ")
-		output += " They are a member of house [family_datum.housename][spousetext ? ", and are married to [spousetext]." : "."]"
-		
+		output += "<BR>They are a member of house [family_datum.housename][spousetext ? ", and are married to [spousetext]." : "."]"
+
 	return output


### PR DESCRIPTION
## About The Pull Request

Restores family/strata button visuals to how I had it for the family system PR!

No family.
<img width="421" height="92" alt="image" src="https://github.com/user-attachments/assets/33f969a5-590d-474d-9eaf-f8903bb547b8" />

Family.
<img width="376" height="115" alt="image" src="https://github.com/user-attachments/assets/6990fd7c-b2cf-44ac-8867-39fcae9466ff" />

Also adds a line break to the tooltip for readability.

## Testing Evidence

<img width="831" height="377" alt="image" src="https://github.com/user-attachments/assets/350745a3-bd9b-46c8-afb1-42a3d8dd6c8c" />

## Why It's Good For The Game
I think it looks good!