### PR TITLE
Clerical Appraise spell range from 2 to 7

### DIFF
--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -8,7 +8,7 @@
 	releasedrain = 10
 	chargedrain = 0
 	chargetime = 0
-	range = 2
+	range = 7
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	invocation_type = "none"


### PR DESCRIPTION
## About The Pull Request

In combat. Matthios clerics must cast Appraise on targets until they find one suitable to cast ''churn wealthy'' in practice at 2 range this was a nightmare. Along with needing to glance at a chatbox with 50 popups of swords clashing. They still need to get a 4 range massive chargeup spell cast off to churn this just helps them find their target much easier. 

Secular version for virtues/merchants/shophands remains unchanged.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

It compiles. It's currently based on a TMed PR so. Bit annoying to test. It's a simple number var it should be fine.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Matty has it kinda bad right now compared to all the other ascendants getting cool spell feature overhauls. It's minor QOL for a very hard spell to get off. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
