### PR TITLE
Adds the new carved gems to all drop tables where it makes sense and the map

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -9078,6 +9078,10 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/skeletoncrypt)
+"cym" = (
+/obj/item/carvedgem/amber/beaver,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/indoors/cave)
 "cyn" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/littlebanners{
@@ -10541,13 +10545,17 @@
 "cRB" = (
 /obj/effect/falling_sakura,
 /obj/structure/table/church,
-/obj/item/reagent_containers/glass/bowl{
-	pixel_y = 6
-	},
 /obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
 /obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals{
 	pixel_y = 6;
 	pixel_x = 11
+	},
+/obj/item/carvedgem/rose/rawrose,
+/obj/item/carvedgem/rose/rawrose{
+	pixel_x = -3
+	},
+/obj/item/carvedgem/rose/rawrose{
+	pixel_x = -7
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/eora)
@@ -11350,6 +11358,7 @@
 /obj/item/reagent_containers/glass/cup/tin{
 	pixel_x = -11
 	},
+/obj/item/clothing/wrists/roguetown/gem/amberbracelet,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "den" = (
@@ -11735,7 +11744,7 @@
 /obj/structure/closet/crate/chest/neu,
 /obj/item/ingot/iron,
 /obj/item/ingot/iron,
-/obj/item/roguegem/diamond,
+/obj/item/carvedgem/shell/duck,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter)
 "djT" = (
@@ -13759,6 +13768,7 @@
 /obj/item/roguestatue/gold{
 	pixel_y = 11
 	},
+/obj/item/carvedgem/jade,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/skeletoncrypt)
 "dMy" = (
@@ -20322,6 +20332,7 @@
 /area/rogue/indoors/town/manor)
 "fvm" = (
 /obj/structure/table/church/end,
+/obj/item/carvedgem/shell/fish,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/outdoors/beach)
 "fvr" = (
@@ -20887,6 +20898,8 @@
 	lockid = "lich"
 	},
 /obj/item/clothing/shoes/roguetown/boots/blacksteel/plateboots,
+/obj/item/roguegem/coral,
+/obj/item/carvedgem/coral/urn,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "fCr" = (
@@ -23934,6 +23947,9 @@
 	},
 /obj/item/book/rogue,
 /obj/item/natural/feather,
+/obj/item/carvedgem/onyxa/snake{
+	pixel_x = -8
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement/keep)
 "guQ" = (
@@ -31797,6 +31813,14 @@
 /obj/item/roguegem/diamond{
 	pixel_x = -16
 	},
+/obj/item/roguegem/jade{
+	pixel_x = 16;
+	pixel_y = -2
+	},
+/obj/item/roguegem/opal{
+	pixel_y = 16;
+	pixel_x = 16
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/mazedungeon)
 "iyg" = (
@@ -33943,6 +33967,8 @@
 	},
 /obj/item/storage/belt/rogue/pouch/coins/rich,
 /obj/item/storage/belt/rogue/pouch/coins/rich,
+/obj/item/carvedgem/amber/vase,
+/obj/item/carvedgem/amber/statue,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "jaq" = (
@@ -36023,6 +36049,7 @@
 /area/rogue/under/cave/orcdungeon)
 "jDP" = (
 /obj/item/clothing/suit/roguetown/armor/leather/heavy,
+/obj/item/carvedgem/coral/jaw,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
 "jDZ" = (
@@ -38660,6 +38687,7 @@
 "knD" = (
 /obj/item/book/rogue/abyssor,
 /obj/structure/rack/rogue/shelf/biggest,
+/obj/item/roguegem/onyxa,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
 "knL" = (
@@ -38810,6 +38838,7 @@
 /obj/item/roguegem/blue,
 /obj/item/roguegem/violet,
 /obj/item/clothing/ring/quartz,
+/obj/item/carvedgem/turq/tablet,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "kqK" = (
@@ -39709,6 +39738,13 @@
 	pixel_y = 10
 	},
 /obj/item/roguegem/blue,
+/obj/item/roguegem/amber{
+	pixel_x = -16
+	},
+/obj/item/roguegem/coral{
+	pixel_y = 10;
+	pixel_x = -16
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/mazedungeon)
 "kBM" = (
@@ -41651,6 +41687,7 @@
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
 	},
+/obj/item/carvedgem/jade/wyrm,
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph6"
 	},
@@ -44216,13 +44253,16 @@
 /obj/structure/table/church{
 	icon_state = "churchtable_end"
 	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_y = 7
-	},
 /obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals,
 /obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals{
 	pixel_y = 9;
 	pixel_x = -12
+	},
+/obj/item/reagent_containers/glass/bowl/carved/rose{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/bowl/carved/rose{
+	pixel_y = 9
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/eora)
@@ -44800,6 +44840,9 @@
 "lQW" = (
 /obj/structure/table/church{
 	icon_state = "churchtable_end"
+	},
+/obj/item/carvedgem/rose/flower{
+	pixel_x = 7
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
@@ -45692,6 +45735,13 @@
 	},
 /obj/item/rogueweapon/huntingknife/scissors,
 /obj/structure/mirror,
+/obj/item/carvedgem/rose/rawrose{
+	pixel_x = -15
+	},
+/obj/item/carvedgem/rose/rawrose{
+	pixel_x = -15;
+	pixel_y = 3
+	},
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
 "med" = (
@@ -48369,10 +48419,7 @@
 	dir = 6;
 	icon_state = "largetable"
 	},
-/obj/item/tablecloth/silk{
-	pixel_x = -6;
-	pixel_y = 6
-	},
+/obj/item/carvedgem/turq/bust,
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
 	},
@@ -48572,6 +48619,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/underdark)
+"mSh" = (
+/obj/item/carvedgem/opal/obelisk,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cave/goblindungeon)
 "mSr" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
@@ -49070,6 +49121,7 @@
 /obj/item/roguegem/diamond,
 /obj/item/roguegem/ruby,
 /obj/item/clothing/ring/ruby,
+/obj/item/carvedgem/turq/urn,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
 "mYW" = (
@@ -50717,6 +50769,7 @@
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
 	},
+/obj/item/roguegem/onyxa,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ntt" = (
@@ -51448,6 +51501,7 @@
 "nEg" = (
 /obj/item/roguestatue/gold/loot,
 /obj/structure/closet/crate/chest/trapped/locked,
+/obj/item/carvedgem/shell/vase,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
 "nEt" = (
@@ -53855,6 +53909,7 @@
 /area/rogue/indoors/shelter/mountains/decap)
 "omV" = (
 /obj/structure/table/church,
+/obj/item/carvedgem/shell/turtle,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/outdoors/beach)
 "omX" = (
@@ -55556,6 +55611,7 @@
 "oMM" = (
 /obj/structure/table/vtable/v2,
 /obj/item/clothing/neck/roguetown/psicross/malum,
+/obj/item/carvedgem/onyxa/snake,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
 "oMO" = (
@@ -56362,6 +56418,10 @@
 /obj/structure/fluff/walldeco/bigpainting/lake{
 	pixel_x = 0
 	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/carvedgem/onyxa/bust,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
 "oXX" = (
@@ -59703,6 +59763,7 @@
 "pQU" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/carvedgem/onyxa/fancyvase,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/skeletoncrypt)
 "pQZ" = (
@@ -62410,6 +62471,8 @@
 /obj/item/reagent_containers/glass/cup,
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/carved/onyxafancy,
+/obj/item/reagent_containers/glass/cup/carved/onyxafancy,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
 "qCE" = (
@@ -63374,6 +63437,7 @@
 	dir = 1
 	},
 /obj/machinery/light/rogue/hearth,
+/obj/item/carvedgem/shell/turtle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "qPv" = (
@@ -67345,6 +67409,9 @@
 /area/rogue/indoors/town)
 "rQP" = (
 /obj/structure/table/church,
+/obj/item/carvedgem/rose/flower{
+	pixel_x = -7
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "rQS" = (
@@ -72838,6 +72905,7 @@
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/rogueweapon/sword/rapier/lord,
+/obj/item/carvedgem/jade/wyrm,
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/under/cave/dukecourt)
 "tln" = (
@@ -77160,6 +77228,7 @@
 /area/rogue/under/cavewet/bogcaves)
 "upX" = (
 /obj/structure/table/wood/fancy/black,
+/obj/item/roguegem/turq,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
 "upZ" = (
@@ -88661,23 +88730,8 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/item/tablecloth/silk{
-	pixel_x = -6;
-	pixel_y = 10
-	},
 /obj/machinery/light/rogue/wallfire/candle/l,
-/obj/item/tablecloth/silk{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/tablecloth/silk{
-	pixel_x = -6;
-	pixel_y = -5
-	},
-/obj/item/tablecloth/silk{
-	pixel_x = 6;
-	pixel_y = -5
-	},
+/obj/item/carvedgem/jade/vase,
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
 	},
@@ -112268,7 +112322,7 @@ oFP
 kaY
 iYG
 iYG
-iYG
+mSh
 qTl
 qvT
 qvT
@@ -212028,7 +212082,7 @@ fnC
 fnC
 fnC
 fnC
-fnC
+cym
 ujm
 jDP
 tDd

--- a/_maps/templates/sewers.dm
+++ b/_maps/templates/sewers.dm
@@ -113,6 +113,20 @@
 		/obj/item/reagent_containers/powder/salt = 6,
 		/obj/item/reagent_containers/food/snacks/egg = 6,
 
+		// Rare gem finds in sewers (lost treasures)
+		/obj/item/roguegem/onyxa = 1,
+		/obj/item/roguegem/jade = 1,
+		/obj/item/roguegem/amber = 1,
+		/obj/item/roguegem/coral = 1,
+		
+		// Carved gem items (discarded/lost)
+		/obj/item/kitchen/fork/carved/jade = 1,
+		/obj/item/kitchen/spoon/carved/onyxa = 1,
+		/obj/item/clothing/ring/jade = 1,
+		/obj/item/clothing/ring/onyxa = 1,
+		/obj/item/carvedgem/jade/figurine = 1,
+		/obj/item/carvedgem/onyxa/cameo = 1
+
 	)
 
 

--- a/_maps/templates/smalldungeons.dm
+++ b/_maps/templates/smalldungeons.dm
@@ -148,6 +148,14 @@
 		/obj/item/reagent_containers/powder/salt = 3,
 		/obj/item/reagent_containers/food/snacks/egg = 3,
 
+		// Gems (rare finds)
+		/obj/item/roguegem/onyxa = 1,
+		/obj/item/roguegem/jade = 1,
+		/obj/item/roguegem/amber = 1,
+		/obj/item/roguegem/coral = 1,
+		/obj/item/roguegem/turq = 1,
+		/obj/item/roguegem/opal = 1
+
 	)
 	lootcount = 1
 
@@ -232,6 +240,20 @@
 		/obj/item/mundane/puzzlebox/medium = 2,
 		/obj/item/mundane/puzzlebox/easy = 2,
 		/obj/item/mundane/puzzlebox/impossible = 1,
+		/obj/item/kitchen/fork/carved/jade = 1,
+		/obj/item/kitchen/spoon/carved/jade = 1,
+		/obj/item/kitchen/fork/carved/onyxa = 1,
+		/obj/item/kitchen/spoon/carved/onyxa = 1,
+		/obj/item/reagent_containers/glass/bowl/carved/jade = 1,
+		/obj/item/reagent_containers/glass/cup/carved/jade = 1,
+		/obj/item/reagent_containers/glass/bowl/carved/onyxa = 1,
+		/obj/item/reagent_containers/glass/cup/carved/onyxa = 1,
+		/obj/item/carvedgem/jade/cameo = 1,
+		/obj/item/carvedgem/jade/figurine = 1,
+		/obj/item/carvedgem/jade/vase = 1,
+		/obj/item/carvedgem/onyxa/cameo = 1,
+		/obj/item/carvedgem/onyxa/figurine = 1,
+		/obj/item/carvedgem/onyxa/vase = 1
 	)
 	lootcount = 1
 

--- a/code/game/objects/effects/spawners/clutter_spawner.dm
+++ b/code/game/objects/effects/spawners/clutter_spawner.dm
@@ -24,7 +24,7 @@
 		/obj/item/needle/thorn = 1,
 		/obj/item/roguestatue/steel = 1,
 		/obj/item/roguestatue/aalloy = 1,
-		/obj/item/roguestatue/iron = 1,
+		/obj/item/roguestatue/iron = 1
 	)
 
 /obj/effect/spawner/lootdrop/valuable_clutter_spawner
@@ -39,6 +39,18 @@
 		/obj/item/roguestatue/silver = 1,
 		/obj/item/roguestatue/steel = 1,
 		/obj/item/rogueweapon/hammer/steel = 1,
+		/obj/item/carvedgem/jade/bust = 1,
+		/obj/item/carvedgem/jade/fancyvase = 1,
+		/obj/item/carvedgem/jade/statue = 1,
+		/obj/item/carvedgem/jade/obelisk = 1,
+		/obj/item/carvedgem/jade/urn = 1,
+		/obj/item/carvedgem/jade/wyrm = 1,
+		/obj/item/carvedgem/onyxa/bust = 1,
+		/obj/item/carvedgem/onyxa/fancyvase = 1,
+		/obj/item/carvedgem/onyxa/statue = 1,
+		/obj/item/carvedgem/onyxa/obelisk = 1,
+		/obj/item/carvedgem/onyxa/urn = 1,
+		/obj/item/carvedgem/onyxa/spider = 1
 	)
 
 /obj/effect/spawner/lootdrop/cheap_candle_spawner
@@ -75,7 +87,7 @@
 		/obj/item/kitchen/spoon/iron = 1,
 		/obj/item/kitchen/spoon/tin = 1,
 		/obj/item/reagent_containers/glass/bowl = 1,
-		/obj/item/reagent_containers/glass/bowl/iron = 1,
+		/obj/item/reagent_containers/glass/bowl/iron = 1
 	)
 
 /obj/effect/spawner/lootdrop/valuable_tableware_spawner
@@ -92,6 +104,12 @@
 		/obj/item/reagent_containers/glass/bowl/gold = 1,
 		/obj/item/reagent_containers/glass/bowl/silver = 1,
 		/obj/item/cooking/platter/silver = 1,
+		/obj/item/cooking/platter/carved/jade = 1,
+		/obj/item/cooking/platter/carved/onyxa = 1,
+		/obj/item/reagent_containers/glass/cup/carved/jadefancy = 1,
+		/obj/item/reagent_containers/glass/cup/carved/onyxafancy = 1,
+		/obj/item/reagent_containers/glass/bucket/pot/carved/teapotjade = 1,
+		/obj/item/reagent_containers/glass/bucket/pot/carved/teapotonyxa = 1
 	)
 
 /obj/effect/spawner/lootdrop/cheap_jewelry_spawner
@@ -116,6 +134,10 @@
 		/obj/item/clothing/neck/roguetown/psicross/shell/bracelet = 6,
 		/obj/item/clothing/neck/roguetown/horus = 1,
 		/obj/item/clothing/neck/roguetown/luckcharm = 1,
+		/obj/item/clothing/ring/jade = 1,
+		/obj/item/clothing/ring/onyxa = 1,
+		/obj/item/clothing/neck/roguetown/carved/jadeamulet = 1,
+		/obj/item/clothing/neck/roguetown/carved/onyxaamulet = 1
 	)
 
 /obj/effect/spawner/lootdrop/valuable_jewelry_spawner
@@ -144,4 +166,16 @@
 		/obj/item/clothing/neck/roguetown/psicross/bpearl = 2,
 		/obj/item/clothing/neck/roguetown/ornateamulet = 3,
 		/obj/item/clothing/neck/roguetown/skullamulet = 3,
+		/obj/item/clothing/ring/jade = 5,
+		/obj/item/clothing/ring/onyxa = 4,
+		/obj/item/clothing/neck/roguetown/carved/jadeamulet = 4,
+		/obj/item/clothing/neck/roguetown/carved/onyxaamulet = 3,
+		/obj/item/clothing/wrists/roguetown/gem/jadebracelet = 3,
+		/obj/item/clothing/wrists/roguetown/gem/onyxabracelet = 2,
+		/obj/item/clothing/head/roguetown/circlet/jade = 2,
+		/obj/item/clothing/head/roguetown/circlet/onyxa = 1,
+		/obj/item/clothing/mask/rogue/facemask/carved/jademask = 1,
+		/obj/item/clothing/mask/rogue/facemask/carved/onyxamask = 1,
+		/obj/item/carvedgem/jade/comb = 1,
+		/obj/item/carvedgem/onyxa/comb = 1
 	)

--- a/code/game/objects/items/rogueitems/gems.dm
+++ b/code/game/objects/items/rogueitems/gems.dm
@@ -212,7 +212,22 @@
 
 /obj/item/roguegem/random/Initialize()
 	..()
-	var/newgem = list(/obj/item/roguegem/ruby = 5, /obj/item/roguegem/green = 15, /obj/item/roguegem/blue = 10, /obj/item/roguegem/yellow = 20, /obj/item/roguegem/violet = 10, /obj/item/roguegem/diamond = 5, /obj/item/riddleofsteel = 1, /obj/item/rogueore/silver = 3, /obj/item/roguegem/onyxa = 5, /obj/item/roguegem/jade = 3, /obj/item/roguegem/coral = 3, /obj/item/roguegem/turq = 3, /obj/item/roguegem/amber = 3, /obj/item/roguegem/opal = 3)
+	var/newgem = list(
+		/obj/item/roguegem/onyxa = 20,
+		/obj/item/roguegem/yellow = 20,
+		/obj/item/roguegem/green = 15,
+		/obj/item/roguegem/amber = 12,
+		/obj/item/roguegem/jade = 12,
+		/obj/item/roguegem/violet = 10,
+		/obj/item/roguegem/blue = 10,
+		/obj/item/roguegem/coral = 9,
+		/obj/item/roguegem/opal = 7,
+		/obj/item/roguegem/turq = 7,
+		/obj/item/roguegem/diamond = 5,
+		/obj/item/roguegem/ruby = 5,
+		/obj/item/rogueore/silver = 3,
+		/obj/item/riddleofsteel = 1
+	)
 	var/pickgem = pickweight(newgem)
 	new pickgem(get_turf(src))
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request
If the dungeon doesn't use a random spawner, I added a gem or gem related item there. If not, it's on the spawners which have had the gems and their items added to them. Changed the drop rates for the randomgem initialization to match their sellprices more compared to other gems.
Also removed the one dorpel spawn that was very easy. I'm a mage player too, but that was far too easy for a dorpel. You get a duck now.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="633" height="193" alt="image" src="https://github.com/user-attachments/assets/33b8d63f-ec80-456a-b792-bb2ba5576333" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
more gems everywhere
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
