### PR TITLE
Church bell spam reduction

### DIFF
--- a/code/game/objects/items/rogueitems/bells.dm
+++ b/code/game/objects/items/rogueitems/bells.dm
@@ -11,7 +11,7 @@
 	damtype = BRUTE
 	force = 5
 	hitsound = 'sound/items/bsmith1.ogg'
-	var/cooldown = 30 SECONDS
+	var/cooldown = 5 SECONDS
 	var/ringing = FALSE
 	resistance_flags = FIRE_PROOF
 	grid_width = 32
@@ -63,7 +63,7 @@
 	density = TRUE
 	layer = ABOVE_MOB_LAYER
 	plane = GAME_PLANE_UPPER
-	var/cooldown = 3 SECONDS
+	var/cooldown = 30 SECONDS
 	var/ringing = FALSE
 
 /*


### PR DESCRIPTION
## About The Pull Request

Title. Yes, it's a salt PR.
Big bell's cooldown 3 seconds  -> 30 seconds
Small bell cooldown 3 seconds -> 5 seconds (collateral damage)

## Testing Evidence
*groanirl
1. Compiles
<img width="336" height="130" alt="image" src="https://github.com/user-attachments/assets/9b423b21-aacb-4b7f-a68a-20dee82919c4" />

2. Spawned as priest, ran to the tower, rang both bells. Works.

## Why It's Good For The Game

1. This. No, that particular round was not the first with such abuse, but something something camel's back.
<img width="516" height="613" alt="image" src="https://github.com/user-attachments/assets/209bbb2e-5bc2-4d25-b8b5-6721f3f4a27f" />

2. Personally i feel this is an oversight for two reasons: 
First, when it was added (eh, whatever, churchlings will just beat the abuser up)
Second, when the range got inreased to global (NOW we are talking)

The big bell is used usually for 2 reasons. 
A) CHURCH UNDER ATTACK SEND DUDES THE YELL IS ON COOLDOWN
B) Ingame wedding.

P.S: If you have a better solution, let me know anywhere and i will take this down.
Or speedmerge this if you are tired of the spam too :^)