### PR TITLE
makes heavy gronn mercenary Ever So Slightly less Ass

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/gronnheavy.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/gronnheavy.dm
@@ -12,7 +12,7 @@
 	subclass_languages = list(/datum/language/gronnic)
 	subclass_stats = list(
 		STATKEY_END = 3, //People see big numbers and start shitting their pants, but their weighted stats are 7 and it's limited to one, singular slot. This is fine. 
-		STATKEY_STR = 3, //TO WIELD THE MAUL. THEY CAN'T USE ANY OTHER WEAPON TYPE BUT MACES ANYWAY.
+		STATKEY_STR = 3,
 		STATKEY_INT = 2,
 		STATKEY_CON = 3,
 		STATKEY_PER = -1, //CAN'T SEE SHIT OUTTA THIS THING!!
@@ -45,10 +45,10 @@
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron/gronn
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/iron/gronn
 	cloak = /obj/item/clothing/cloak/volfmantle			//Aura farming.
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/iron //Weakspot.
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/iron
 	pants = /obj/item/clothing/under/roguetown/platelegs/iron/gronn
-	r_hand = /obj/item/rogueweapon/mace //this is literally the only weapon type they'll get to use. No alternatives.
-	neck = /obj/item/clothing/neck/roguetown/gorget //Their weakspot. Go replace it if you're a chud I guess
+	r_hand = /obj/item/rogueweapon/mace/goden/steel //this is literally the only weapon type they'll get to use. No alternatives.
+	neck = /obj/item/clothing/neck/roguetown/gorget
 	backl = /obj/item/storage/backpack/rogue/satchel/black
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor


### PR DESCRIPTION
## About The Pull Request

replaces heavy gronn mercenary's shitty ass poop mace with an actual grand mace
yes it's not much of an improvement and i guess it goes against the idea that everything gronn uses should be made of iron but there's no iron grand mace and i can't be assed to go like
port the maul that they're supposed to have so consider this a temporary solution until someone goes and does that

also removes comments referencing the maul and comments insistent upon the class's """"""""""weakspots"""""""""" as if you can't replace them very easily

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

webedit if this breaks the video game i'll genuinely post feet pics to after round discussion

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

makes the giant armor heavy knight guy have an appropriately not dinky weapon

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
