### PR TITLE
Fixes roundstart clangs by disabling roundstart adventurers

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -9,7 +9,7 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 	department_flag = PEASANTS
 	faction = "Station"
 	total_positions = 25
-	spawn_positions = 25
+	spawn_positions = 0
 	allowed_races = RACES_ALL_KINDS
 	disallowed_races = /datum/species/ogre
 	tutorial = "Hero of nothing, a wanderer in foreign lands in search of fame and riches. Whatever led you to this fate is up to the wind to decide, and you've never fancied yourself for much other than the thrill. Some day your pride is going to catch up to you, and you're going to find out why most men don't end up in the annals of history."


### PR DESCRIPTION
I cannot even get to why this fix is more satisfying than fixing the root cause.

I simply don't care.

I said this might be the issue two weeks ago.