### PR TITLE
Antlerhoods on mask slots

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -36,7 +36,7 @@
 	item_state = "antlerhood"
 	icon = 'icons/roguetown/clothing/head.dmi'
 	body_parts_covered = HEAD|HAIR|EARS|NECK
-	slot_flags = ITEM_SLOT_HEAD
+	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK
 	dynamic_hair_suffix = ""
 	max_integrity = 80
 	armor = ARMOR_HEAD_CLOTHING


### PR DESCRIPTION
## About The Pull Request

Adds ITEM_SLOT_MASK to the antlerhood

## Testing Evidence

one liner

## Why It's Good For The Game

I like using it, its a cosmetic item that costs 1 hide and 2 bones. F and D+ protection with 80 durability. 
COSMETICS COSMETICS COSMETICS.

This makes it viable for wearing without entirely giving up armor on the head
its a hood...all hoods fit on the mask slot