### PR TITLE
Fixes harpy flight carry

### DIFF
--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -207,6 +207,8 @@
 					stamina_cost_final *= 2 //double our stamina cost if we're pulling someone with us
 					time_taken *= 2
 				if(do_after(C, time_taken))
+					if(ismob(C.pulling))
+						C.pulling.forceMove(turf_above)
 					C.forceMove(turf_above)
 					C.start_pulling(pulling, state = 1, supress_message = TRUE)
 					if(C.pulling)
@@ -214,8 +216,6 @@
 						var/obj/item/grabbing/I = C.get_inactive_held_item()
 						if(istype(I, /obj/item/grabbing/))
 							I.icon_state = null
-						if(ismob(C.pulling))
-							C.pulling.forceMove(turf_above)
 					C.stamina_add(stamina_cost_final)
 					to_chat(C, span_notice("I fly upwards."))
 			else
@@ -258,6 +258,8 @@
 					stamina_cost_final *= 2 //double our stamina cost if we're pulling someone with us
 					time_taken *= 2
 				if(do_after(C, time_taken))
+					if(ismob(C.pulling))
+						C.pulling.forceMove(turf_below)
 					C.forceMove(turf_below)
 					C.start_pulling(pulling, state = 1, supress_message = TRUE)
 					if(C.pulling)
@@ -265,8 +267,6 @@
 						var/obj/item/grabbing/I = C.get_inactive_held_item()
 						if(istype(I, /obj/item/grabbing/))
 							I.icon_state = null
-						if(ismob(C.pulling))
-							C.pulling.forceMove(turf_below)
 					C.stamina_add(stamina_cost_final)
 					to_chat(C, span_notice("I fly downwards."))
 			else


### PR DESCRIPTION
## About The Pull Request

Harpies were unable to carry anyone up and down z-levels since the lattest change to flight. The code that allowed buckling didn't work because the force move action had been moved down for some reason.

This returns the force move action to where it was, fixing flight. It hasn't broken anything else during testing.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="215" height="236" alt="imagen" src="https://github.com/user-attachments/assets/ec9d3ab7-42f5-4755-b53a-1570db768ef7" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Bug fix

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
