### PR TITLE
Removes the try/catch block from advclass loadout equipping

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -63,59 +63,8 @@
 	if(!H)
 		return FALSE
 
-	// ALL OF THIS FUCKING SLOP IS TEMPORARY TO PREVENT RUNTIMES DURING INPUT() CALLS OF LOADOUT SELECTION
-	// IT SHOULD BE REMOVED ONCE THE LOADOUT SELECTION IS TGUI BASED AND NO LONGER USES INPUT()
-	// Store client reference before equipment (input() can cause disconnect)
-	var/client/original_client = H.client
-	var/original_ckey = H.ckey
-
 	if(outfit)
-		// Wrap in try/catch to handle "bad client" runtime during input()
-		try
-			H.equipOutfit(outfit)
-		catch(var/exception/e)
-			// Runtime occurred (likely "bad client" from disconnect during input())
-			log_game("LOADOUT RUNTIME: [original_ckey] caused runtime during [name] equipment: [e]")
-			
-			// Always cleanup on runtime - client may be detached
-			log_game("LOADOUT CLEANUP: Cleaning up [original_ckey] after runtime")
-			
-			// Free up the job slot
-			var/job_name = H.job || "Unknown"
-			if(H.job)
-				var/datum/job/J = SSjob.GetJob(H.job)
-				if(J)
-					J.current_positions = max(0, J.current_positions - 1)
-					log_game("LOADOUT CLEANUP: Freed [H.job] slot (now [J.current_positions]/[J.total_positions])")
-			
-			// Delete the character
-			if(H.mind)
-				H.mind.current = null
-			log_game("LOADOUT CLEANUP: Deleting mob for [original_ckey]")
-			qdel(H)
-			
-			// Notify admins
-			message_admins(span_boldwarning("Player [original_ckey] has disconnected during loadout equipment. Their mob has been deleted and a [job_name] slot has been opened up."))
-			
-			return FALSE
-	
-	// Check if client disconnected during equipOutfit (input() calls)
-	if(original_client && !H.client)
-		log_game("LOADOUT DISCONNECT: [original_ckey] disconnected during [name] equipment, cleaning up")
-		
-		// Free up the job slot
-		if(H.job)
-			var/datum/job/J = SSjob.GetJob(H.job)
-			if(J)
-				J.current_positions = max(0, J.current_positions - 1)
-				log_game("LOADOUT DISCONNECT: Freed [H.job] slot (now [J.current_positions]/[J.total_positions])")
-		
-		// Delete the character
-		if(H.mind)
-			H.mind.current = null
-		qdel(H)
-		
-		return FALSE
+		H.equipOutfit(outfit)
 
 	post_equip(H)
 


### PR DESCRIPTION
## About The Pull Request
Turns out try/catch sucks in BYOND because it doesn't tell you what it caught!!
Having it runtime is better because then we know what the actual issue is.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="394" height="89" alt="image" src="https://github.com/user-attachments/assets/8b650a1d-4d70-494b-a8f9-f4e30e1954f5" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
more work for admins when a user joins a fucked up job
more work for devs when a user finds a fucked up job
it really isn't good
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
