### PR TITLE
Etruscan Bascinet now as durable as all other visored helmets

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -1789,6 +1789,7 @@
 	desc = "A steel bascinet helmet with a straight visor, or \"klappvisier\", which can greatly reduce visibility. Though it was first developed in Etrusca, it is also widely used in Grenzelhoft."
 	icon_state = "klappvisier"
 	item_state = "klappvisier"
+	max_integrity = 325
 	adjustable = CAN_CADJUST
 	emote_environment = 3
 	body_parts_covered = FULL_HEAD


### PR DESCRIPTION
## About The Pull Request

etruscan bascinet durability moved to 325, in line with knight helmet/armet/hounskull and other same ingot-price and class distribution equivalents

## Testing Evidence

<img width="504" height="384" alt="image" src="https://github.com/user-attachments/assets/e982e1fb-ba25-4798-b053-889d8b4b068c" />


## Why It's Good For The Game

It's CUTE! No reason it shouldn't be viable.
