### PR TITLE
fix: runtime in ticker division by zero

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -526,7 +526,7 @@ SUBSYSTEM_DEF(ticker)
 		CHECK_TICK
 	
 	var/total_time = world.timeofday - start_time
-	log_game("EQUIP COMPLETE: [valid_characters.len] players in [DisplayTimeText(total_time * 0.1)] (avg [DisplayTimeText(total_time / valid_characters.len * 0.1)] per player)")
+	log_game("EQUIP COMPLETE: [valid_characters.len] players in [DisplayTimeText(total_time * 0.1)] (avg [valid_characters.len? (DisplayTimeText(total_time / valid_characters.len * 0.1)) : DisplayTimeText(total_time)] per player)")
 
 /datum/controller/subsystem/ticker/proc/transfer_characters()
 	var/list/livings = list()


### PR DESCRIPTION
## About The Pull Request

Fixes runtime that happened on 0 readied players

## Testing Evidence

<img width="1515" height="413" alt="image" src="https://github.com/user-attachments/assets/fad8d9d9-557f-47e1-b56f-015005277aae" />

## Why It's Good For The Game

SYLLINNNNNNNNNNNNNNNNNNNNNNNNNNNN!!!!!!!!!!!!!