### PR TITLE
Microscopic guild smithy experience improvement (oneliners :( )

### DIFF
--- a/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
@@ -122,14 +122,16 @@ GLOBAL_VAR_INIT(last_guildmaster_announcement, -50000) // Inits variable for lat
 		if(!src.can_speak_vocal())
 			to_chat(src,span_warning("I can't speak!"))
 			return FALSE
-		if(world.time < GLOB.last_guildmaster_announcement + 600 SECONDS)
-			to_chat(src, span_warning("You must wait [round((GLOB.last_guildmaster_announcement + 600 SECONDS - world.time)/600, 0.1)] minutes before making another announcement!"))
+		if(world.time < GLOB.last_guildmaster_announcement + 450 SECONDS)
+			to_chat(src, span_warning("You must wait [round((GLOB.last_guildmaster_announcement + 450 SECONDS - world.time)/600, 0.1)] minutes before making another announcement!"))
 			return FALSE
 		visible_message(span_warning("[src] takes a deep breath, preparing to make an announcement.."))
 		if(do_after(src, 15 SECONDS, target = src)) // Reduced to 15 seconds from 30 on the original Herald PR. 15 is well enough time for sm1 to shove you.
 			say(announcementinput)
 			priority_announce("[announcementinput]", "The Guildmaster Heralds", 'sound/misc/bell.ogg', sender = src)
 			GLOB.last_guildmaster_announcement = world.time
+			spawn(450 SECONDS)
+			to_chat(src, span_notice("I can make an announcement again!"))
 		else
 			to_chat(src, span_warning("Your announcement was interrupted!"))
 			return FALSE

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil.dm
@@ -220,7 +220,7 @@
 
 /obj/machinery/anvil/process()
 	if(hott)
-		if(world.time > hott + 10 SECONDS)
+		if(world.time > hott + 15 SECONDS)
 			hott = null
 			STOP_PROCESSING(SSmachines, src)
 	else

--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -143,12 +143,12 @@
 		return
 	if(on)
 		if(ore.len)
-			if(cooking < 20)
+			if(cooking < 18)
 				cooking++
 				playsound(src.loc,'sound/misc/smelter_sound.ogg', 50, FALSE)
 				actively_smelting = TRUE
 			else
-				if(cooking == 20)
+				if(cooking == 18)
 					for(var/obj/item/I in ore)
 						if(I.smeltresult)
 //							while(I.smelt_bar_num)
@@ -162,7 +162,7 @@
 							qdel(I)
 					playsound(src,'sound/misc/smelter_fin.ogg', 100, FALSE)
 					visible_message(span_notice("\The [src] finished smelting."))
-					cooking = 21
+					cooking = 19
 					actively_smelting = FALSE
 
 /obj/machinery/light/rogue/smelter/burn_out()
@@ -185,12 +185,12 @@
 	..()
 	if(on)
 		if(ore.len)
-			if(cooking < 30)
+			if(cooking < 27)
 				cooking++
 				playsound(src.loc,'sound/misc/smelter_sound.ogg', 50, FALSE)
 				actively_smelting = TRUE
 			else
-				if(cooking == 30)
+				if(cooking == 27)
 					var/alloy //moving each alloy to it's own var allows for possible additions later
 					// Steel Alloy requires a 1 coal to 1 iron ratio. Yes. Doesn't make sense but it is to make
 					// Steel more expensive to make
@@ -257,7 +257,7 @@
 					playsound(src,'sound/misc/smelter_fin.ogg', 100, FALSE)
 					visible_message(span_notice("\The [src] finished smelting."))
 					maxore = initial(maxore)
-					cooking = 31
+					cooking = 28
 					actively_smelting = FALSE
 
 
@@ -277,12 +277,12 @@
 	..()
 	if(on)
 		if(ore.len)
-			if(cooking < 40)
+			if(cooking < 36)
 				cooking++
 				playsound(src.loc,'sound/misc/smelter_sound.ogg', 50, FALSE)
 				actively_smelting = TRUE
 			else
-				if(cooking == 40)
+				if(cooking == 36)
 					var/alloy //moving each alloy to it's own var allows for possible additions later
 					var/bronzealloy
 					for(var/obj/item/I in ore)
@@ -320,7 +320,7 @@
 					playsound(src,'sound/misc/smelter_fin.ogg', 100, FALSE)
 					visible_message(span_notice("\The [src] finished smelting."))
 					maxore = initial(maxore)
-					cooking = 41
+					cooking = 37
 					actively_smelting = FALSE
 
 /obj/machinery/light/rogue/smelter/hiron
@@ -340,12 +340,12 @@
 	..()
 	if(on)
 		if(ore.len)
-			if(cooking < 45)
+			if(cooking < 40)
 				cooking++
 				playsound(src.loc,'sound/misc/smelter_sound.ogg', 50, FALSE)
 				actively_smelting = TRUE
 			else
-				if(cooking == 45)
+				if(cooking == 40)
 					for(var/obj/item/I in ore)
 						if(I.smeltresult)
 							var/obj/item/R = new I.smeltresult(src, ore[I])
@@ -356,5 +356,5 @@
 					playsound(src,'sound/misc/smelter_fin.ogg', 100, FALSE)
 					visible_message(span_notice("\The [src] finished smelting."))
 					maxore = initial(maxore)
-					cooking = 46
+					cooking = 41
 					actively_smelting = FALSE


### PR DESCRIPTION
## About The Pull Request
Sponsored by me malding in another smithing discussion thread and the least funny role that is guildmaster.
Here's an attempt to make it a bit better.

Changelog:
General: 
**Hot ingot to cold ingot timer:** - 10 -> 15 seconds. Reason: Allows you TO FUCKING TALK IN A ROLEPLAYING GAME while smithing a bit more. Plus accounting for tidi, connection issues (trust me it sucks), etc.
**Furnaces:** Take ~10% less time to smelt things. Reason: Less dick in hand, more shit done.
**Guildmaster's announcement:** Cooldown: 600 -> 450 seconds. Reason: For a supposedly important role of an important town organization, the cooldown felt too big 4noraisin. Wanted 5 minutes, decided to settle in the middle.
**Guildmaster's announcement:** Now you get a notification in chat when it's ready to be used again. Reason: I wanted it, duh.

## Testing Evidence
1. Compiles

<img width="266" height="124" alt="image" src="https://github.com/user-attachments/assets/b23d579d-5b3e-4220-a637-1db8f17451ee" />

2. Guildmaster announcement notification ingame:

<img width="440" height="89" alt="image" src="https://github.com/user-attachments/assets/237d9c43-23d0-400e-9972-b1040fa5811b" />

## Why It's Good For The Game

QoL and reasons above.