### PR TITLE
Towner and ogre class selection subclass information

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/villager.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/villager.dm
@@ -22,10 +22,35 @@
 	advjob_examine = TRUE
 	always_show_on_latechoices = TRUE
 	same_job_respawn_delay = 0
-	class_setup_examine = FALSE	//Nooo thank you
+	class_setup_examine = TRUE
 	cmode_music = 'sound/music/combat_towner.ogg'
 	social_rank = SOCIAL_RANK_PEASANT
 
+	job_subclasses = list(
+		/datum/advclass/blacksmith,
+		/datum/advclass/carpenter,
+		/datum/advclass/cheesemaker,
+		/datum/advclass/drunkard,
+		/datum/advclass/fisher,
+		/datum/advclass/hunter,
+		/datum/advclass/miner,
+		/datum/advclass/minstrel,
+		/datum/advclass/peasant,
+		/datum/advclass/potter,
+		/datum/advclass/seamstress,
+		/datum/advclass/butcher,
+		/datum/advclass/thug/goon,
+		/datum/advclass/thug/wiseguy,
+		/datum/advclass/thug/bigman,
+		/datum/advclass/towndoctor,
+		/datum/advclass/witch,
+		/datum/advclass/woodcutter,
+		/datum/advclass/masterchef,
+		/datum/advclass/masterblacksmith,
+		/datum/advclass/minermaster,
+		/datum/advclass/fishermaster,
+		/datum/advclass/farmermaster
+	) //Master carpenter and mason aren't rolling for some reasons, so they are not present at the time of writing.
 /*
 /datum/job/roguetown/adventurer/villager/New()
 	. = ..()

--- a/code/modules/jobs/job_types/roguetown/ogre/ogre.dm
+++ b/code/modules/jobs/job_types/roguetown/ogre/ogre.dm
@@ -25,3 +25,10 @@
 	cmode_music = 'sound/music/combat.ogg'
 
 	job_traits = list(TRAIT_OUTLANDER, TRAIT_STEELHEARTED, TRAIT_OGRE_STRENGTH)
+	job_subclasses = list(
+		/datum/advclass/ogre/avatar,
+		/datum/advclass/ogre/cook,
+		/datum/advclass/ogre/dumdum,
+		/datum/advclass/ogre/mercenary,
+		/datum/advclass/ogre/warlord
+	)


### PR DESCRIPTION
## About The Pull Request
Title. Not much else to say. I do know about the inevitable ogre changes, but since eta is unknown might aswell fill the gap for now.

## Testing Evidence
1. Compiles
<img width="337" height="126" alt="image" src="https://github.com/user-attachments/assets/9b88143a-b640-46b6-90cc-a0667a5aa981" />

2. Towner and ogre class info ingame
<img width="470" height="720" alt="image" src="https://github.com/user-attachments/assets/8648b7e5-c76b-47fc-bb0d-38345b463d92" />
<img width="469" height="363" alt="image" src="https://github.com/user-attachments/assets/fd9c59e3-1ac6-4f2b-b17c-5f4f55639577" />

## Why It's Good For The Game
Bugfix, sort of? The information disappeared after a big PR for quite some time (months), despite all other classes having it.
P.s: Thanks, Syllin.