### PR TITLE
The Crown is a heavy burden (Duke DNR)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -315,6 +315,7 @@ GLOBAL_LIST_EMPTY(heretical_players)
 		//Coronate new King (or Queen)
 		HU.mind.assigned_role = "Grand Duke"
 		HU.job = "Grand Duke"
+		ADD_TRAIT(HU, TRAIT_DNR, TRAIT_GENERIC)
 		if(should_wear_femme_clothes(HU))
 			SSticker.rulertype = "Grand Duchess"
 		else

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -128,7 +128,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	outfit = /datum/outfit/job/lord/warrior
 	category_tags = list(CTAG_LORD)
 
-	traits_applied = list(TRAIT_HEAVYARMOR)
+	traits_applied = list(TRAIT_HEAVYARMOR, TRAIT_DNR)
 	subclass_stats = list(
 		STATKEY_LCK = 5,
 		STATKEY_INT = 3,
@@ -176,7 +176,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	category_tags = list(CTAG_LORD)
 	noble_income = 400 // Let's go crazy. This is +400 per day for a total of 2400 per round at the end of a day. This is probably equal to doubling passive incomes of the keep.
 
-	traits_applied = list(TRAIT_SEEPRICES, TRAIT_CICERONE, TRAIT_KEENEARS, TRAIT_MEDIUMARMOR)
+	traits_applied = list(TRAIT_SEEPRICES, TRAIT_CICERONE, TRAIT_KEENEARS, TRAIT_MEDIUMARMOR, TRAIT_DNR)
 	subclass_stats = list(
 		STATKEY_LCK = 5,
 		STATKEY_INT = 5,
@@ -218,7 +218,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	outfit = /datum/outfit/job/lord/sorcerer
 	category_tags = list(CTAG_LORD)
 	
-	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T2, TRAIT_INTELLECTUAL)
+	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T2, TRAIT_INTELLECTUAL, TRAIT_DNR)
 	subclass_stats = list(
 		STATKEY_LCK = 5,
 		STATKEY_INT = 5,
@@ -266,7 +266,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	outfit = /datum/outfit/job/lord/inbred
 	category_tags = list(CTAG_LORD)
 
-	traits_applied = list(TRAIT_CRITICAL_WEAKNESS, TRAIT_NORUN, TRAIT_HEAVYARMOR)
+	traits_applied = list(TRAIT_CRITICAL_WEAKNESS, TRAIT_NORUN, TRAIT_HEAVYARMOR, TRAIT_DNR)
 	subclass_stats = list(
 		STATKEY_LCK = 10,
 		STATKEY_INT = -2,


### PR DESCRIPTION
## About The Pull Request

Being the ruler, regardless of if you are the proper duke, or coronated, will give you the DNR trait.  Credits to Azure peaks 4843 by BurpleBineapple, as that was the PR I was shown and requested to port.

## Testing Evidence

I haven't yet. I'm sick please don't yell at me.  PR up already so people can yell at me early.
Edit: Was supposedly tested by a maintainer, then testmerged.  If any issues exist, ping Triyarg on the discord or let me know here, thanks.

## Why It's Good For The Game

Frok asked for it.  It'd be really really funny.  Giving the DNR trait gives the ruler a fair warning about their state, unlike in #1819.  Forceful coronation of heirs means running away from their royal/holy duty still comes with great risk.
