### PR TITLE
Wretched toiler Athletics  

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/wretchedtoiler.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/wretchedtoiler.dm
@@ -39,6 +39,7 @@
 		/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT, //summon monsters? I think?
 		/datum/skill/magic/holy = SKILL_LEVEL_EXPERT, //miracle regen? I think?
 		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT, // brotherhood order spells most importantly. But this fellas gonna run a lot to.
 		)
 
 // Hedge Mage on purpose has nearly the same fit as a Adv Mage / Mage Associate who cast conjure armor roundstart. Call it meta disguise.


### PR DESCRIPTION
## About The Pull Request

Gives toiler expert athletics. Onpar with most other wretch classes. The brotherhood ''spells'' are not ''magic'' thus they use athletics skill when calculating stamina draw. This means using any of these powers the toilers would instantly be stam crit (effectively like trying to cast a fireball with 5 int its not fun)

I put it on the base class rather then the mastermind subclass since well...running kinda important when you have 0 offense as the servant  does. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiles. Just numbers can't fuck up.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
QOL. Just makes sense. This was most likely a oversight in the original PR and not intended.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
