### PR TITLE
Claimable town houses now use real name instead of current name.

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -209,7 +209,7 @@
 		to_chat(human, span_notice("They're just where I left them..."))
 	else
 		to_chat(human, span_notice("It's just where I left it..."))
-	name = "[user.name] the [human.advjob ? human.advjob : human.job]'s house"
+	name = "[user.real_name] the [human.advjob ? human.advjob : human.job]'s house"
 	return TRUE
 
 /obj/structure/mineral_door/Move()


### PR DESCRIPTION
## About The Pull Request
Title.
Farewell, Tall Man the Big man's house.

## Testing Evidence
1. It's a oneliner... again (mood). Compiles.
<img width="325" height="163" alt="image" src="https://github.com/user-attachments/assets/30a2e5e6-aef2-4a9a-ba40-ef9540648161" />

2. Screenshots before and after.
<img width="303" height="184" alt="image" src="https://github.com/user-attachments/assets/2ba34618-935f-4630-9f33-4d836c9ae0f7" />
<img width="327" height="232" alt="image" src="https://github.com/user-attachments/assets/b5d9c68e-d80c-42e2-937a-98d3d7d8f892" />

## Why It's Good For The Game

Frankly? I think it's an oversight. Been a few cases where i'd like to contact someone's char but the player merely forgot to take off the hood while claiming and it's ogre.
There's muhlogic argument too, blah blah paper trail on town residents...
