### PR TITLE
The Old Ways II: More witch flavor and miscellaneous improvements (WIP)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -291,6 +291,12 @@
 		)
 		src.visible_message(span_warning("[src] shoves the silver psycross in [H]'s face!"))
 		say(pick(faith_lines), spans = list("torture"))
+		if (HAS_TRAIT(H, TRAIT_WITCH))
+			to_chat(H, span_notice("The weepers don't understand. They don't know what you are."))
+			to_chat(src, span_notice("[H] does not respond - your compulsion is fruitless. How can this be?"))
+			if (prob(30))
+				to_chat(src, span_warning("The hairs upon the back of your neck rise..."))
+			return
 		H.emote("agony", forced = TRUE)
 
 		if(!(do_mob(src, H, 10 SECONDS)))
@@ -357,6 +363,12 @@
 			"TELL ME!",
 		)
 		say(pick(torture_lines), spans = list("torture"))
+		if (HAS_TRAIT(H, TRAIT_WITCH))
+			to_chat(H, span_notice("The weepers don't understand. They don't know what you are."))
+			to_chat(src, span_notice("[H] does not respond - your compulsion is fruitless. How can this be?"))
+			if (prob(30))
+				to_chat(src, span_warning("The hairs upon the back of your neck rise..."))
+			return
 		H.emote("agony", forced = TRUE)
 
 		if(!(do_mob(src, H, 10 SECONDS)))


### PR DESCRIPTION
## About The Pull Request

Warning: I'm going to be locking down Witch slots as part of this PR chain at some point in the future. There's not going to be more than 4 of them in a round. This is already probably too many.

Anyway, stupid lore/soul PR purely because I feel like it:

- Confessors/puritans can no longer force witches to confess their patron.
   - This is because witches mechanically do not really worship their patrons, or are at least, not supposed to. You can of course, choose to ignore this at your discretion. The game will still portray your worship as non-standard, because you're a witch.
   - The "Old Ways" are essentially lost magickal practices that allow witches to draw upon pantheonic power through a variety of esoteric and broadly unknown methods.

## Testing Evidence

fuck you it compiles

## Why It's Good For The Game

More flavor gooderer.
