### PR TITLE
Gives Eoran Arils some love

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -1014,16 +1014,25 @@
 	name = "opalescent aril"
 	desc = "An iridescent seed that shifts colors in the light."
 	icon_state = "opalescent"
-	effect_desc = "Transforms held gems into rubies."
+	effect_desc = "Transforms held gems into a rontz or manifests a pair of rosellusks if no gem is held."
     
 /obj/item/reagent_containers/food/snacks/eoran_aril/opalescent/apply_effects(mob/living/eater)
+	var/found_gem = FALSE
 	for(var/obj/item/roguegem/G in eater.held_items)
 		var/obj/item/roguegem/ruby/new_gem = new(eater.loc)
 		qdel(G)
 		eater.put_in_hands(new_gem)
 		to_chat(eater, span_notice("The [G] transforms into a rontz in your hand!"))
+		found_gem = TRUE
 		//Probably best not to allow 2 at once...
 		break
+	
+	if(!found_gem)
+		var/obj/item/carvedgem/rose/rawrose/rosellusk1 = new(eater.loc)
+		var/obj/item/carvedgem/rose/rawrose/rosellusk2 = new(eater.loc)
+		eater.put_in_hands(rosellusk1)
+		eater.put_in_hands(rosellusk2)
+		to_chat(eater, span_notice("A pair of rosellusks manifest in your hands!"))
 
 // TIER 2
 /obj/item/reagent_containers/food/snacks/eoran_aril/cerulean


### PR DESCRIPTION
## About The Pull Request
Opalescent arils now spawn two Rosellusks in your hands if you are not holding a gem to turn into a rontz.
Rosellusks do not count as gems (not my doing, they are coded as not gems!) and therefore cannot be turned into a rontz.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="629" height="163" alt="image" src="https://github.com/user-attachments/assets/b77787f0-17a8-4c70-bb6f-8353e50b940e" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
New gem stuff good
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
