### PR TITLE
Town elder and guildmaster announcement sidework

### DIFF
--- a/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
@@ -117,14 +117,14 @@ GLOBAL_VAR_INIT(last_guildmaster_announcement, -50000) // Inits variable for lat
 	set category = "GUILDMASTER"
 	if(stat)
 		return
+	if(!src.can_speak_vocal())
+		to_chat(src,span_warning("I can't speak!"))
+		return FALSE
+	if(world.time < GLOB.last_guildmaster_announcement + 450 SECONDS)
+		to_chat(src, span_warning("You must wait [round((GLOB.last_guildmaster_announcement + 450 SECONDS - world.time)/600, 0.1)] minutes before making another announcement!"))
+		return FALSE
 	var/announcementinput = input("Bellow to the Peaks", "Make an Announcement") as text|null
 	if(announcementinput)
-		if(!src.can_speak_vocal())
-			to_chat(src,span_warning("I can't speak!"))
-			return FALSE
-		if(world.time < GLOB.last_guildmaster_announcement + 450 SECONDS)
-			to_chat(src, span_warning("You must wait [round((GLOB.last_guildmaster_announcement + 450 SECONDS - world.time)/600, 0.1)] minutes before making another announcement!"))
-			return FALSE
 		visible_message(span_warning("[src] takes a deep breath, preparing to make an announcement.."))
 		if(do_after(src, 15 SECONDS, target = src)) // Reduced to 15 seconds from 30 on the original Herald PR. 15 is well enough time for sm1 to shove you.
 			say(announcementinput)

--- a/code/modules/jobs/job_types/roguetown/yeomen/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/villagechief.dm
@@ -93,14 +93,14 @@ GLOBAL_VAR_INIT(last_elder_announcement, -50000) // Inits variable for later, co
 	set category = "ELDER"
 	if(stat)
 		return
+	if(!src.can_speak_vocal())
+		to_chat(src,span_warning("I can't speak!"))
+		return FALSE
+	if(world.time < GLOB.last_elder_announcement + 450 SECONDS)
+		to_chat(src, span_warning("You must wait [round((GLOB.last_elder_announcement + 450 SECONDS - world.time)/600, 0.1)] minutes before making another announcement!"))
+		return FALSE
 	var/announcementinput = input("Bellow to the Peaks", "Make an Announcement") as text|null
 	if(announcementinput)
-		if(!src.can_speak_vocal())
-			to_chat(src,span_warning("I can't speak!"))
-			return FALSE
-		if(world.time < GLOB.last_elder_announcement + 450 SECONDS)
-			to_chat(src, span_warning("You must wait [round((GLOB.last_elder_announcement + 450 SECONDS - world.time)/600, 0.1)] minutes before making another announcement!"))
-			return FALSE
 		visible_message(span_warning("[src] takes a deep breath, preparing to make an announcement.."))
 		if(do_after(src, 15 SECONDS, target = src)) // Reduced to 15 seconds from 30 on the original Herald PR. 15 is well enough time for sm1 to shove you.
 			say(announcementinput)


### PR DESCRIPTION
## About The Pull Request
It only took this long to find out live because unironically 2 people on the server play town elder. Town elder + guildmaster + announcements at the same time = stars aligning type of probability.
Final changelog:

**Announcements:** Now use the following checklist. Can talk (mouthgrab) -> Can announce (cooldown is off) -> Textbox appears.
Before it was: Textbox appears - any input - _then_ checks for ability to talk OR COOLDOWN. 

**Elder's announcement:** Fixed a typo? that made it share the cooldown with guildmaster's announcement and vice-versa i assume.
**Elder's announcement cooldown:** 10 -> 7.5 minutes. 
**Elder's announcement**: Now gets a notification when it's ready, similiar to guildmaster
<img width="440" height="89" alt="image" src="https://github.com/user-attachments/assets/20987637-bea6-4349-80c0-de7d71257ebf" />


## Testing Evidence

1. Another day, another oneliner and some codeswaps. Compiles

<img width="362" height="104" alt="image" src="https://github.com/user-attachments/assets/5228f6de-c653-4608-aab7-44059b57b375" />

2. Screenshots before (taken from a live server yesterday, i was a guildmaster) and after (localhost with 2 clients)

<img width="458" height="244" alt="image" src="https://github.com/user-attachments/assets/55c42909-7a07-400e-81d1-a1f39603ed57" />

<img width="468" height="340" alt="image" src="https://github.com/user-attachments/assets/4eb6c180-04f0-4f1e-a1c6-2c63210d09e2" />

3. Spawned as both roles, mouthgrabbed myself to check (works, "i can't speak!"), announced normally, tried to again right after (works, shows cd), prayed for suicide and tried to announce (nothing), all works as intended. 

## Why It's Good For The Game

1. Bugfix.
2. Bringing elder's shout in line with guildmaster (i forgot about his existence tbh)
3. Changed the priority check because it was annoying to use otherwise for obvious reasons.
