### PR TITLE
Dendor shapeshift is now properly cancellable

### DIFF
--- a/code/modules/spells/spell_types/wildshape.dm
+++ b/code/modules/spells/spell_types/wildshape.dm
@@ -44,6 +44,11 @@
 
 			var/new_wildshape_type = input(M, "Choose Your Animal Form!", "It's Morphing Time!", null) as null|anything in sortList(animal_list)
 
+			if(!new_wildshape_type)
+				to_chat(user, span_warning("I have decided to maintain my current form.")) //Can't believe this wasn't in the code to begin with
+				revert_cast()
+				return FALSE
+
 			for(var/crecher in possible_shapes) //Second pass to fetch the mob type itself and send it on wildshape_transformation
 				var/mob/living/carbon/human/species/wildshape/B = crecher
 				if(new_wildshape_type == B.name)


### PR DESCRIPTION
## About The Pull Request
Shit that annoyed me part 8 or so. 

Changelog:
**Beast form spell:** Now if you cancel the beast choice, it will refund the cooldown, you won't yell and it won't take devotion.
And it will output a small warning in chat.

<img width="330" height="62" alt="image" src="https://github.com/user-attachments/assets/c97ff688-f995-4195-ac53-e42d6b130d2b" />


## Testing Evidence

1. Essentially oneliner, compiles.

<img width="323" height="103" alt="image" src="https://github.com/user-attachments/assets/3a6dd310-2b90-464c-8024-a53abcb3ffd6" />

2. Tested locally, works fine, no runtimes either. Alert example above. Video on demand.

## Why It's Good For The Game

You uhh... can call this a bugfix i suppose?