### PR TITLE
destroys bait on omni intent

### DIFF
--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -339,15 +339,6 @@
 		if (ishuman(target))
 			HT = target
 
-		// RMB on mob (priority 0): check to see if a bait has any chance to succeed (match targeting zones between us and the target), if so, attempt it (ONLY check for matching zones, nothing else).
-		if (HT)
-			var/target_zone = HT.zone_selected
-			var/user_zone = HU.zone_selected
-			if (!user.has_status_effect(/datum/status_effect/debuff/baitcd) && !user.has_status_effect(/datum/status_effect/debuff/baited) && target_zone && user_zone && (target_zone != BODY_ZONE_CHEST && user_zone != BODY_ZONE_CHEST) && target_zone == user_zone)
-				HU.attempt_bait(user, target)
-				HU.changeNext_move(0.5 SECONDS)
-				return
-		
 		// RMB on mob (priority 1): has something grappled us (passively), and can we kick? if so, attempt a kick.
 		if (!HU.IsOffBalanced())
 			var/mob/kick_target


### PR DESCRIPTION
## About The Pull Request

destroys bait on omni intent

## Testing Evidence

i just removed it if it looks fucked up idk what to say

## Why It's Good For The Game

baiting has risk involved. if you fuck up your gambit, you put it on cooldown for 30 seconds. 

omni intent specifically checks for if they're aiming the same limb and if it is, then it'll do it, otherwise they won't. 

there's no risk or gamble involved it's just cheatcodes