### PR TITLE
Fixes fixedeye getting stuck sometimes

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -201,12 +201,15 @@
 	if(mob.curplaying)
 		mob.curplaying.on_mouse_up()
 
-	if(!mob.fixedeye)
+	if(!mob.targetting)
 		mob.tempfixeye = FALSE
+
+	if(!mob.fixedeye && !mob.tempfixeye)
 		mob.nodirchange = FALSE
-		if(mob.hud_used)
-			for(var/atom/movable/screen/eye_intent/eyet in mob.hud_used.static_inventory)
-				eyet.update_icon(mob) //Update eye icon
+
+	if(mob.hud_used)
+		for(var/atom/movable/screen/eye_intent/eyet in mob.hud_used.static_inventory)
+			eyet.update_icon(mob) //Update eye icon
 
 	if(!mob.atkswinging)
 		return


### PR DESCRIPTION
## About The Pull Request

Resolves an old bug that caused the fixedeye state to become stuck if you used the hotkey while holding down RMB.

## Testing Evidence

Tested it in game - held down RMB and hit the hotkey, let go of RMB and stayed fixed in the last direction I looked at. Hit the hotkey again and it turned off. Works in both scenarios (turning it on or off while holding down a mouse button).

## Why It's Good For The Game

Janky input handling makes me salt.
